### PR TITLE
Update-actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.16", "1.17"]
+        go: ["1.16", "1.18"]
     steps:
       - name: Updating ...
         run: sudo apt-get -qq update

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.16', '1.17']
+        go: ["1.16", "1.17"]
     steps:
       - name: Updating ...
         run: sudo apt-get -qq update
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -20,21 +20,21 @@ jobs:
             ${{ runner.os }}-go-
       - run: go mod download
       - name: Run commitsar
-        uses: aevea/commitsar@v0.16.0
+        uses: aevea/commitsar@v0.20.1
   lint-code:
     name: Lint code
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.1
+        uses: golangci/golangci-lint-action@v3.3.0
   lint-language:
     name: Lint language
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run woke
         uses: get-woke/woke-action@v0
         with:


### PR DESCRIPTION
Update action versions (this removes the deprecation notices about node12 actions) and update the Go version matrix to drop 1.17 and include 1.18.