### PR TITLE
Include insights-client during "connect" and "disconnect"

### DIFF
--- a/insights.go
+++ b/insights.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os/exec"
+)
+
+func registerInsights() error {
+	cmd := exec.Command("/usr/bin/insights-client", "--register")
+
+	return cmd.Run()
+}
+
+func unregisterInsights() error {
+	cmd := exec.Command("/usr/bin/insights-client", "--unregister")
+
+	return cmd.Run()
+}
+
+func insightsIsRegistered() bool {
+	cmd := exec.Command("/usr/bin/insights-client", "--status")
+
+	_ = cmd.Run()
+
+	return cmd.ProcessState.Success()
+}

--- a/rhc.spec.in
+++ b/rhc.spec.in
@@ -18,6 +18,8 @@ Source1: https://github.com/RedHatInsights/yggdrasil/archive/refs/heads/main.tar
 
 ExclusiveArch: %{go_arches}
 
+Requires:      insights-client
+
 BuildRequires: git
 BuildRequires: golang
 BuildRequires: dbus-devel


### PR DESCRIPTION
Introduce `insights-client` as an explicit step during the `connect` and `disconnect` subcommands. During `connect`, the process shells out to, and waits for, `/usr/bin/insights-client --register` to execute successfully. Conversely, during `disconnect`, the process shells out to and waits for `/usr/bin/insights-client --unregister` to execute successfully. In addition, the `insights-client --status` exit code is checking during the `status` subcommand execution.