### PR TITLE
Bundle yggdrasil and yggdrasil-worker-package-manager

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,5 +1,8 @@
 include Makefile
 
+outdir ?= $(PWD)/outdir
+spec ?= $(PWD)
+
 SOURCEDIR := $(shell rpmbuild -E %_sourcedir)
 SRCRPMDIR := $(shell rpmbuild -E %_srcrpmdir)
 
@@ -7,11 +10,14 @@ srpm: SHORTNAME = $(shell basename $(PWD))
 srpm: LONGNAME = $(SHORTNAME)
 srpm: BRANDNAME = $(SHORTNAME)
 srpm: VERSION := $(shell echo $(VERSION) | awk -F. '{printf("%d.%d.%d", $$1, $$2, $$3+1)}')
-srpm: RELEASE = $(shell printf "0.%s.git.%s" $(shell git rev-list $(shell git describe --tags --abbrev=0 | tr -d '\n')..HEAD --count | tr -d '\n') $(shell git rev-parse --short HEAD | tr -d '\n'))
+srpm: RELEASE = $(shell printf "0.%s.git.%s" $(shell git rev-list $(shell git describe --tags --abbrev=0 --always | tr -d '\n')..HEAD --count | tr -d '\n') $(shell git rev-parse --short HEAD | tr -d '\n'))
 srpm: PKGNAME = $(SHORTNAME)
 
 .PHONY: srpm
 srpm: deps
+	mkdir -p $(SOURCEDIR)
+	mkdir -p $(SRCRPMDIR)
+	mkdir -p $(outdir)
 	sed \
 	    -e 's,[@]SHORTNAME[@],$(SHORTNAME),g' \
 		-e 's,[@]LONGNAME[@],$(LONGNAME),g' \
@@ -31,10 +37,11 @@ srpm: deps
 		-e 's,[@]SYSCONFDIR[@],$(SYSCONFDIR),g' \
 		-e 's,[@]LOCALSTATEDIR[@],$(LOCALSTATEDIR),g' \
 		-e 's,[@]DOCDIR[@],$(DOCDIR),g' \
-		rhc.spec.in > rhc.spec.tmp && mv rhc.spec.tmp rhc.spec
+		$(spec)/.copr/rhc.spec.in > $(spec)/rhc.spec
 	make PKGNAME=$(PKGNAME) VERSION=$(VERSION)-$(RELEASE) dist
-	install -D -m644 $(PKGNAME)-$(VERSION)-$(RELEASE).tar.gz $(SOURCEDIR)/
+	install -D -m644 $(PKGNAME)-$(VERSION)-$(RELEASE).tar.gz $(SOURCEDIR)
 	spectool --get-files --source 1 --sourcedir $(spec)/rhc.spec
