### PR TITLE
feat: rhc renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-`rhc` is a simple, one-step front-end client for Red Hat connected services. It
+`rhc` is a simple, one-step front-end client for remote host configured services. It
 is built to be an alternative client to `subscription-manager`,
 `insights-client`, and any other client utility that enables connecting a system
 to Red Hat services.
@@ -11,7 +11,7 @@ It currently performs 3 steps when it connects a system:
    registered, this step is a noop and it moves to the next step.
 3. Activate the `rhcd` daemon.
 
-Likewise, when rhc is disconnecting a system, it performs the steps in
+Likewise, when `rhc` is disconnecting a system, it performs the steps in
 descending order.
 
 1. Deactivates the `rhcd` daemon.

--- a/main.go
+++ b/main.go
@@ -228,7 +228,7 @@ func connectAction(ctx *cli.Context) error {
 	}
 
 	/* 4. Show footer message */
-	fmt.Printf("\nManage your Red Hat connector systems: https://red.ht/connector\n")
+	fmt.Printf("\nManage your connected systems: https://red.ht/connector\n")
 
 	/* 5. Optionally display duration time of each sub-action */
 	showTimeDuration(durations)
@@ -293,7 +293,7 @@ func disconnectAction(ctx *cli.Context) error {
 	}
 	durations["rhsm"] = time.Since(start)
 
-	fmt.Printf("\nManage your Red Hat connector systems: https://red.ht/connector\n")
+	fmt.Printf("\nManage your connected systems: https://red.ht/connector\n")
 
 	showTimeDuration(durations)
 
@@ -493,7 +493,7 @@ func statusAction(ctx *cli.Context) (err error) {
 	}
 
 	if !machineReadable {
-		fmt.Printf("\nManage your Red Hat connector systems: https://red.ht/connector\n")
+		fmt.Printf("\nManage your connected systems: https://red.ht/connector\n")
 	}
 
 	return nil


### PR DESCRIPTION
RHC stands for Remote Host configuration, change all old mentions to this acronym to meet this name.

Resolves: ESSNTL-4228