### PR TITLE
build: update go version

### DIFF
--- a/.copr/rhc.spec.in
+++ b/.copr/rhc.spec.in
@@ -26,6 +26,7 @@ BuildRequires: git
 BuildRequires: golang
 BuildRequires: dbus-devel
 BuildRequires: systemd-devel
+BuildRequires: systemd
 
 
 %description

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhatinsights/rhc
 
-go 1.16
+go 1.18
 
 require (
 	git.sr.ht/~spc/go-ini v0.0.0-20210406163956-61abbbf0b164
@@ -13,4 +13,15 @@ require (
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/sys v0.1.0
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
+)
+
+require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
+	github.com/fatih/color v1.7.0 // indirect
+	github.com/mattn/go-colorable v0.1.2 // indirect
+	github.com/mattn/go-isatty v0.0.8 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	gopkg.in/yaml.v2 v2.2.3 // indirect
 )


### PR DESCRIPTION
This commit:

- Updates go version to 1.18
- Add systemd as a BuildRequirement

This is meant to fix current COPR builds.
Resolves: CCT-61