+	spectool --get-files --source 2 --sourcedir $(spec)/rhc.spec
 	rpmbuild -bs $(spec)/rhc.spec
 	install -D -m644 $(SRCRPMDIR)/*.rpm $(outdir)/
 

--- a/.copr/rhc.spec.in
+++ b/.copr/rhc.spec.in
@@ -8,13 +8,15 @@
 
 Name:    @LONGNAME@
 Version: @VERSION@
-Release: @RELEASE@
+Release: @RELEASE@%{?dist}
+Epoch:   1
 Summary: Client for registering Red Hat Enterprise Linux systems
 License: GPLv3
 URL:     https://github.com/redhatinsights/rhc
 
-Source0: %{name}-%{version}-%{release}.tar.gz
-Source1: https://github.com/RedHatInsights/yggdrasil/archive/refs/heads/main.tar.gz
+Source0: %{name}-%{version}-@RELEASE@.tar.gz
+Source1: https://github.com/RedHatInsights/yggdrasil/releases/download/0.2.1/yggdrasil-0.2.1.tar.gz
+Source2: https://github.com/RedHatInsights/yggdrasil-worker-package-manager/releases/download/0.1.0/yggdrasil-worker-package-manager-0.1.0.tar.gz
 
 ExclusiveArch: %{go_arches}
 
@@ -32,12 +34,13 @@ MQTT client.
 
 
 %prep
-%setup -n %{name}-%{version}-%{release} -a 0
-%setup -n %{name}-%{version}-%{release} -a 1
+%setup -T -D -c -n %{name} -a 0
+%setup -T -D -c -n %{name} -a 1
+%setup -T -D -c -n %{name} -a 2
 
 
 %build
-cd yggdrasil-main
+cd %{_builddir}/%{name}/yggdrasil-0.2.1
 make PREFIX=%{_prefix} \
      SYSCONFDIR=%{_sysconfdir} \
      LOCALSTATEDIR=%{_localstatedir} \
@@ -49,7 +52,11 @@ make PREFIX=%{_prefix} \
      VERSION=%{version} \
      DATAHOST=@DATAHOST@ \
      'PROVIDER=@PROVIDER@'
-cd ..
+
+cd %{_builddir}/%{name}/yggdrasil-worker-package-manager
+go build -o rhc-package-manager-worker -mod=vendor .
+
+cd %{_builddir}/%{name}/%{name}-%{version}-@RELEASE@
 make PREFIX=%{_prefix} \
      SYSCONFDIR=%{_sysconfdir} \
      LOCALSTATEDIR=%{_localstatedir} \
@@ -64,7 +71,7 @@ make PREFIX=%{_prefix} \
 
 
 %install
-cd yggdrasil-main
+cd %{_builddir}/%{name}/yggdrasil-0.2.1
 make PREFIX=%{_prefix} \
      SYSCONFDIR=%{_sysconfdir} \
      LOCALSTATEDIR=%{_localstatedir} \
@@ -78,7 +85,12 @@ make PREFIX=%{_prefix} \
      DATAHOST=@DATAHOST@ \
      'PROVIDER=@PROVIDER@' \
      install
-cd ..
+
+cd %{_builddir}/%{name}/yggdrasil-worker-package-manager
+install -D -m 755 rhc-package-manager-worker %{buildroot}%{_libexecdir}/@LONGNAME@/
+install -D -m 644 config.toml %{buildroot}%{_sysconfdir}/@LONGNAME@/workers/rhc-package-manager.toml
+
+cd %{_builddir}/%{name}/%{name}-%{version}-@RELEASE@
 make PREFIX=%{_prefix} \
      SYSCONFDIR=%{_sysconfdir} \
      LOCALSTATEDIR=%{_localstatedir} \
@@ -94,9 +106,10 @@ make PREFIX=%{_prefix} \
      install
 
 %files
-%doc README.md
+%doc %{name}-%{version}-@RELEASE@/README.md
 %{_bindir}/@SHORTNAME@
 %{_sbindir}/@SHORTNAME@d
+%{_sysconfdir}/@LONGNAME@/
 %config(noreplace) %{_sysconfdir}/@LONGNAME@/config.toml
 %{_unitdir}/@SHORTNAME@d.service
 %{_datadir}/bash-completion/completions/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,9 @@
 /rhc.1.gz
 /rhc.bash
 /USAGE.md
-/rhc.spec
+rhc.spec
+BUILD
+BUILDROOT
+RPMS
+SOURCES
+SRPMS

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ LONGNAME  := rhc
 BRANDNAME   := rhc
 # Used as the tarball file name. Cannot contain spaces.
 PKGNAME   := rhc
-VERSION   := 0.2.98
+VERSION   := 0.2.0
 # Used as the prefix for MQTT topic names
 TOPICPREFIX := redhat/insights
 # Used to force sending all HTTP traffic to a specific host.


### PR DESCRIPTION
As part of the decoupling of `rhc` and `yggdrasil`, we need to stitch things back together when building the `rhc` RPM. This PR modifies the spec file that is built in COPR to include `yggdrasil` and `yggdrasil-worker-package-manager` as secondary sources, builds them and includes them in the resulting RPM.