### PR TITLE
fix: Fix building "rhc" using make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,8 +148,8 @@ dist:
 .PHONY: clean
 clean:
 	go mod tidy
-	rm $(BIN)
-	rm $(DATA)
+	rm -f $(BIN)
+	rm -f $(DATA)
 
 .PHONY: tests
 tests:

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,7 @@ BUILDFLAGS += -mod=vendor
 endif
 
 BIN  = rhc
-DATA = rhc.bash \
-	   rhc.1.gz \
+DATA = rhc.1.gz \
 	   USAGE.md
 
 GOSRC := $(shell find . -name '*.go')


### PR DESCRIPTION
* It is possible to build rhc using `make`
* It is also possible to clean repository using `make clean`, when some generated file has been already deleted.