### PR TITLE
fix: Update testing matrix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.16", "1.18", "1.19"]
+        go: ["1.18", "1.19", "1.20"]
     steps:
       - name: Updating ...
         run: sudo apt-get -qq update


### PR DESCRIPTION
* Drop Go 1.16 from testing matrix
* Added Go 1.20 to the same matrix
* Note: The RHEL7.9 uses Go 1.19 and the latest Fedora uses 1.20