### PR TITLE
Refactoring of status command and rhcd service

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -8,7 +8,7 @@ SRCRPMDIR := $(shell rpmbuild -E %_srcrpmdir)
 
 srpm: SHORTNAME = $(shell basename $(PWD))
 srpm: LONGNAME = $(SHORTNAME)
-srpm: BRANDNAME = $(SHORTNAME)
+srpm: SERVICENAME = "yggdrasil"
 srpm: VERSION := $(shell echo $(VERSION) | awk -F. '{printf("%d.%d.%d", $$1, $$2, $$3+1)}')
 srpm: RELEASE = $(shell printf "0.%s.git.%s" $(shell git rev-list $(shell git describe --tags --abbrev=0 --always | tr -d '\n')..HEAD --count | tr -d '\n') $(shell git rev-parse --short HEAD | tr -d '\n'))
 srpm: PKGNAME = $(SHORTNAME)
@@ -21,7 +21,6 @@ srpm: deps
 	sed \
 	    -e 's,[@]SHORTNAME[@],$(SHORTNAME),g' \
 		-e 's,[@]LONGNAME[@],$(LONGNAME),g' \
-		-e 's,[@]BRANDNAME[@],$(BRANDNAME),g' \
 		-e 's,[@]VERSION[@],$(VERSION),g' \
 		-e 's,[@]RELEASE[@],$(RELEASE),g' \
 		-e 's,[@]PKGNAME[@],$(PKGNAME),g' \
@@ -37,6 +36,7 @@ srpm: deps
 		-e 's,[@]SYSCONFDIR[@],$(SYSCONFDIR),g' \
 		-e 's,[@]LOCALSTATEDIR[@],$(LOCALSTATEDIR),g' \
 		-e 's,[@]DOCDIR[@],$(DOCDIR),g' \
+		-e 's,[@]SERVICENAME[@],$(SERVICENAME),g' \
 		$(spec)/.copr/rhc.spec.in > $(spec)/rhc.spec
 	make PKGNAME=$(PKGNAME) VERSION=$(VERSION)-$(RELEASE) dist
 	install -D -m644 $(PKGNAME)-$(VERSION)-$(RELEASE).tar.gz $(SOURCEDIR)

--- a/.copr/rhc.spec.in
+++ b/.copr/rhc.spec.in
@@ -48,10 +48,10 @@ make PREFIX=%{_prefix} \
      SHORTNAME=@SHORTNAME@ \
      LONGNAME=@LONGNAME@ \
      PKGNAME=@PKGNAME@ \
-     BRANDNAME=@BRANDNAME@ \
      TOPICPREFIX=@TOPICPREFIX@ \
      VERSION=%{version} \
      DATAHOST=@DATAHOST@ \
+     SERVICENAME=@SERVICENAME@ \
      'PROVIDER=@PROVIDER@'
 
 cd %{_builddir}/%{name}/yggdrasil-worker-package-manager
@@ -64,10 +64,10 @@ make PREFIX=%{_prefix} \
      SHORTNAME=@SHORTNAME@ \
      LONGNAME=@LONGNAME@ \
      PKGNAME=@PKGNAME@ \
-     BRANDNAME=@BRANDNAME@ \
      TOPICPREFIX=@TOPICPREFIX@ \
      VERSION=%{version} \
      DATAHOST=@DATAHOST@ \
+     SERVICENAME=@SERVICENAME@ \
      'PROVIDER=@PROVIDER@'
 
 
@@ -80,10 +80,10 @@ make PREFIX=%{_prefix} \
      SHORTNAME=@SHORTNAME@ \
      LONGNAME=@LONGNAME@ \
      PKGNAME=@PKGNAME@ \
-     BRANDNAME=@BRANDNAME@ \
      TOPICPREFIX=@TOPICPREFIX@ \
      VERSION=%{version} \
      DATAHOST=@DATAHOST@ \
+     SERVICENAME=@SERVICENAME@ \
      'PROVIDER=@PROVIDER@' \
      install
 
@@ -99,10 +99,10 @@ make PREFIX=%{_prefix} \
      SHORTNAME=@SHORTNAME@ \
      LONGNAME=@LONGNAME@ \
      PKGNAME=@PKGNAME@ \
-     BRANDNAME=@BRANDNAME@ \
      TOPICPREFIX=@TOPICPREFIX@ \
      VERSION=%{version} \
      DATAHOST=@DATAHOST@ \
+     SERVICENAME=@SERVICENAME@ \
      'PROVIDER=@PROVIDER@' \
      install
 

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ MAKEFLAGS += --no-builtin-rules
 SHORTNAME := rhc
 # Used as file and directory names. Cannot contain spaces.
 LONGNAME  := rhc
