### PR TITLE
fix: Detect insights-client status in non-legacy mode

### DIFF
--- a/status.go
+++ b/status.go
@@ -66,7 +66,7 @@ func insightStatus(systemStatus *SystemStatus) {
 				systemStatus.InsightsConnected = false
 				systemStatus.InsightsError = err.Error()
 			} else {
-				fmt.Printf(uiSettings.iconError+" Cannot execute insights-client: %v\n", err)
+				fmt.Printf(uiSettings.iconError+" Cannot detect Red Hat Insights status: %v\n", err)
 			}
 		}
 	}


### PR DESCRIPTION
* Card ID: CCT-525

With `legacy_upload=True` mode, `insights-client --status` returns code
0 if the system is registered and 1 otherwise. In non-legacy mode, 0 is
always returned.

Even though the `/etc/insights-client/.registered` file is not a public
API, it is reliable and we should be able to use it to detect the
registration status.