### PR TITLE
fix: rhc crashed, when insights-client.conf was empty

### DIFF
--- a/util.go
+++ b/util.go
@@ -70,8 +70,8 @@ func ConfigPath() (string, error) {
 	return filePath, nil
 }
 
-// Get the API server URL based on, insights-client.conf and rhsm.conf
-// This URL may differ from prod, stage and Satellite
+// GuessAPIURL gets the API server URL based on, insights-client.conf
+// and rhsm.conf. This URL may differ from prod, stage and Satellite
 func GuessAPIURL() (string, error) {
 	var uString string
 	var baseURL *url.URL
@@ -87,11 +87,16 @@ func GuessAPIURL() (string, error) {
 	type InsightsConf struct {
 		InsightsClient InsightsClientConf `ini:"insights-client"`
 	}
+
 	var cfg InsightsConf
 	// Read the config file
-	data, err := os.ReadFile("/etc/insights-client/insights-client.conf")
+	confFilePath := "/etc/insights-client/insights-client.conf"
+	data, err := os.ReadFile(confFilePath)
 	if err != nil {
-		return "", fmt.Errorf("fail to read file: %v", err)
+		return "", fmt.Errorf("fail to read file %v: %v", confFilePath, err)
+	}
+	if len(data) == 0 {
+		return "", fmt.Errorf("configuratio file %v is empty", confFilePath)
 	}
 	// Get the config into the struct
 	if err := ini.UnmarshalWithOptions(data, &cfg, opts); err != nil {


### PR DESCRIPTION
* Card ID: CCT-218
* Resolves #78
* When /etc/insights-client/insights-client.conf was empty, then rhc crashed during "rhc connect"
* Error message is printed now