### PR TITLE
fix: Set locale in all D-Bus RHSM calls according LANG env. var.

### DIFF
--- a/util.go
+++ b/util.go
@@ -144,3 +144,12 @@ func hasPriorityErrors(errorMessages map[string]LogMessage, level log.Level) boo
 	}
 	return false
 }
+
+// getLocale tries to get current locale
+func getLocale() string {
+	// FIXME: Locale should be detected in more reliable way. We are going to support
+	//        localization in better way. Maybe we could use following go module
+	//        https://github.com/Xuanwo/go-locale. Maybe some other will be better.
+	locale := os.Getenv("LANG")
+	return locale
+}


### PR DESCRIPTION
* It is important to call all RHSM D-Bus methods with some locale string, because candlepin server generates some error string, and candlepin server has localized these error messages. Thus, candlepin server needs to know locale string to generate error messages properly.
* All methods were called with locale hardcoded to "". It means that error messages could not be localized according users' preferences.
* Locale string is get from environment variable $LANG.