### PR TITLE
feat: Add --format json option for status sub-command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,6 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.1.2
 	github.com/urfave/cli/v2 v2.3.0
-	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 )


### PR DESCRIPTION
* Sub-command status has now --json option. When this option is used, then status is printed to stdout at JSON document.
* JSON document always contains following items:
  - hostname
  - rhsm_connected
  - insights_connected
  - rhcd_running
* When something goes wrong, then JSON document can contain addition following items:
  - hostname_error
  - rhsm_error
  - insights_error
  - rhcd_error
* Example of JSON output can look like this:

```
[root@rhel9 ~]$ rhc status --json
{
    "hostname": "rhel9",
    "rhsm_connected": true,
    "insights_connected": false,
    "insights_error": {
        "Op": "fork/exec",
        "Path": "/usr/bin/insights-client",
        "Err": 2
    },
    "rhcd_running": false
}
```