### PR TITLE
fix: Upgrade github.com/briandowns/spinner to v1.17.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	git.sr.ht/~spc/go-log v0.0.0-20210611184941-ce2f05edb627
-	github.com/briandowns/spinner v1.13.0
+	github.com/briandowns/spinner v1.17.0
 	github.com/coreos/go-systemd/v22 v22.1.0
 	github.com/godbus/dbus/v5 v5.0.3
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 git.sr.ht/~spc/go-log v0.0.0-20210611184941-ce2f05edb627 h1:V8lJMgdkSw4e9vn5ET1WXmhUruSxuk+Ep0VfLcYPl8o=
 git.sr.ht/~spc/go-log v0.0.0-20210611184941-ce2f05edb627/go.mod h1:IKiYUc0lWbZO4uSV0kWNzJSFnABNdrybpPWo46CGgFM=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/briandowns/spinner v1.13.0 h1:q/Y9LtpwtvL0CRzXrAMj0keVXqNhBYUFg6tBOUiY8ek=
-github.com/briandowns/spinner v1.13.0/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX3FScO+3/ZPQ=
+github.com/briandowns/spinner v1.17.0 h1:7HjHI07APcVZBT71J2UvJl3CAvYCnqqCrxW5gXSDOVA=
+github.com/briandowns/spinner v1.17.0/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX3FScO+3/ZPQ=
 github.com/coreos/go-systemd/v22 v22.1.0 h1:kq/SbG2BCKLkDKkjQf5OWwKWUKj1lgs3lFI4PxnR5lg=
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=


### PR DESCRIPTION
In commit [1], we've had to downgrade that package due to a rendering
bug[2]. This latter has been fixed upstream[3] and released in the v1.17.0[4].
We can now 'revert' the downgrade to v1.13.0 by upgrading directly to
the v1.17.0.

[1] https://github.com/RedHatInsights/rhc/pull/5/commits/2ed9d23e087958481ee5aa7675cd5b899dcd7f8e
[2] https://github.com/briandowns/spinner/issues/123
[3] https://github.com/briandowns/spinner/pull/126
[4] https://github.com/briandowns/spinner/releases/tag/v1.17.0

Test done with the v1.17.0:
<img width="677" alt="Screen Shot 2022-01-21 at 2 21 42 PM" src="https://user-images.githubusercontent.com/242115/150534392-63e22105-ef18-4728-88c4-240a15831179.png">

