### PR TITLE
fix: not end with an error when retrieving the system profile

### DIFF
--- a/util.go
+++ b/util.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	ini "git.sr.ht/~spc/go-ini"
+	"git.sr.ht/~spc/go-log"
 
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sys/unix"
@@ -131,4 +132,15 @@ func GuessAPIURL() (string, error) {
 	}
 
 	return uString, nil
+}
+
+// hasPriorityErrors checks if the errorMessage map has any error
+// with a higher priority than the logLevel configure.
+func hasPriorityErrors(errorMessages map[string]LogMessage, level log.Level) bool {
+	for _, logMsg := range errorMessages {
+		if logMsg.level <= level {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This commit fixes the exit status when `rhc` fails to retrieve the system profile. When `rhc` cannot retrieve the profile it will debug this failure, but the execution will fail without any error.

`rhc` should not end with a 1 status if it is connected to `rhsm` and `insights`.

old `rhc` output:
```
rhc connect
Connecting localhost.localdomain to Red Hat.
This might take a few seconds.

● Connected to Red Hat Subscription Management
● Connected to Red Hat Insights
● Activated the Remote Host Configuration daemon

Successfully connected to Red Hat!

Manage your connected systems: https://red.ht/connector

The following errors were encountered during connect:

STEP                       ERROR  
Remote Host Configuration  Cannot get the user profile: Get "https://subscription.rhsm.stage.redhat.com/redhat_access/r/insights/platform/config-manager/v2/profiles/current": x509: certificate signed by unknown authority

echo $?
1
```

fixed `rhc` output, with log-level configured to `debug`:

```
rhc connect
Connecting localhost.localdomain to Red Hat.
This might take a few seconds.

● This system is already connected to Red Hat Subscription Management
● Connected to Red Hat Insights
● Activated the rhc daemon
Cannot configure TLS: cannot create key pair: tls: failed to find certificate PEM data in certificate input, but did find a private key; PEM inputs may have been switched
Cannot get the user profile: cannot get system profile: 401 Unauthorized

Successfully connected to Red Hat!

Manage your connected systems: https://red.ht/connector

STEP      DURATION  
rhsm      3ms       
insights  34.035s   
rhc       23ms   

echo $?
0
```