-# Used as a long-form description. Can contain spaces and punctuation.
-BRANDNAME   := rhc
 # Used as the tarball file name. Cannot contain spaces.
 PKGNAME   := rhc
 VERSION   := 0.2.4
+# Used for service name of yggdrasil service (rhcd service). Cannot contain spaces
+SERVICENAME := yggdrasil
 # Used as the prefix for MQTT topic names
 TOPICPREFIX := redhat/insights
 # Used to force sending all HTTP traffic to a specific host.
@@ -46,7 +46,6 @@ LDFLAGS :=
 LDFLAGS += -X 'main.Version=$(VERSION)'
 LDFLAGS += -X 'main.ShortName=$(SHORTNAME)'
 LDFLAGS += -X 'main.LongName=$(LONGNAME)'
-LDFLAGS += -X 'main.BrandName=$(BRANDNAME)'
 LDFLAGS += -X 'main.PrefixDir=$(PREFIX)'
 LDFLAGS += -X 'main.BinDir=$(BINDIR)'
 LDFLAGS += -X 'main.SbinDir=$(SBINDIR)'
@@ -59,6 +58,7 @@ LDFLAGS += -X 'main.DocDir=$(DOCDIR)'
 LDFLAGS += -X 'main.LocalstateDir=$(LOCALSTATEDIR)'
 LDFLAGS += -X 'main.TopicPrefix=$(TOPICPREFIX)'
 LDFLAGS += -X 'main.Provider=$(PROVIDER)'
+LDFLAGS += -X 'main.ServiceName=$(SERVICENAME)'
 
 BUILDFLAGS ?=
 BUILDFLAGS += -buildmode=pie
@@ -98,7 +98,6 @@ USAGE.md: $(GOSRC)
 	sed \
 	    -e 's,[@]SHORTNAME[@],$(SHORTNAME),g' \
 		-e 's,[@]LONGNAME[@],$(LONGNAME),g' \
-		-e 's,[@]BRANDNAME[@],$(BRANDNAME),g' \
 		-e 's,[@]VERSION[@],$(VERSION),g' \
 		-e 's,[@]PACKAGE[@],$(PACKAGE),g' \
 		-e 's,[@]TOPICPREFIX[@],$(TOPICPREFIX),g' \
@@ -113,6 +112,7 @@ USAGE.md: $(GOSRC)
 		-e 's,[@]SYSCONFDIR[@],$(SYSCONFDIR),g' \
 		-e 's,[@]LOCALSTATEDIR[@],$(LOCALSTATEDIR),g' \
 		-e 's,[@]DOCDIR[@],$(DOCDIR),g' \
+		-e 's,[@]SERVICENAME[@],$(SERVICENAME),g' \
 		$< > $@.tmp && mv $@.tmp $@
 
 .PHONY: install

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ It currently performs 3 steps when it connects a system:
    already registered, this step is a noop and it moves to the next step.
 2. Registers the system with Red Hat Insights. If the system is already
    registered, this step is a noop and it moves to the next step.
-3. Activate the `rhcd` daemon.
+3. Activate the `yggdrasil` (or branded `rhcd`) service.
 
 Likewise, when `rhc` is disconnecting a system, it performs the steps in
 descending order.
 
-1. Deactivates the `rhcd` daemon.
+1. Deactivates the `yggdrasil` (or branded `rhcd`) service.
 2. Unregisters the system from Red Hat Insights.
 3. Unregisters the system from Red Hat Subscription Management.
 
