### PR TITLE
Fix/bash completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /rhc
 /rhc.1.gz
-/rhc.bash
 /USAGE.md
 rhc.spec
 BUILD

--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,6 @@ $(BIN): $(GOSRC)
 .PHONY: data
 data: $(DATA)
 
-%.bash: $(GOSRC)
-	go run $(BUILDFLAGS) -ldflags "$(LDFLAGS)" . --generate-bash-completion > $@
-
 %.1: $(GOSRC)
 	go run $(BUILDFLAGS) -ldflags "$(LDFLAGS)" . --generate-man-page > $@
 

--- a/rhc.bash
+++ b/rhc.bash
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+: ${PROG:=$(basename ${BASH_SOURCE})}
+
+_cli_bash_autocomplete() {
+  if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+    local cur opts base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    if [[ "$cur" == "-"* ]]; then
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
+    else
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+    fi
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    return 0
+  fi
+}
+
+complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete $PROG
+unset PROG


### PR DESCRIPTION
# Bash completion of rhc does not work ([RHELPLAN-140295](https://issues.redhat.com/browse/RHELPLAN-140295))
[GitHub [grunwmar](https://github.com/grunwmar) repo/branch [rhc/fix/bash-completion](https://github.com/grunwmar/rhc/tree/fix/bash-completion)]
Bugzilla link: https://bugzilla.redhat.com/show_bug.cgi?id=2145198

*I hope the text is understandable. Excuseme for quite verbose style, however as many of us are not native speakers of English I just want to be sure that all things are explained and understood well.*

## Analysis
### Urfave/cli
 - The `urfave/cli` package exports apps subcommands and options as a textual list to `stdout` defined inside instance of its `cli.App` .
 - This is done by calling app with option `--generate-bash-completion` which exports the list to `stdout`.
 - Inside `urfave/cli` package there is predefined bash script `urfave/cli/<version>/autocomplete/bash_autocomplete` which does proper autocompletion using call of the app with the mentioned `--generate-bash-completion` option, so the script can get subcommands and options to show (the autocompletion calls  the app with mentioned option everytime the `tab` key is pressed to obtain autocompletion). 
 - This script needs to be distributed to correct system directory "manually" and has to have a name of the app/command i.e. `/usr/share/bash-completion/completions/<app_name> `. The `urfave/cli` will not to do it by itself (see [documentation](https://github.com/urfave/cli/blob/main/docs/v2/examples/bash-completions.md)).  
 - Another approach is to call autocompletion script directly from `go` package `urfave/cli/<version>/autocomplete/bash_autocomplete` with correctly defined `PROG` environmental variable in shell session (described later in [Summary/Another approach](#another-approach) section).
 - Both is decribed in [documentation](https://github.com/urfave/cli/blob/main/docs/v2/examples/bash-completions.md) on **Urfave/cli**'s GitHub.
 - To make autocompletion active, there has to be installed package `bash-autocompletion` (just by `dnf install bash-completion`).

### RHC
- In the **rhc**'s makefile I have found two things which I consider as the cause of malfunction. 
- The `Makefile` creates a file `rhc.bash` containing list of subcommands/option for autocompletion by running `rhc --generate-bash-completion > rhc.bash` ([github](https://github.com/grunwmar/rhc/blob/15af69150276036c7f7dacb984995ae42abf73ea/Makefile#L89)). But it means that file `rhc.bash` is not a bash script indeed. Then this file is delivered to the destination where the autoclompletion script should be i.e. to `/usr/share/bash-completion/completions/`. And of course the corresponding file for `rhcd` command is somewhere on [Arrakis](https://en.wikipedia.org/wiki/Arrakis).
- In the nutshell, the `Makefile` makes and places to directory containing autocompletions a nonsense, but not the autocompletion script for `rhc` and `rhcd` commands.

[`rhc/main: Makefile [row 90]`](https://github.com/grunwmar/rhc/blob/15af69150276036c7f7dacb984995ae42abf73ea/Makefile#L89)
```makefile
%.bash: $(GOSRC)
go run $(BUILDFLAGS) -ldflags "$(LDFLAGS)" . --generate-bash-completion > $@
``` 
[`rhc/main: Makefile [row 128]`](https://github.com/grunwmar/rhc/blob/15af69150276036c7f7dacb984995ae42abf73ea/Makefile#L128)
```makefile
install: $(BIN) $(DATA)
	pkg-config --modversion dbus-1 || exit 1
	pkg-config --modversion systemd || exit 1
	install -D -m755 ./rhc      $(DESTDIR)$(BINDIR)/$(SHORTNAME)
	install -D -m644 ./rhc.1.gz $(DESTDIR)$(MANDIR)/man1/$(SHORTNAME).1.gz
	install -D -m644 ./rhc.bash $(DESTDIR)$(DATADIR)/bash-completion/completions/$(SHORTNAME)
```

Solution seems to be simple. Just to take file from `urfave/cli/<version>/autocomplete/bash_autocomplete` and copy it to `/usr/share/bash-completion/completions/` two-times. Once as `rhc` once as `rhcd`. Then all works nicely (if `bash-completion` are installed).


## Solution
I choose approach to just place the file
`urfave/cli/<version>/autocomplete/bash_autocomplete` to **rhc** project as `rhc.bash` and removing corresponding part of `Makefile` ([`rhc/main: Makefile [row 89]`](https://github.com/grunwmar/rhc/blob/15af69150276036c7f7dacb984995ae42abf73ea/Makefile#L89)). 


## Summary
I am not fully satisfied with this solution, mainly because the [`urfave_cli_path.sh`](https://github.com/grunwmar/rhc/blob/fix/bash-completion/urfave_cli_path.sh) script I added **has to be marked as executable**. I found, that `Urfave/cli.App`  loads information about the path to is `bash_autocomplete` to `App` object, but this variable is not exposed and I was unable to reach it from `rhc` code, although to be able to get the path direclty from `Urfave/cli.App` instance would be much much nicer way to solve the problem.

### Another approach
using 
```bash
export PROG=rhc
source urfave/cli/<version>/autocomplete/bash_autocomplete

export PROG=rhcd
source urfave/cli/<version>/autocomplete/bash_autocomplete
```
still requres the fill the correct `<verstion>` placeholder and therefore usage of something like [`urfave_cli_path.sh`](https://github.com/grunwmar/rhc/blob/fix/bash-completion/urfave_cli_path.sh), i.e. still is needed to get correct path to the `bash_autocomplete` file.

Another minor issue is, that when running `make install` the command is complaining about missing `dbus-1` package:
```
...
Package dbus-1 was not found in the pkg-config search path.
Perhaps you should add the directory containing `dbus-1.pc'
to the PKG_CONFIG_PATH environment variable
Package 'dbus-1', required by 'virtual:world', not found
make: *** [Makefile:125: install] Error 1

```
This could be easily fixed by running `dnf install dbus-devel`.


<hr>
<div style="font-size: 1.1em;  font-style: italic; color: crimson; border padding: 2.5pt 10pt;">Changes were tested on RHEL 8.6 and on RHEL 9.2</div>
