### PR TITLE
fix: insights connection status

### DIFF
--- a/main.go
+++ b/main.go
@@ -602,7 +602,7 @@ func statusAction(ctx *cli.Context) (err error) {
 	} else {
 		if err == nil {
 			if machineReadable {
-				systemStatus.InsightsConnected = true
+				systemStatus.InsightsConnected = false
 			} else {
 				fmt.Print(disconnectedPrefix + " Not connected to Red Hat Insights\n")
 			}


### PR DESCRIPTION
This commits fixes the insights-connection status when it is not connected.
Now it shows false when printing in the json format.