### PR TITLE
ci: build & test also on centos-stream-10

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -49,21 +49,9 @@ jobs:
 
   - job: tests
     trigger: pull_request
-    identifier: "unit/centos-stream-8"
+    identifier: "unit/centos-stream"
     targets:
       - centos-stream-8
-    labels:
-      - unit
-    tf_extra_params:
-      environments:
-        - artifacts:
-            - type: repository-file
-              id: https://copr.fedorainfracloud.org/coprs/g/yggdrasil/latest/repo/centos-stream-8/group_yggdrasil-latest-centos-stream-8.repo
-
-  - job: tests
-    trigger: pull_request
-    identifier: "unit/centos-stream-9"
-    targets:
       - centos-stream-9
     labels:
       - unit
@@ -71,7 +59,7 @@ jobs:
       environments:
         - artifacts:
             - type: repository-file
-              id: https://copr.fedorainfracloud.org/coprs/g/yggdrasil/latest/repo/centos-stream-9/group_yggdrasil-latest-centos-stream-9.repo
+              id: https://copr.fedorainfracloud.org/coprs/g/yggdrasil/latest/repo/centos-stream-$releasever/group_yggdrasil-latest-centos-stream-$releasever.repo
 
   - job: tests
     trigger: pull_request

--- a/.packit.yml
+++ b/.packit.yml
@@ -29,6 +29,7 @@ jobs:
     targets:
       - centos-stream-8
       - centos-stream-9
+      - centos-stream-10
       - fedora-all
       - rhel-8
       - rhel-9
@@ -43,6 +44,7 @@ jobs:
     targets:
       - centos-stream-8
       - centos-stream-9
+      - centos-stream-10
       - fedora-all
       - rhel-8
       - rhel-9
@@ -53,6 +55,7 @@ jobs:
     targets:
       - centos-stream-8
       - centos-stream-9
+      - centos-stream-10
     labels:
       - unit
     tf_extra_params:


### PR DESCRIPTION
Factorize the existing tests blocks for centos-stream first, so adding the new version is easier.