### PR TITLE
fix: Return non-zero code, when some sub-status is wrong

### DIFF
--- a/main.go
+++ b/main.go
@@ -504,6 +504,7 @@ type SystemStatus struct {
 	InsightsError     string `json:"insights_error,omitempty"`
 	YggdrasilRunning  bool   `json:"yggdrasil_running"`
 	YggdrasilError    string `json:"yggdrasil_error,omitempty"`
+	returnCode        int
 }
 
 // printJSONStatus tries to print the system status as JSON to stdout.
@@ -571,6 +572,10 @@ func statusAction(ctx *cli.Context) (err error) {
 					fmt.Errorf("unable to print status as %s document: %s", format, err.Error()),
 					1)
 			}
+			// When any of status is not correct, then return 1 exit code
+			if systemStatus.returnCode != 0 {
+				err = cli.Exit("", 1)
+			}
 		}(&systemStatus)
 	}
 
@@ -606,6 +611,12 @@ func statusAction(ctx *cli.Context) (err error) {
 
 	if !uiSettings.isMachineReadable {
 		fmt.Printf("\nManage your connected systems: https://red.ht/connector\n")
+	}
+
+	// At the end check if all statuses are correct.
+	// If not, return 1 exit code without any message.
+	if systemStatus.returnCode != 0 {
+		return cli.Exit("", 1)
 	}
 
 	return nil

--- a/status.go
+++ b/status.go
@@ -19,6 +19,7 @@ func rhsmStatus(systemStatus *SystemStatus) error {
 		return fmt.Errorf("unable to get consumer UUID: %s", err)
 	}
 	if uuid == "" {
+		systemStatus.returnCode += 1
 		if uiSettings.isMachineReadable {
 			systemStatus.RHSMConnected = false
 		} else {
@@ -53,6 +54,7 @@ func insightStatus(systemStatus *SystemStatus) {
 			fmt.Print(uiSettings.iconOK + " Connected to Red Hat Insights\n")
 		}
 	} else {
+		systemStatus.returnCode += 1
 		if err == nil {
 			if uiSettings.isMachineReadable {
 				systemStatus.InsightsConnected = false
@@ -95,6 +97,7 @@ func serviceStatus(systemStatus *SystemStatus) error {
 			fmt.Printf(uiSettings.iconOK+" The %v service is active\n", ServiceName)
 		}
 	} else {
+		systemStatus.returnCode += 1
 		if uiSettings.isMachineReadable {
 			systemStatus.YggdrasilRunning = false
 		} else {


### PR DESCRIPTION
* When some sub-status is not correct (system is not registered, insights-client is not registered or yggdrasil is not running), then return non-zero status code
* This change follow behavior of subscription-manager and it could help automation