### PR TITLE
feat: Big refactoring of main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -314,7 +314,7 @@ func canonicalFactAction(_ *cli.Context) error {
 // answer on following questions:
 // 1. Is system registered to Red Hat Subscription Management?
 // 2. Is system connected to red Hat Insights?
-// 3. Is rhsm.service running?
+// 3. Is rhcd.service running?
 func statusAction(ctx *cli.Context) error {
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"golang.org/x/term"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -14,7 +15,6 @@ import (
 	"github.com/briandowns/spinner"
 	systemd "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/term"
 )
 
 const redColor = "\u001B[31m"
@@ -22,14 +22,405 @@ const greenColor = "\u001B[32m"
 const endColor = "\u001B[0m"
 
 // Colorful prefixes
-const ttySuccessPrefix = greenColor + "●" + endColor
-const ttyFailPrefix = redColor + "●" + endColor
+const ttyConnectedPrefix = greenColor + "●" + endColor
+const ttyDisconnectedPrefix = redColor + "●" + endColor
 const ttyErrorPrefix = redColor + "!" + endColor
 
 // Black & white prefixes. Unicode characters
-const bwSuccessPrefix = "✓"
-const bwFailPrefix = "𐄂"
+const bwConnectedPrefix = "✓"
+const bwDisconnectedPrefix = "𐄂"
 const bwErrorPrefix = "!"
+
+// showProgress calls function and, when it is possible display spinner with
+// some progress message.
+func showProgress(progressMessage string, isColorful bool, function func() error) error {
+	var s *spinner.Spinner
+	if isColorful {
+		s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+		s.Suffix = progressMessage
+		s.Start()
+		// Stop spinner after running function
+		defer func() {s.Stop()}()
+	}
+	return function()
+}
+
+// getColorPreferences tries to get color preferences form context
+func getColorPreferences(ctx *cli.Context) (connectedPrefix string, disconnectedPrefix string,
+		errorPrefix string, isColorful bool) {
+	noColor := ctx.Bool("no-color")
+
+	if noColor {
+		isColorful = false
+		connectedPrefix = bwConnectedPrefix
+		disconnectedPrefix = bwDisconnectedPrefix
+		errorPrefix = bwErrorPrefix
+	} else {
+		isColorful = true
+		connectedPrefix = ttyConnectedPrefix
+		disconnectedPrefix = ttyDisconnectedPrefix
+		errorPrefix = ttyErrorPrefix
+	}
+	return
+}
+
+// showTimeDuration shows table with duration of each sub-action
+func showTimeDuration(durations map[string]time.Duration) {
+	if log.CurrentLevel() >= log.LevelDebug {
+		fmt.Println()
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(w, "STEP\tDURATION\t")
+		for step, duration := range durations {
+			_, _ = fmt.Fprintf(w, "%v\t%v\t\n", step, duration.Truncate(time.Millisecond))
+		}
+		_ = w.Flush()
+	}
+}
+
+// showErrorMessages shows table with all error messages gathered during action
+func showErrorMessages(action string, errorMessages map[string]error) error {
+	if len(errorMessages) > 0 {
+		fmt.Println()
+		fmt.Printf("The following errors were encountered during %s:\n\n", action)
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(w, "STEP\tERROR\t")
+		for svc, err := range errorMessages {
+			_, _ = fmt.Fprintf(w, "%v\t%v\n", svc, err)
+		}
+		_ = w.Flush()
+		return cli.Exit("", 1)
+	}
+	return nil
+}
+
+// registerRHSM tries to register system against Red Hat Subscription Management server (candlepin server)
+func registerRHSM(ctx *cli.Context) (error, string) {
+	uuid, err := getConsumerUUID()
+	if err != nil {
+		return cli.Exit(err, 1), "Unable to get consumer UUID"
+	}
+	var successMsg string
+
+	_, _, _, isColorful := getColorPreferences(ctx)
+
+	if uuid == "" {
+		username := ctx.String("username")
+		password := ctx.String("password")
+		organization := ctx.String("organization")
+		activationKeys := ctx.StringSlice("activation-key")
+
+		if len(activationKeys) == 0 {
+			if username == "" {
+				password = ""
+				scanner := bufio.NewScanner(os.Stdin)
+				fmt.Print("Username: ")
+				_ = scanner.Scan()
+				username = strings.TrimSpace(scanner.Text())
+			}
+			if password == "" {
+				fmt.Print("Password: ")
+				data, err := term.ReadPassword(int(os.Stdin.Fd()))
+				if err != nil {
+					return cli.Exit(err, 1), "Unable to read password"
+				}
+				password = string(data)
+				fmt.Printf("\n\n")
+			}
+		}
+
+		var s *spinner.Spinner
+		if isColorful {
+			s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+			s.Suffix = " Connecting to Red Hat Subscription Management..."
+			s.Start()
+			defer s.Stop()
+		}
+
+		var err error
+		if len(activationKeys) > 0 {
+			err = registerActivationKey(
+				organization,
+				ctx.StringSlice("activation-key"),
+				ctx.String("server"))
+		} else {
+			if organization != "" {
+				err = registerPassword(username, password, organization, ctx.String("server"))
+			} else {
+				/* TODO: When organization was not specified using CLI option --organization and it is
+				   required, because user is member of more than one organization, then ask for
+				   the organization. RHSM D-Bus API can provide list of available organizations
+				   in this case. */
+				err = registerPassword(username, password, "", ctx.String("server"))
+			}
+		}
+		if err != nil {
+			return cli.Exit(err, 1), "Unable to register system to RHSM"
+		}
+		successMsg = "Connected to Red Hat Subscription Management"
+	} else {
+		successMsg = "This system is already connected to Red Hat Subscription Management"
+	}
+	return nil, successMsg
+}
+
+// connectAction tries to register system against Red Hat Subscription Management,
+// connect system to Red Hat Insights and it also tries to start rhcd service
+func connectAction(ctx *cli.Context) error {
+	var start time.Time
+	durations := make(map[string]time.Duration)
+	errorMessages := make(map[string]error)
+	hostname, err := os.Hostname()
+	if err != nil {
+		return cli.Exit(err, 1)
+	}
+
+	fmt.Printf("Connecting %v to %v.\nThis might take a few seconds.\n\n", hostname, Provider)
+
+	connectedPrefix, disconnectedPrefix, errorPrefix, isColorful := getColorPreferences(ctx)
+
+	/* 1. Register to RHSM, because we need to get consumer certificate. This blocks following action */
+	start = time.Now()
+	var returnedMsg string
+	err, returnedMsg = registerRHSM(ctx)
+	if err != nil {
+		errorMessages["rhsm"] = fmt.Errorf("cannot connect to Red Hat Subscription Management: %w", err)
+		fmt.Printf(errorPrefix + " Cannot connect to Red Hat Subscription Management\n")
+	} else {
+		fmt.Printf(connectedPrefix + " " + returnedMsg + "\n")
+	}
+	durations["rhsm"] = time.Since(start)
+
+	/* 2. Register insights-client */
+	if _, exist := errorMessages["rhsm"]; exist {
+		fmt.Printf(disconnectedPrefix + " Skipping connection to Red Hat Insights\n")
+	} else {
+		start = time.Now()
+		err = showProgress(" Connecting to Red Hat Insights...", isColorful, registerInsights)
+		if err != nil {
+			errorMessages["insights"] = fmt.Errorf("cannot connect to Red Hat Insights: %w", err)
+			fmt.Printf(errorPrefix + " Cannot connect to Red Hat Insights\n")
+		} else {
+			fmt.Printf(connectedPrefix + " Connected to Red Hat Insights\n")
+		}
+		durations["insights"] = time.Since(start)
+	}
+
+	/* 3. Start rhcd daemon */
+	if _, exist := errorMessages["rhsm"]; exist {
+		fmt.Printf(disconnectedPrefix + " Skipping activation of %v daemon\n", BrandName)
+	} else {
+		start = time.Now()
+		progressMessage := fmt.Sprintf(" Activating the %v daemon", BrandName)
+		err = showProgress(progressMessage, isColorful, activate)
+		if err != nil {
+			errorMessages[BrandName] = fmt.Errorf("cannot activate daemon: %w", err)
+			fmt.Printf(errorPrefix+" Cannot activate the %v daemon\n", BrandName)
+		} else {
+			fmt.Printf(connectedPrefix+" Activated the %v daemon\n", BrandName)
+		}
+		durations[BrandName] = time.Since(start)
+	}
+
+	/* 4. Show footer message */
+	fmt.Printf("\nManage your Red Hat connector systems: https://red.ht/connector\n")
+
+	/* 5. Optionally display duration time of each sub-action */
+	showTimeDuration(durations)
+
+	err = showErrorMessages("connect", errorMessages)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// disconnectAction tries to stop rhscd service, disconnect from Red Hat Insights and finally
+// it unregister system from Red Hat Subscription Management
+func disconnectAction(ctx *cli.Context) error {
+	var start time.Time
+	durations := make(map[string]time.Duration)
+	errorMessages := make(map[string]error)
+	hostname, err := os.Hostname()
+	if err != nil {
+		return cli.Exit(err, 1)
+	}
+	fmt.Printf("Disconnecting %v from %v.\nThis might take a few seconds.\n\n", hostname, Provider)
+
+	_, disconnectedPrefix, errorPrefix, isColorful := getColorPreferences(ctx)
+
+	/* 1. Deactivate rhcd daemon */
+	start = time.Now()
+	progressMessage := fmt.Sprintf(" Deactivating the %v daemon", BrandName)
+	err = showProgress(progressMessage, isColorful, deactivate)
+	if err != nil {
+		errorMessages[BrandName] = fmt.Errorf("cannot deactivate daemon: %w", err)
+		fmt.Printf(errorPrefix+" Cannot deactivate the %v daemon\n", BrandName)
+	} else {
+		fmt.Printf(disconnectedPrefix+" Deactivated the %v daemon\n", BrandName)
+	}
+	durations[BrandName] = time.Since(start)
+
+	/* 2. Disconnect from Red Hat Insights */
+	start = time.Now()
+	err = showProgress(" Disconnecting from Red Hat Insights...", isColorful, unregisterInsights)
+	if err != nil {
+		errorMessages["insights"] = fmt.Errorf("cannot disconnect from Red Hat Insights: %w", err)
+		fmt.Printf(errorPrefix + " Cannot disconnect from Red Hat Insights\n")
+	} else {
+		fmt.Print(disconnectedPrefix + " Disconnected from Red Hat Insights\n")
+	}
+	durations["insights"] = time.Since(start)
+
+	/* 3. Unregister system from Red Hat Subscription Management */
+	err = showProgress(" Disconnecting from Red Hat Subscription Management...", isColorful, unregister)
+	if err != nil {
+		errorMessages["rhsm"] = fmt.Errorf("cannot disconnect from Red Hat Subscription Management: %w", err)
+		fmt.Printf(errorPrefix + " Cannot disconnect from Red Hat Subscription Management\n")
+	} else {
+		fmt.Printf(disconnectedPrefix + " Disconnected from Red Hat Subscription Management\n")
+	}
+	durations["rhsm"] = time.Since(start)
+
+	fmt.Printf("\nManage your Red Hat connector systems: https://red.ht/connector\n")
+
+	showTimeDuration(durations)
+
+	err = showErrorMessages("disconnect", errorMessages)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// canonicalFactAction tries to gather canonical facts about system,
+// and it prints JSON with facts to stdout.
+func canonicalFactAction(_ *cli.Context) error {
+	// NOTE: CLI context is not useful for anything
+	facts, err := GetCanonicalFacts()
+	if err != nil {
+		return cli.Exit(err, 1)
+	}
+	data, err := json.MarshalIndent(facts, "", "   ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+// statusAction tries to print status of system. It means that it gives
+// answer on following questions:
+// 1. Is system registered to Red Hat Subscription Management?
+// 2. Is system connected to red Hat Insights?
+// 3. Is rhsm.service running?
+func statusAction(ctx *cli.Context) error {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return cli.Exit(err, 1)
+	}
+
+	fmt.Printf("Connection status for %v:\n\n", hostname)
+
+	connectedPrefix, disconnectedPrefix, errorPrefix, isColorful := getColorPreferences(ctx)
+
+	/* 1. Get Status of RHSM */
+	uuid, err := getConsumerUUID()
+	if err != nil {
+		return cli.Exit(err, 1)
+	}
+	if uuid == "" {
+		fmt.Printf(disconnectedPrefix + " Not connected to Red Hat Subscription Management\n")
+	} else {
+		fmt.Printf(connectedPrefix + " Connected to Red Hat Subscription Management\n")
+	}
+
+	/* 2. Get status of insights-client */
+	var s *spinner.Spinner
+	if isColorful {
+		s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+		s.Suffix = " Checking Red Hat Insights..."
+		s.Start()
+	}
+	isRegistered, err := insightsIsRegistered()
+	if isColorful {
+		s.Stop()
+	}
+	if isRegistered {
+		fmt.Print(connectedPrefix + " Connected to Red Hat Insights\n")
+	} else {
+		if err == nil {
+			fmt.Print(disconnectedPrefix + " Not connected to Red Hat Insights\n")
+		} else {
+			fmt.Printf(errorPrefix+" Cannot execute insights-client: %v\n", err)
+		}
+	}
+
+	/* 3. Get status of rhcd */
+	conn, err := systemd.NewSystemConnection()
+	if err != nil {
+		return cli.Exit(err, 1)
+	}
+	defer conn.Close()
+	unitName := ShortName + "d.service"
+	properties, err := conn.GetUnitProperties(unitName)
+	if err != nil {
+		return cli.Exit(err, 1)
+	}
+	activeState := properties["ActiveState"]
+	if activeState.(string) == "active" {
+		fmt.Printf(connectedPrefix+" The %v daemon is active\n", BrandName)
+	} else {
+		fmt.Printf(disconnectedPrefix+" The %v daemon is inactive\n", BrandName)
+	}
+
+	fmt.Printf("\nManage your Red Hat connector systems: https://red.ht/connector\n")
+
+	return nil
+}
+
+// mainAction is triggered in the case, when no sub-command is specified
+func mainAction(c *cli.Context) error {
+	type GenerationFunc func() (string, error)
+	var generationFunc GenerationFunc
+	if c.Bool("generate-man-page") {
+		generationFunc = c.App.ToMan
+	} else if c.Bool("generate-markdown") {
+		generationFunc = c.App.ToMarkdown
+	} else {
+		cli.ShowAppHelpAndExit(c, 0)
+	}
+	data, err := generationFunc()
+	if err != nil {
+		return cli.Exit(err, 1)
+	}
+	fmt.Println(data)
+	return nil
+}
+
+// beforeAction is triggered before other actions are triggered
+func beforeAction(c *cli.Context) error {
+	level, err := log.ParseLevel(c.String("log-level"))
+	if err != nil {
+		return cli.Exit(err, 1)
+	}
+	log.SetLevel(level)
+
+	// When environment variable NO_COLOR or --no-color CLI option is set, then do not display colors
+	// and animations too. The NO_COLOR environment variable have to have value "1" or "true",
+	// "True", "TRUE" to take effect
+	// When no-color is not set, then try to detect if the output goes to some file. In this case
+	// colors nor animations will not be printed to file.
+	if !isTerminal(os.Stdout.Fd()) {
+		err := c.Set("no-color", "true")
+		if err != nil {
+			log.Debug("Unable to set no-color flag to \"true\"")
+		}
+	}
+
+	return nil
+}
 
 func main() {
 	app := cli.NewApp()
@@ -48,12 +439,6 @@ func main() {
 	log.SetFlags(0)
 	log.SetPrefix("")
 
-	isColorful := true
-
-	successPrefix := ttySuccessPrefix
-	failPrefix := ttyFailPrefix
-	errorPrefix := ttyErrorPrefix
-
 	app.Flags = []cli.Flag{
 		&cli.BoolFlag{
 			Name:   "generate-man-page",
@@ -69,9 +454,9 @@ func main() {
 			Value:  "error",
 		},
 		&cli.BoolFlag{
-			Name:   "no-color",
-			Hidden: false,
-			Value:  false,
+			Name:    "no-color",
+			Hidden:  false,
+			Value:   false,
 			EnvVars: []string{"NO_COLOR"},
 		},
 	}
@@ -107,210 +492,14 @@ func main() {
 			Usage:       "Connects the system to " + Provider,
 			UsageText:   fmt.Sprintf("%v connect [command options]", app.Name),
 			Description: fmt.Sprintf("The connect command connects the system to Red Hat Subscription Management, Red Hat Insights and %v and activates the %v daemon that enables %v to interact with the system. For details visit: https://red.ht/connector", Provider, BrandName, Provider),
-			Action: func(c *cli.Context) error {
-				var start time.Time
-				durations := make(map[string]time.Duration)
-				hostname, err := os.Hostname()
-				if err != nil {
-					return cli.Exit(err, 1)
-				}
-
-				fmt.Printf("Connecting %v to %v.\nThis might take a few seconds.\n\n", hostname, Provider)
-
-				start = time.Now()
-				uuid, err := getConsumerUUID()
-				if err != nil {
-					return cli.Exit(err, 1)
-				}
-
-				if uuid == "" {
-					username := c.String("username")
-					password := c.String("password")
-
-					if c.String("organization") == "" {
-						if username == "" {
-							password = ""
-							scanner := bufio.NewScanner(os.Stdin)
-							fmt.Print("Username: ")
-							_ = scanner.Scan()
-							username = strings.TrimSpace(scanner.Text())
-						}
-						if password == "" {
-							fmt.Print("Password: ")
-							data, err := term.ReadPassword(int(os.Stdin.Fd()))
-							if err != nil {
-								return cli.Exit(err, 1)
-							}
-							password = string(data)
-							fmt.Printf("\n\n")
-						}
-					}
-
-					var s *spinner.Spinner
-					if isColorful {
-						s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-						s.Suffix = " Connecting to Red Hat Subscription Management..."
-						s.Start()
-					}
-					var err error
-					if c.String("organization") != "" {
-						err = registerActivationKey(c.String("organization"), c.StringSlice("activation-key"), c.String("server"))
-					} else {
-						err = registerPassword(username, password, c.String("server"))
-					}
-					if isColorful {
-						s.Stop()
-					}
-					if err != nil {
-						return cli.Exit(err, 1)
-					}
-					fmt.Printf(successPrefix + " Connected to Red Hat Subscription Management\n")
-				} else {
-					fmt.Printf(successPrefix + " This system is already connected to Red Hat Subscription Management\n")
-				}
-				durations["rhsm"] = time.Since(start)
-
-				start = time.Now()
-				var s *spinner.Spinner
-				if isColorful {
-					s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-					s.Suffix = " Connecting to Red Hat Insights..."
-					s.Start()
-				}
-				err = registerInsights()
-				if isColorful {
-					s.Stop()
-				}
-				if err != nil {
-					return cli.Exit(err, 1)
-				}
-				fmt.Printf(successPrefix + " Connected to Red Hat Insights\n")
-				durations["insights"] = time.Since(start)
-
-				start = time.Now()
-				if isColorful {
-					s.Suffix = fmt.Sprintf(" Activating the %v daemon", BrandName)
-					s.Start()
-				}
-				err = activate()
-				if isColorful {
-					s.Stop()
-				}
-				if err != nil {
-					return cli.Exit(err, 1)
-				}
-				fmt.Printf(successPrefix+" Activated the %v daemon\n", BrandName)
-				durations[BrandName] = time.Since(start)
-
-				fmt.Printf("\nManage your Red Hat connector systems: https://red.ht/connector\n")
-
-				if log.CurrentLevel() >= log.LevelDebug {
-					fmt.Println()
-					w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-					fmt.Fprintln(w, "STEP\tDURATION\t")
-					for step, duration := range durations {
-						fmt.Fprintf(w, "%v\t%v\t\n", step, duration.Truncate(time.Millisecond))
-					}
-					w.Flush()
-				}
-
-				return nil
-			},
+			Action:      connectAction,
 		},
 		{
 			Name:        "disconnect",
 			Usage:       "Disconnects the system from " + Provider,
 			UsageText:   fmt.Sprintf("%v disconnect", app.Name),
 			Description: fmt.Sprintf("The disconnect command disconnects the system from Red Hat Subscription Management, Red Hat Insights and %v and deactivates the %v daemon. %v will no longer be able to interact with the system.", Provider, BrandName, Provider),
-			Action: func(c *cli.Context) error {
-				var start time.Time
-				durations := make(map[string]time.Duration)
-				errorMessages := make(map[string]error)
-				hostname, err := os.Hostname()
-				if err != nil {
-					return cli.Exit(err, 1)
-				}
-				fmt.Printf("Disconnecting %v from %v.\nThis might take a few seconds.\n\n", hostname, Provider)
-
-				s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-
-				start = time.Now()
-				if isColorful {
-					s.Suffix = fmt.Sprintf(" Deactivating the %v daemon", BrandName)
-					s.Start()
-				}
-				err = deactivate()
-				if isColorful {
-					s.Stop()
-				}
-				if err != nil {
-					errorMessages[BrandName] = fmt.Errorf("cannot deactivate daemon: %w", err)
-					fmt.Printf(errorPrefix+" Cannot deactivate the %v daemon\n", BrandName)
-				} else {
-					fmt.Printf(failPrefix+" Deactivated the %v daemon\n", BrandName)
-				}
-				durations[BrandName] = time.Since(start)
-
-				start = time.Now()
-				if isColorful {
-					s.Suffix = " Disconnecting from Red Hat Insights..."
-					s.Start()
-				}
-				err = unregisterInsights()
-				if isColorful {
-					s.Stop()
-				}
-				if err != nil {
-					errorMessages["insights"] = fmt.Errorf("cannot disconnect from Red Hat Insights: %w", err)
-					fmt.Printf(errorPrefix + " Cannot disconnect from Red Hat Insights\n")
-				} else {
-					fmt.Print(failPrefix + " Disconnected from Red Hat Insights\n")
-				}
-				durations["insights"] = time.Since(start)
-
-				start = time.Now()
-				if isColorful {
-					s.Suffix = " Disconnecting from Red Hat Subscription Management..."
-					s.Start()
-				}
-				err = unregister()
-				if isColorful {
-					s.Stop()
-				}
-				if err != nil {
-					errorMessages["rhsm"] = fmt.Errorf("cannot disconnect from Red Hat Subscription Management: %w", err)
-					fmt.Printf(errorPrefix + " Cannot disconnect from Red Hat Subscription Management\n")
-				} else {
-					fmt.Printf(failPrefix + " Disconnected from Red Hat Subscription Management\n")
-				}
-				durations["rhsm"] = time.Since(start)
-
-				fmt.Printf("\nManage your Red Hat connector systems: https://red.ht/connector\n")
-
-				if log.CurrentLevel() >= log.LevelDebug {
-					fmt.Println()
-					w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-					fmt.Fprintln(w, "STEP\tDURATION\t")
-					for step, duration := range durations {
-						fmt.Fprintf(w, "%v\t%v\t\n", step, duration.Truncate(time.Millisecond))
-					}
-					w.Flush()
-				}
-
-				if len(errorMessages) > 0 {
-					fmt.Println()
-					fmt.Printf("The following errors were encountered during disconnect:\n\n")
-					w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-					fmt.Fprintln(w, "STEP\tERROR\t")
-					for svc, err := range errorMessages {
-						fmt.Fprintf(w, "%v\t%v\n", svc, err)
-					}
-					w.Flush()
-					return cli.Exit("", 1)
-				}
-
-				return nil
-			},
+			Action:      disconnectAction,
 		},
 		{
 			Name:        "canonical-facts",
@@ -318,128 +507,20 @@ func main() {
 			Usage:       "Prints canonical facts about the system.",
 			UsageText:   fmt.Sprintf("%v canonical-facts", app.Name),
 			Description: fmt.Sprintf("The canonical-facts command prints data that uniquely identifies the system in the %v inventory service. Use only as directed for debugging purposes.", Provider),
-			Action: func(c *cli.Context) error {
-				facts, err := GetCanonicalFacts()
-				if err != nil {
-					return cli.Exit(err, 1)
-				}
-				data, err := json.MarshalIndent(facts, "", "   ")
-				if err != nil {
-					return err
-				}
-				fmt.Println(string(data))
-				return nil
-			},
+			Action:      canonicalFactAction,
 		},
 		{
 			Name:        "status",
 			Usage:       "Prints status of the system's connection to " + Provider,
 			UsageText:   fmt.Sprintf("%v status", app.Name),
 			Description: fmt.Sprintf("The status command prints the state of the connection to Red Hat Subscription Management, Red Hat Insights and %v.", Provider),
-			Action: func(c *cli.Context) error {
-				hostname, err := os.Hostname()
-				if err != nil {
-					return cli.Exit(err, 1)
-				}
-
-				fmt.Printf("Connection status for %v:\n\n", hostname)
-
-				uuid, err := getConsumerUUID()
-				if err != nil {
-					return cli.Exit(err, 1)
-				}
-				if uuid == "" {
-					fmt.Printf(failPrefix + " Not connected to Red Hat Subscription Management\n")
-				} else {
-					fmt.Printf(successPrefix + " Connected to Red Hat Subscription Management\n")
-				}
-
-				var s *spinner.Spinner
-				if isColorful {
-					s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-					s.Suffix = " Checking Red Hat Insights..."
-					s.Start()
-				}
-				isRegistered, err := insightsIsRegistered()
-				if isColorful {
-					s.Stop()
-				}
-
-				if isRegistered {
-					fmt.Print(successPrefix + " Connected to Red Hat Insights\n")
-				} else {
-					if err == nil {
-						fmt.Print(failPrefix + " Not connected to Red Hat Insights\n")
-					} else {
-						fmt.Printf(errorPrefix+" Cannot execute insights-client: %v\n", err)
-					}
-				}
-
-				conn, err := systemd.NewSystemConnection()
-				if err != nil {
-					return cli.Exit(err, 1)
-				}
-				defer conn.Close()
-
-				unitName := ShortName + "d.service"
-
-				properties, err := conn.GetUnitProperties(unitName)
-				if err != nil {
-					return cli.Exit(err, 1)
-				}
-
-				activeState := properties["ActiveState"]
-				if activeState.(string) == "active" {
-					fmt.Printf(successPrefix+" The %v daemon is active\n", BrandName)
-				} else {
-					fmt.Printf(failPrefix+" The %v daemon is inactive\n", BrandName)
-				}
-
-				fmt.Printf("\nManage your Red Hat connector systems: https://red.ht/connector\n")
-
-				return nil
-			},
+			Action:      statusAction,
 		},
 	}
 	app.EnableBashCompletion = true
 	app.BashComplete = BashComplete
-	app.Action = func(c *cli.Context) error {
-		type GenerationFunc func() (string, error)
-		var generationFunc GenerationFunc
-		if c.Bool("generate-man-page") {
-			generationFunc = c.App.ToMan
-		} else if c.Bool("generate-markdown") {
-			generationFunc = c.App.ToMarkdown
-		} else {
-			cli.ShowAppHelpAndExit(c, 0)
-		}
-		data, err := generationFunc()
-		if err != nil {
-			return cli.Exit(err, 1)
-		}
-		fmt.Println(data)
-		return nil
-	}
-	app.Before = func(c *cli.Context) error {
-		level, err := log.ParseLevel(c.String("log-level"))
-		if err != nil {
-			return cli.Exit(err, 1)
-		}
-		log.SetLevel(level)
-
-		// When environment variable NO_COLOR or --no-color CLI option is set, then do not display colors
-		// and animations too. BTW: We do not care about value of NO_COLOR variable.
-		// When no-color is not set, then try to detect if the output goes to some file. In this case
-		// colors nor animations will not be printed to file.
-		if c.Bool("no-color") || !isTerminal(os.Stdout.Fd()) {
-			successPrefix = bwSuccessPrefix
-			failPrefix = bwFailPrefix
-			errorPrefix = bwErrorPrefix
-			isColorful = false
-		}
-
-		return nil
-	}
+	app.Action = mainAction
+	app.Before = beforeAction
 
 	if err := app.Run(os.Args); err != nil {
 		log.Error(err)

--- a/register.go
+++ b/register.go
@@ -23,7 +23,7 @@ func getConsumerUUID() (string, error) {
 	return uuid, nil
 }
 
-func registerPassword(username, password, serverURL string) error {
+func registerPassword(username, password, organization, serverURL string) error {
 	if serverURL != "" {
 		if err := configureRHSM(serverURL); err != nil {
 			return fmt.Errorf("cannot configure RHSM: %w", err)
@@ -61,7 +61,7 @@ func registerPassword(username, password, serverURL string) error {
 		return err
 	}
 
-	if err := privConn.Object("com.redhat.RHSM1", "/com/redhat/RHSM1/Register").Call("com.redhat.RHSM1.Register.Register", dbus.Flags(0), "", username, password, map[string]string{}, map[string]string{}, "").Err; err != nil {
+	if err := privConn.Object("com.redhat.RHSM1", "/com/redhat/RHSM1/Register").Call("com.redhat.RHSM1.Register.Register", dbus.Flags(0), organization, username, password, map[string]string{}, map[string]string{}, "").Err; err != nil {
 		return unpackError(err)
 	}
 


### PR DESCRIPTION
* Functions of sub-commands were moved to function outside of main function. Created several functions to not duplicate code. Side effect of this effort is better displaying of errors for "connect" sub-command.
* Functions for "main" and "before" actions were also move outside main function
* Fixed one small issue with registration to RHSM. It is possible to use --organization, when --username and --password are specified. The registration process could be improved more, but it should be part of another commit. Added only fix-me comment for this case.