### PR TITLE
fix: Simple fix of Makefile to not require user input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ data: $(DATA)
 	go run $(BUILDFLAGS) -ldflags "$(LDFLAGS)" . --generate-man-page > $@
 
 %.1.gz: %.1
-	gzip -k $^
+	gzip -k -f $^
 
 USAGE.md: $(GOSRC)
 	go run $(BUILDFLAGS) -ldflags "$(LDFLAGS)" . --generate-markdown > $@


### PR DESCRIPTION
* When `make` is used for building `rhc`, then `gzip` is triggered to compress man page, but it required confirmation that old compressed man page would be rewritten. Adding -f option avoid the need of this confirmation.