### PR TITLE
feat: Drop version of GO 1.15 from CI testing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.15', '1.16', '1.17']
+        go: ['1.16', '1.17']
     steps:
       - name: Updating ...
         run: sudo apt-get -qq update


### PR DESCRIPTION
Do not test Go version 1.15, because it is not used by any supported RHEL (7,8,9). The RHEL7 uses version 1.17.