### PR TITLE
fix: stdout redirection blocking terminal

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,15 +1,12 @@
 package main
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 	"text/tabwriter"
 	"time"
-
-	"golang.org/x/term"
 
 	"git.sr.ht/~spc/go-log"
 
@@ -113,18 +110,17 @@ func registerRHSM(ctx *cli.Context) (string, error) {
 		if len(activationKeys) == 0 {
 			if username == "" {
 				password = ""
-				scanner := bufio.NewScanner(os.Stdin)
-				fmt.Print("Username: ")
-				_ = scanner.Scan()
-				username = strings.TrimSpace(scanner.Text())
+				username, err = readInput("Username: ", false)
+				if err != nil {
+					return "Unable to read username", cli.Exit(err, 1)
+				}
+				username = strings.TrimSpace(username)
 			}
 			if password == "" {
-				fmt.Print("Password: ")
-				data, err := term.ReadPassword(int(os.Stdin.Fd()))
+				password, err = readInput("Password: ", true)
 				if err != nil {
 					return "Unable to read password", cli.Exit(err, 1)
 				}
-				password = string(data)
 				fmt.Printf("\n\n")
 			}
 		}
@@ -159,7 +155,6 @@ func registerRHSM(ctx *cli.Context) (string, error) {
 					}
 
 					// Ask for organization and display hint with list of organizations
-					scanner := bufio.NewScanner(os.Stdin)
 					fmt.Println("Available Organizations:")
 					writer := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
 					for i, org := range orgs {
@@ -169,9 +164,11 @@ func registerRHSM(ctx *cli.Context) (string, error) {
 						}
 					}
 					_ = writer.Flush()
-					fmt.Print("\nOrganization: ")
-					_ = scanner.Scan()
-					organization = strings.TrimSpace(scanner.Text())
+					organization, err = readInput("\nOrganization: ", false)
+					if err != nil {
+						return "Unable to read organization", cli.Exit(err, 1)
+					}
+					organization = strings.TrimSpace(organization)
 					fmt.Printf("\n")
 
 					// Start spinner again

--- a/util.go
+++ b/util.go
@@ -1,17 +1,56 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sys/unix"
+	"golang.org/x/term"
 )
 
 // isTerminal returns true if the file descriptor is terminal.
 func isTerminal(fd uintptr) bool {
 	_, err := unix.IoctlGetTermios(int(fd), unix.TCGETS)
 	return err == nil
+}
+
+// stdIsRedirected returns true if the std* is redirected out of the terminal.
+// This can be used to check if an rhc command is being redirected to a file.
+func stdIsRedirected(std *os.File) (bool, error) {
+	out, err := std.Stat()
+	if err != nil {
+		return false, err
+	}
+	return (out.Mode() & os.ModeCharDevice) != os.ModeCharDevice, nil
+}
+
+// readInput is used to gather user input from the terminal and checks if
+// rhc is being used in a non-interactive context to ensure the terminal is not blocked.
+func readInput(prompt string, isSensitiveInput bool) (string, error) {
+	stdoutRedirected, err := stdIsRedirected(os.Stdout)
+	if err != nil {
+		return "", err
+	}
+	if stdoutRedirected {
+		errMsg := fmt.Errorf("non-interactive usage of rhc does not support interactive user input")
+		return "", errMsg
+	}
+	if prompt != "" {
+		fmt.Print(prompt)
+	}
+	if isSensitiveInput {
+		data, err := term.ReadPassword(int(os.Stdin.Fd()))
+		if err != nil {
+			return "", err
+		}
+		return string(data), nil
+	}
+	scanner := bufio.NewScanner(os.Stdin)
+	_ = scanner.Scan()
+	return scanner.Text(), nil
 }
 
 // BashCompleteCommand prints all visible flag options for the given command,


### PR DESCRIPTION
When rhc is invoked non-interactively and required arguments
are not provided, user prompts from rhc block/hang the terminal.
This commit aims to check for this occurrence and return an error instead.
This issue was originally discussed by Matyas and Jiri in #24 

- Introduces two utility methods: `stdIsRedirected` and `readInput`.
- When an rhc command is invoked with redirected output, an error with exit code 1 is returned instead of blocking the terminal.
- Moved user input prompts to a universal `readInput` utility method which can handle prompt messages and sensitive user input to prevent repeated usage of non-interactive context checks.

Useful and informative article I found about this while trying to find a solution: [Here](https://rderik.com/blog/identify-if-output-goes-to-the-terminal-or-is-being-redirected-in-golang/)