### PR TITLE
packit: tag cloud resources in Testing Farm

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -103,4 +103,8 @@ jobs:
         - artifacts:
             - type: repository-file
               id: https://copr.fedorainfracloud.org/coprs/g/yggdrasil/latest/repo/rhel-$releasever/group_yggdrasil-latest-rhel-$releasever.repo
+          settings:
+            provisioning:
+              tags:
+                BusinessUnit: sst_csi_client_tools
     use_internal_tf: true


### PR DESCRIPTION
This way we can track the cloud costs for the team and also provide more detailed team specific metrics.