### PR TITLE
fix: Machine readable output corrupted, when registration fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -322,7 +322,7 @@ func connectAction(ctx *cli.Context) error {
 	/* 2. Register insights-client */
 	if errors, exist := errorMessages["rhsm"]; exist {
 		if errors.level == log.LevelError {
-			fmt.Printf(
+			interactivePrintf(
 				"%v Skipping connection to Red Hat Insights\n",
 				uiSettings.iconError,
 			)


### PR DESCRIPTION
* When RHSM registration failed, then machine output was corrupted, because we printed information about skipping registration using insights-client to stdout