### PR TITLE
feat: Make --server CLI option hidden

### DIFF
--- a/main.go
+++ b/main.go
@@ -764,8 +764,9 @@ func main() {
 					Aliases: []string{"a"},
 				},
 				&cli.StringFlag{
-					Name:  "server",
-					Usage: "register against `URL`",
+					Name:   "server",
+					Hidden: true,
+					Usage:  "register against `URL`",
 				},
 			},
 			Usage:       "Connects the system to " + Provider,


### PR DESCRIPTION
* When you want to connect system against Satellite, then it is not possible to simply run on freshly installed  RHEL system:

    `rhc connect --server satellite.company.com`

  It just cannot work. Why? Using satellite server requires more changes in `rhsm.conf` (e.g. `base_url`). It requires installing CA cert and potentially something else (proxy). All required changes are typically done by kickstart script during installation of RHEL or you can use bootstrap script provided by Satellite server.
* The --server CLI option could be still used for testing against stage environment, but it is useless for our customers. For this reason it is kept as hidden option.