### PR TITLE
Bug fix: check result of running command

### DIFF
--- a/insights.go
+++ b/insights.go
@@ -16,10 +16,20 @@ func unregisterInsights() error {
 	return cmd.Run()
 }
 
-func insightsIsRegistered() bool {
+func insightsIsRegistered() (bool, error) {
 	cmd := exec.Command("/usr/bin/insights-client", "--status")
 
-	_ = cmd.Run()
+	err := cmd.Run()
 
-	return cmd.ProcessState.Success()
+	if err != nil {
+		// When the error is ExitError, then we know that insights-client only returned
+		// some error code not equal to zero. We do not care about error number.
+		if _, ok := err.(*exec.ExitError); ok {
+			return false, nil
+		} else {
+			return false, err
+		}
+	}
+
+	return cmd.ProcessState.Success(), err
 }

--- a/main.go
+++ b/main.go
@@ -17,9 +17,13 @@ import (
 	"golang.org/x/term"
 )
 
-const successPrefix = "\033[32m●\033[0m"
-const failPrefix = "\033[31m●\033[0m"
-const errorPrefix = "\033[31m!\033[0m"
+const redColor = "\u001B[31m"
+const greenColor = "\u001B[32m"
+const endColor = "\u001B[0m"
+
+const successPrefix = greenColor + "●" + endColor
+const failPrefix = redColor + "●" + endColor
+const errorPrefix = redColor + "!" + endColor
 
 func main() {
 	app := cli.NewApp()
@@ -312,13 +316,17 @@ func main() {
 
 				s.Suffix = " Checking Red Hat Insights..."
 				s.Start()
-				isRegistered := insightsIsRegistered()
+				isRegistered, err := insightsIsRegistered()
 				s.Stop()
 
 				if isRegistered {
 					fmt.Print(successPrefix + " Connected to Red Hat Insights\n")
 				} else {
-					fmt.Print(failPrefix + " Not connected to Red Hat Insights\n")
+					if err == nil {
+						fmt.Print(failPrefix + " Not connected to Red Hat Insights\n")
+					} else {
+						fmt.Printf(errorPrefix+" Cannot execute insights-client: %v\n", err)
+					}
 				}
 
 				conn, err := systemd.NewSystemConnection()


### PR DESCRIPTION
* When insights-client is not installed, then running command is finished with `*ExitError` and it is not possible to check state of the process