### PR TITLE
fix: Do not trigger build go actions twice on PR

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,8 +1,8 @@
 name: Go
 
 on:
-  push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 name: Lint
 
-on: pull_request
+on:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   lint-commits:


### PR DESCRIPTION
* When PR was created or updated, then all jobs releated to Go were triggered twice. Not useful and wasting of time and resources
* Added workflow_dispatch to be able to trigger workflows manually