@@ -22,7 +22,7 @@ descending order.
 [`yggdrasil`](https://github.com/RedHatInsights/yggdrasil). `rhc` began
 as a program within the `yggdrasil` project, but has since been forked out.
 `rhc` still has a soft dependency on `yggdrasil`; `yggdrasil` provides `rhcd`
-(or `yggd`), the daemon that `rhc` activates as the last step in its connection
+(or `yggd`), the service that `rhc` activates as the last step in its connection
 process.
 
 ## Non-goals

--- a/activate.go
+++ b/activate.go
@@ -7,16 +7,17 @@ import (
 	systemd "github.com/coreos/go-systemd/v22/dbus"
 )
 
-func activate() error {
-	// Use simple background context without anything extra
-	ctx := context.Background()
+// activateService tries to enable and start yggdrasil service.
+// The service can be branded to rhcd on RHEL
+func activateService() error {
+    ctx := context.Background()
 	conn, err := systemd.NewSystemConnectionContext(ctx)
 	if err != nil {
 		return err
 	}
 	defer conn.Close()
 
-	unitName := ShortName + "d.service"
+	unitName := ServiceName + ".service"
 
 	if _, _, err := conn.EnableUnitFilesContext(ctx, []string{unitName}, false, true); err != nil {
 		return err
@@ -39,8 +40,10 @@ func activate() error {
 	return nil
 }
 
-func deactivate() error {
-	// Use simple background context without anything extra
+// deactivateService tries to stop and disable yggdrasil service.
+// The service can be branded to rhcd on RHEL
+func deactivateService() error {
+		// Use simple background context without anything extra
 	ctx := context.Background()
 	conn, err := systemd.NewSystemConnectionContext(ctx)
 	if err != nil {
@@ -48,7 +51,7 @@ func deactivate() error {
 	}
 	defer conn.Close()
 
-	unitName := ShortName + "d.service"
+	unitName := ServiceName + ".service"
 
 	done := make(chan string)
 	if _, err := conn.StopUnitContext(ctx, unitName, "replace", done); err != nil {

--- a/constants.go
+++ b/constants.go
@@ -12,15 +12,16 @@ var (
 	// LongName is used in file and directory names.
 	LongName string
 
-	// BrandName is a long-form description.
-	BrandName string
-
 	// TopicPrefix is used as a prefix to all MQTT topics in the client.
 	TopicPrefix string
 
 	// Provider is used when constructing user-facing string output to identify
 	// the agency providing the connection broker.
 	Provider string
+
+	// ServiceName us used for manipulating of yggdrasil service
+	// It can be branded to rhcd on RHEL
+	ServiceName string
 )
 
 // Installation directory prefix and paths. Values are specified by compile-time
@@ -81,13 +82,13 @@ func init() {
 	if LongName == "" {
 		LongName = "rhc"
 	}
-	if BrandName == "" {
-		BrandName = "rhc"
-	}
 	if TopicPrefix == "" {
 		TopicPrefix = "rhc"
 	}
 	if Provider == "" {
 		Provider = "Red Hat"
+	}
+	if ServiceName == "" {
+		ServiceName = "yggdrasil"
 	}
 }

--- a/status.go
+++ b/status.go
@@ -75,30 +75,30 @@ func serviceStatus(systemStatus *SystemStatus, uiPreferences *UserInterfacePrefe
 	ctx := context.Background()
 	conn, err := systemd.NewSystemConnectionContext(ctx)
 	if err != nil {
-		systemStatus.RHCDRunning = false
-		systemStatus.RHCDError = err
+		systemStatus.YggdrasilRunning = false
+		systemStatus.YggdrasilError = err
 		return fmt.Errorf("unable to connect to systemd: %s", err)
 	}
 	defer conn.Close()
-	unitName := ShortName + "d.service"
+	unitName := ServiceName + ".service"
 	properties, err := conn.GetUnitPropertiesContext(ctx, unitName)
 	if err != nil {
-		systemStatus.RHCDRunning = false
-		systemStatus.RHCDError = err
+		systemStatus.YggdrasilRunning = false
+		systemStatus.YggdrasilError = err
 		return fmt.Errorf("unable to get properties of %s: %s", unitName, err)
 	}
 	activeState := properties["ActiveState"]
 	if activeState.(string) == "active" {
 		if uiPreferences.MachineReadable {
-			systemStatus.RHCDRunning = true
+			systemStatus.YggdrasilRunning = true
 		} else {
-			fmt.Printf(uiPreferences.ConnectedPrefix+" The %v daemon is active\n", BrandName)
+			fmt.Printf(uiPreferences.ConnectedPrefix+" The %v service is active\n", ServiceName)
 		}
 	} else {
 		if uiPreferences.MachineReadable {
-			systemStatus.RHCDRunning = false
+			systemStatus.YggdrasilRunning = false
 		} else {
-			fmt.Printf(uiPreferences.DisconnectedPrefix+" The %v daemon is inactive\n", BrandName)
+			fmt.Printf(uiPreferences.DisconnectedPrefix+" The %v service is inactive\n", ServiceName)
 		}
 	}
 	return nil

--- a/status.go
+++ b/status.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/briandowns/spinner"
+	systemd "github.com/coreos/go-systemd/v22/dbus"
+)
+
+// rhsmStatus tries to print status provided by RHSM D-Bus API. If we provide
+// output in machine-readable format, then we only set files in SystemStatus
+// structure and content of this structure will be printed later
+func rhsmStatus(systemStatus *SystemStatus, uiPreferences *UserInterfacePreferences) error {
+
+	uuid, err := getConsumerUUID()
+	if err != nil {
+		return fmt.Errorf("unable to get consumer UUID: %s", err)
+	}
+	if uuid == "" {
+		if uiPreferences.MachineReadable {
+			systemStatus.RHSMConnected = false
+		} else {
+			fmt.Printf(uiPreferences.DisconnectedPrefix + " Not connected to Red Hat Subscription Management\n")
+		}
+	} else {
+		if uiPreferences.MachineReadable {
+			systemStatus.RHSMConnected = true
+		} else {
+			fmt.Printf(uiPreferences.ConnectedPrefix + " Connected to Red Hat Subscription Management\n")
+		}
+	}
+	return nil
+}
+
+// insightStatus tries to print status of insights client
+func insightStatus(systemStatus *SystemStatus, uiPreferences *UserInterfacePreferences) {
+	var s *spinner.Spinner
+	if uiPreferences.IsColorful {
+		s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+		s.Suffix = " Checking Red Hat Insights..."
+		s.Start()
+	}
+	isRegistered, err := insightsIsRegistered()
+	if uiPreferences.IsColorful {
+		s.Stop()
+	}
+	if isRegistered {
+		if uiPreferences.MachineReadable {
+			systemStatus.InsightsConnected = true
+		} else {
+			fmt.Print(uiPreferences.ConnectedPrefix + " Connected to Red Hat Insights\n")
+		}
+	} else {
+		if err == nil {
+			if uiPreferences.MachineReadable {
+				systemStatus.InsightsConnected = false
+			} else {
+				fmt.Print(uiPreferences.DisconnectedPrefix + " Not connected to Red Hat Insights\n")
+			}
+		} else {
+			if uiPreferences.MachineReadable {
+				systemStatus.InsightsConnected = false
+				systemStatus.InsightsError = err
+			} else {
+				fmt.Printf(uiPreferences.ErrorPrefix+" Cannot execute insights-client: %v\n", err)
+			}
+		}
+	}
+}
+
+// serviceStatus tries to print status of yggdrasil.service or rhcd.service
+func serviceStatus(systemStatus *SystemStatus, uiPreferences *UserInterfacePreferences) error {
+	ctx := context.Background()
+	conn, err := systemd.NewSystemConnectionContext(ctx)
+	if err != nil {
+		systemStatus.RHCDRunning = false
+		systemStatus.RHCDError = err
+		return fmt.Errorf("unable to connect to systemd: %s", err)
+	}
+	defer conn.Close()
+	unitName := ShortName + "d.service"
+	properties, err := conn.GetUnitPropertiesContext(ctx, unitName)
+	if err != nil {
+		systemStatus.RHCDRunning = false
+		systemStatus.RHCDError = err
+		return fmt.Errorf("unable to get properties of %s: %s", unitName, err)
+	}
+	activeState := properties["ActiveState"]
+	if activeState.(string) == "active" {
+		if uiPreferences.MachineReadable {
+			systemStatus.RHCDRunning = true
+		} else {
+			fmt.Printf(uiPreferences.ConnectedPrefix+" The %v daemon is active\n", BrandName)
+		}
+	} else {
+		if uiPreferences.MachineReadable {
+			systemStatus.RHCDRunning = false
+		} else {
+			fmt.Printf(uiPreferences.DisconnectedPrefix+" The %v daemon is inactive\n", BrandName)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Code cleanup before fixing RHEL-2490

### Refactoring of status action
* Split `statusAction` to several logical functions and moved
  these functions to new new file `status.go`
* Refactored getting user interface preferences


### Refactoring of service management
* Previous management was confusing
  * Upstream name of the service is `yggdrasil`, but upstream
    version of `rhc` used default branded name `rhcd` from downstream
    for this service. Thus, it was not possible to use
    upstream version of `rhc` for activating/deactivating
    of upstream version of `yggdrasil`.
  * Brand name was not brand name of `rhc`, but it was used
    for branding of service name.
  * The service name was assembled from short name of `rhc`.
    `rhc + "d.service"`. Thus, it actually was not possible to
    brand the service.
* Removed `BrandName` and introduced `ServiceName` and `SERVICENAME`
  constants. `SERVICENAME` can be configured in Makefile
  * Modified spec files according this change
* Replaced all occurrence of keyword daemon with keyword service,
  because "service" is more accurate keyword and it could
  not scare people ;-)
* Changed output of `rhc status --format json` a little bit.
  Renamed "rhcd_running" to "yggdrasil_running" and
  "rhcd_error" to "yggdrasil_error".
* Refactored code a little bit