### PR TITLE
refactor: update go-log path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/redhatinsights/rhc
 go 1.18
 
 require (
-	git.sr.ht/~spc/go-log v0.1.1
 	github.com/briandowns/spinner v1.23.0
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.5.0
 	github.com/subpop/go-ini v0.1.5
+	github.com/subpop/go-log v0.1.2
 	github.com/urfave/cli/v2 v2.27.1
 	golang.org/x/sys v0.16.0
 	golang.org/x/term v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-git.sr.ht/~spc/go-log v0.1.1 h1:pdfV6Q1pNcGVT77DAWzc6LxJyi83PRu1ioZo98ZobAU=
-git.sr.ht/~spc/go-log v0.1.1/go.mod h1:Albq15b/jXGrQ659oyB8X1wX8quqpU+LxXFw7YmEuTg=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/briandowns/spinner v1.23.0 h1:alDF2guRWqa/FOZZYWjlMIx2L6H0wyewPxo/CH4Pt2A=
@@ -25,6 +23,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/subpop/go-ini v0.1.5 h1:08hu8slz5c4KBXJWYOycyuDQ0E7xHr2vV2rH9x79FrY=
 github.com/subpop/go-ini v0.1.5/go.mod h1:mM5HCw/1+q92kIf4Btd7Oorioa8rAXb4NSBT2ldZNiU=
+github.com/subpop/go-log v0.1.2 h1:NgbZR6frmeDtC+96d+UxOkt4X/JxO626fokwL56Dff0=
+github.com/subpop/go-log v0.1.2/go.mod h1:uAEovif98swmWm/8qYGrzGFahUIRQ/KwlBUpJuoOdds=
 github.com/urfave/cli/v2 v2.27.1 h1:8xSQ6szndafKVRmfyeUMxkNUJQMjL1F2zmsZ+qHpfho=
 github.com/urfave/cli/v2 v2.27.1/go.mod h1:8qnjx1vcq5s2/wpsqoZFndg2CE5tNFyrTvS6SinrnYQ=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"git.sr.ht/~spc/go-log"
+	"github.com/subpop/go-log"
 	"golang.org/x/term"
 
 	"github.com/briandowns/spinner"

--- a/util.go
+++ b/util.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"git.sr.ht/~spc/go-log"
 	"github.com/subpop/go-ini"
+	"github.com/subpop/go-log"
 
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sys/unix"


### PR DESCRIPTION
Update to github.com/subpop/go-log.

This change was motivate because of SourceHut service and its stability. We also change the go-ini to github https://github.com/RedHatInsights/rhc/pull/81