### PR TITLE
fix: Add subscription-manager as required RPM package

### DIFF
--- a/.copr/rhc.spec.in
+++ b/.copr/rhc.spec.in
@@ -20,6 +20,7 @@ ExclusiveArch: %{go_arches}
 
 Requires:      insights-client
 Requires:      yggdrasil-worker-package-manager
+Requires:      subscription-manager
 
 BuildRequires: golang
 BuildRequires: dbus-devel


### PR DESCRIPTION
* Card ID: CCT-162
* The subscription-manager should be required RPM package, because rhc needs rhsm.service for all commands (connect, disconnect, status), and rhsm.service is part of subscription-manager RPM package