### PR TITLE
[canonical-facts] Display output as pretty formatted JSON

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,32 @@
+name: Go
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: "Build"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ['1.15', '1.16', '1.17']
+    steps:
+      - name: Updating ...
+        run: sudo apt-get -qq update
+
+      - uses: actions/checkout@v2
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Go build (source)
+        run: make
+
+      - name: Go build (tests)
+        run: make tests
+
+      - name: Go vet
+        run: make vet

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ LDFLAGS += -X 'main.ManDir=$(MANDIR)'
 LDFLAGS += -X 'main.DocDir=$(DOCDIR)'
 LDFLAGS += -X 'main.LocalstateDir=$(LOCALSTATEDIR)'
 LDFLAGS += -X 'main.TopicPrefix=$(TOPICPREFIX)'
-LDFLAGS += -X 'main.DataHost=$(DATAHOST)'
 LDFLAGS += -X 'main.Provider=$(PROVIDER)'
 
 BUILDFLAGS ?=

--- a/Makefile
+++ b/Makefile
@@ -154,3 +154,11 @@ clean:
 	go mod tidy
 	rm $(BIN)
 	rm $(DATA)
+
+.PHONY: tests
+tests:
+	go test -v ./...
+
+.PHONY: vet
+vet:
+	go vet -v ./...

--- a/constants.go
+++ b/constants.go
@@ -18,9 +18,6 @@ var (
 	// TopicPrefix is used as a prefix to all MQTT topics in the client.
 	TopicPrefix string
 
-	// DataHost is used to force sending all HTTP traffic to a specific host.
-	DataHost string
-
 	// Provider is used when constructing user-facing string output to identify
 	// the agency providing the connection broker.
 	Provider string

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,6 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.1.2
 	github.com/urfave/cli/v2 v2.3.0
-	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 )

--- a/go.sum
+++ b/go.sum
@@ -27,17 +27,12 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5I
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
-golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e h1:gsTQYXdTw2Gq7RBsWvlQ91b+aEQ6bXFUngBGuR8sPpI=
-golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/briandowns/spinner"
 	systemd "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 const successPrefix = "\033[32m●\033[0m"
@@ -110,7 +110,7 @@ func main() {
 						}
 						if password == "" {
 							fmt.Print("Password: ")
-							data, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+							data, err := term.ReadPassword(int(os.Stdin.Fd()))
 							if err != nil {
 								return cli.Exit(err, 1)
 							}

--- a/main.go
+++ b/main.go
@@ -198,11 +198,11 @@ func main() {
 				if err != nil {
 					return cli.Exit(err, 1)
 				}
-				data, err := json.Marshal(facts)
+				data, err := json.MarshalIndent(facts, "", "   ")
 				if err != nil {
 					return err
 				}
-				fmt.Print(string(data))
+				fmt.Println(string(data))
 				return nil
 			},
 		},


### PR DESCRIPTION
This patch outputs the canonical facts with an appropriate indentation
for better readability.

Expected results:

```
$ rhc canonical-facts
{
    "insights_id": "08eca62e-ee30-49c6-a96c-d8bf59a570e5",
    "machine_id": "e64a070b-fdb9-139e-2586-f6ee138068b5",
    "bios_uuid": "2a362d74-d64e-4be5-aaf8-daa758d052f4",
    "subscription_manager_id": "a5c5f1e1-c117-4a55-93c3-bc361353e9b6",
    "ip_addresses": [
        "192.168.0.28"
    ],
    "mac_addresses": [
        "52:54:00:78:d4:02",
        "00:00:00:00:00:00"
    ],
    "fqdn": "rhel84.strider.local"
}
```

Signed-off-by: Gael Chamoulaud (Strider) <gchamoul@redhat.com>