### PR TITLE
Fix rendering bug where the spinner doesn't erase its loading message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	git.sr.ht/~spc/go-log v0.0.0-20210611184941-ce2f05edb627
-	github.com/briandowns/spinner v1.16.0
+	github.com/briandowns/spinner v1.13.0
 	github.com/coreos/go-systemd/v22 v22.1.0
 	github.com/godbus/dbus/v5 v5.0.3
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 git.sr.ht/~spc/go-log v0.0.0-20210611184941-ce2f05edb627 h1:V8lJMgdkSw4e9vn5ET1WXmhUruSxuk+Ep0VfLcYPl8o=
 git.sr.ht/~spc/go-log v0.0.0-20210611184941-ce2f05edb627/go.mod h1:IKiYUc0lWbZO4uSV0kWNzJSFnABNdrybpPWo46CGgFM=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/briandowns/spinner v1.16.0 h1:DFmp6hEaIx2QXXuqSJmtfSBSAjRmpGiKG6ip2Wm/yOs=
-github.com/briandowns/spinner v1.16.0/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX3FScO+3/ZPQ=
+github.com/briandowns/spinner v1.13.0 h1:q/Y9LtpwtvL0CRzXrAMj0keVXqNhBYUFg6tBOUiY8ek=
+github.com/briandowns/spinner v1.13.0/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX3FScO+3/ZPQ=
 github.com/coreos/go-systemd/v22 v22.1.0 h1:kq/SbG2BCKLkDKkjQf5OWwKWUKj1lgs3lFI4PxnR5lg=
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=


### PR DESCRIPTION
Summary

Downgrade the spinner library to fix a rendering bug. See briandowns/spinner#123.

With spinner v1.16.0:
<img width="711" alt="image" src="https://user-images.githubusercontent.com/242115/144928399-70778c0e-3244-4284-839e-1add71ebbae5.png">

With spinner v.1.13.0:
<img width="711" alt="image" src="https://user-images.githubusercontent.com/242115/144928515-d3b075bc-9ad6-4927-89f8-b95b28557e57.png">

Signed-off-by: Gael Chamoulaud (Strider) <gchamoul@redhat.com>