### PR TITLE
feat: Saving test report as junit file

### DIFF
--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-set -eu
-set -x
+set -ux
 
 # get to project root
 cd ../../../
@@ -18,4 +17,11 @@ python3 -m venv venv
 
 pip install -r integration-tests/requirements.txt
 
-pytest -v integration-tests
+pytest --junit-xml=./junit.xml -v integration-tests
+retval=$?
+
+if [ -d "$TMT_PLAN_DATA" ]; then
+  cp ./junit.xml "$TMT_PLAN_DATA/junit.xml"
+fi
+
+exit $retval


### PR DESCRIPTION
Saving the test report as a junit file.  This will also fix failing rhc jenkins tests since they're now expecting a junit.xml