### PR TITLE
feat: Better support for non-interactive mode

### DIFF
--- a/util.go
+++ b/util.go
@@ -5,7 +5,14 @@ import (
 	"io"
 
 	"github.com/urfave/cli/v2"
+	"golang.org/x/sys/unix"
 )
+
+// isTerminal returns true if the file descriptor is terminal.
+func isTerminal(fd uintptr) bool {
+	_, err := unix.IoctlGetTermios(int(fd), unix.TCGETS)
+	return err == nil
+}
 
 // BashCompleteCommand prints all visible flag options for the given command,
 // and then recursively calls itself on each subcommand.


### PR DESCRIPTION
* When `stdout` is not TTY, then do not display spinner and status text and the output of `rhc` should not be colorful, because output is redirected to some file. When temporary status messages and escape sequences were added to log file, then viewing such file could be complicated.
* When `NO_COLOR` environment variable is set, then do not display color nor animation too.
* This commit closes #14 issue