### PR TITLE
feat: write canonical-facts file for yggd

### DIFF
--- a/80-rhc.preset
+++ b/80-rhc.preset
@@ -1,0 +1,1 @@
+enable rhc-canonical-facts.timer

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ DESTDIR       ?=
 
 # Dependent package directories
 SYSTEMD_SYSTEM_UNIT_DIR  := $(shell pkg-config --variable systemdsystemunitdir systemd)
+SYSTEMD_SYSTEM_PRESET_DIR := $(shell pkg-config --variable systemdsystempresetdir systemd)
 
 # Build flags
 LDFLAGS := 
@@ -122,6 +123,9 @@ install: $(BIN) $(DATA)
 	install -D -m755 ./rhc      $(DESTDIR)$(BINDIR)/$(SHORTNAME)
 	install -D -m644 ./rhc.1.gz $(DESTDIR)$(MANDIR)/man1/$(SHORTNAME).1.gz
 	install -D -m644 ./rhc.bash $(DESTDIR)$(DATADIR)/bash-completion/completions/$(SHORTNAME)
+	install -D -m644 ./rhc-canonical-facts.service $(DESTDIR)$(SYSTEMD_SYSTEM_UNIT_DIR)/rhc-canonical-facts.service
+	install -D -m644 ./rhc-canonical-facts.timer $(DESTDIR)$(SYSTEMD_SYSTEM_UNIT_DIR)/rhc-canonical-facts.timer
+	install -D -m644 ./80-rhc.preset $(DESTDIR)$(SYSTEMD_SYSTEM_PRESET_DIR)/80-rhc.preset
 
 .PHONY: uninstall
 uninstall:

--- a/rhc-canonical-facts.service
+++ b/rhc-canonical-facts.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=rhc canonical-facts service
+Documentation=https://github.com/RedHatInsights/rhc
+
+[Service]
+Type=oneshot
+User=root
+Group=yggdrasil-worker
+ExecStart=rhc canonical-facts
+StandardOutput=truncate:/var/lib/yggdrasil/canonical-facts.json
+StandardError=journal
+UMask=0027

--- a/rhc-canonical-facts.timer
+++ b/rhc-canonical-facts.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=yggdrasil canonical-facts service timer
+Documentation=https://github.com/RedHatInsights/yggdrasil
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/rhc.spec.in
+++ b/rhc.spec.in
@@ -69,11 +69,29 @@ make PREFIX=%{_prefix} \
      'PROVIDER=@PROVIDER@' \
      install
 
+%post
+%systemd_post rhc-canonical-facts.timer
+if [ $1 -eq 1 ]; then
+     systemctl daemon-reload
+     systemctl start rhc-canonical-facts.timer
+fi
+
+%preun
+%systemd_preun rhc-canonical-facts.timer
+
+%postun
+%systemd_postun_with_restart rhc-canonical-facts.timer
+if [ $1 -eq 0 ]; then
+     systemctl daemon-reload
+fi
+
 %files
 %doc %{name}-%{version}/README.md
 %{_bindir}/@SHORTNAME@
 %{_datadir}/bash-completion/completions/*
 %{_mandir}/man1/*
+%{_unitdir}/*
+%{_presetdir}/*
 
 
 %changelog


### PR DESCRIPTION
In order to correctly identify a yggd instance to console.redhat.com,
yggd needs to be told where to get canonical-facts. This timer writes
the output of canonical-facts to a path where yggd can be configured to
read it when it starts up.

Card ID: CCT-291