### PR TITLE
Enable content when registering with username & password

### DIFF
--- a/register.go
+++ b/register.go
@@ -61,7 +61,7 @@ func registerPassword(username, password, organization, serverURL string) error 
 		return err
 	}
 
-	if err := privConn.Object("com.redhat.RHSM1", "/com/redhat/RHSM1/Register").Call("com.redhat.RHSM1.Register.Register", dbus.Flags(0), organization, username, password, map[string]string{}, map[string]string{}, "").Err; err != nil {
+	if err := privConn.Object("com.redhat.RHSM1", "/com/redhat/RHSM1/Register").Call("com.redhat.RHSM1.Register.Register", dbus.Flags(0), organization, username, password, map[string]string{"enable_content": "true"}, map[string]string{}, "").Err; err != nil {
 		return unpackError(err)
 	}
 


### PR DESCRIPTION
When registering with username & password, include "enable_content" in the options map to ensure content gets enabled.

Fixes: RHBZ#2141454