### PR TITLE
fix: http proxy configuration

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -7,20 +7,21 @@ import (
 )
 
 type Client struct {
-	client *http.Client
+	client http.Client
 }
 
-func NewHTTPClient(tlsConfig *tls.Config) (*Client, error) {
+func NewHTTPClient(tlsConfig *tls.Config) *Client {
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
+	// Create a httpClient with the configured tlsConfig.
+	// Use the DefaultTransport, as it has some configuration by default.
+	client := http.Client{
+		Transport: http.DefaultTransport.(*http.Transport).Clone(),
 	}
+	client.Transport.(*http.Transport).TLSClientConfig = tlsConfig.Clone()
 
 	return &Client{
 		client: client,
-	}, nil
+	}
 }
 
 func (c *Client) Get(url string) (*http.Response, error) {

--- a/main.go
+++ b/main.go
@@ -326,10 +326,8 @@ func connectAction(ctx *cli.Context) error {
 		if err != nil {
 			errorMessages[BrandName] = fmt.Errorf("cannot configure TLS: %w", err)
 		}
-		client, err := http.NewHTTPClient(tlsConfig)
-		if err != nil {
-			errorMessages[BrandName] = fmt.Errorf("cannot configure HTTP client: %w", err)
-		}
+		client := http.NewHTTPClient(tlsConfig)
+
 		// Get the user profile
 		profile, err := getConfProfile(client)
 		if err != nil {


### PR DESCRIPTION
HTTPClient was setting a custom transport instead of using the Default, leading to a unconfigured proxy from environment variables.

This commit modifies the default transport to use the proxy env variables.

Resolves: [RHBZ#2223405](https://bugzilla.redhat.com/show_bug.cgi?id=2223405)