### PR TITLE
fix: Fix issues of bash auto-complete script

### DIFF
--- a/rhc.bash
+++ b/rhc.bash
@@ -1,21 +1,22 @@
 #! /bin/bash
 
-: ${PROG:=$(basename ${BASH_SOURCE})}
+: "${PROG:=$(basename "${BASH_SOURCE[0]}")}"
 
 _cli_bash_autocomplete() {
   if [[ "${COMP_WORDS[0]}" != "source" ]]; then
-    local cur opts base
+    local cur opts
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     if [[ "$cur" == "-"* ]]; then
-      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
+      opts=$( "${COMP_WORDS[@]:0:$COMP_CWORD}" "${cur}" --generate-bash-completion )
     else
-      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+      opts=$( "${COMP_WORDS[@]:0:$COMP_CWORD}" --generate-bash-completion )
     fi
-    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    # Redirect output of command to array variable COMPREPLY
+    mapfile -t COMPREPLY < <(compgen -W "${opts}" -- "${cur}")
     return 0
   fi
 }
 
-complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete $PROG
+complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete "${PROG}"
 unset PROG


### PR DESCRIPTION
* Card ID: RHELPLAN-164718
* Checking of issues using shell script analysis tool shellcheck should be without any issue now.
* Note: current version of bash auto-complete script provided by urfave package looks little bit different, but it is not compatible with rhc for some reason.