### PR TITLE
feat: Correctly start rhc-canonical-facts.timer and service

### DIFF
--- a/data/systemd/80-rhc.preset
+++ b/data/systemd/80-rhc.preset
@@ -1,1 +1,0 @@
-enable rhc-canonical-facts.timer

--- a/data/systemd/meson.build
+++ b/data/systemd/meson.build
@@ -1,6 +1,4 @@
 systemd_system_unit_dir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
-systemd_system_preset_dir = systemd.get_variable(pkgconfig: 'systemdsystempresetdir')
 
-install_data('80-rhc.preset', install_dir: systemd_system_preset_dir)
 install_data('rhc-canonical-facts.service', install_dir: systemd_system_unit_dir)
 install_data('rhc-canonical-facts.timer', install_dir: systemd_system_unit_dir)

--- a/data/systemd/rhc-canonical-facts.service
+++ b/data/systemd/rhc-canonical-facts.service
@@ -4,8 +4,8 @@ Documentation=https://github.com/RedHatInsights/rhc
 
 [Service]
 Type=oneshot
-User=root
-Group=yggdrasil-worker
+ExecStart=touch /var/lib/yggdrasil/canonical-facts.json
+ExecStart=chown yggdrasil:yggdrasil /var/lib/yggdrasil/canonical-facts.json
 ExecStart=rhc canonical-facts
 StandardOutput=truncate:/var/lib/yggdrasil/canonical-facts.json
 StandardError=journal

--- a/dist/srpm/rhc.spec.in
+++ b/dist/srpm/rhc.spec.in
@@ -143,7 +143,6 @@ fi
 %{_datadir}/bash-completion/completions/*
 %{_mandir}/man1/*
 %{_unitdir}/rhc-canonical-facts.*
-%{_presetdir}/*
 
 %files compat
 %{_unitdir}/rhcd.service

--- a/dist/srpm/rhc.spec.in
+++ b/dist/srpm/rhc.spec.in
@@ -68,7 +68,9 @@ BuildRequires:  meson
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:  pkgconfig(bash-completion)
 BuildRequires:  golang >= 1.18
-
+%if %{with check}
+BuildRequires:  /usr/bin/dbus-launch
+%endif
 
 %description %{common_description}
 

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -1,0 +1,173 @@
+// Package systemd provides a structured API for interacting with systemd
+// services. It builds on top of the go-systemd package's D-Bus API, abstracting
+// away some of the quirks that exist due to the D-Bus bindings.
+package systemd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	systemd "github.com/coreos/go-systemd/v22/dbus"
+	"github.com/subpop/go-log"
+)
+
+type ConnectionType int
+
+const (
+	ConnectionTypeSystem ConnectionType = iota
+	ConnectionTypeUser
+)
+
+type Conn struct {
+	ctx  context.Context
+	conn *systemd.Conn
+}
+
+// NewConnectionContext creates a new connection to the given systemd service.
+func NewConnectionContext(ctx context.Context, connectionType ConnectionType) (*Conn, error) {
+	var conn *systemd.Conn
+	var err error
+	if connectionType == ConnectionTypeSystem {
+		conn, err = systemd.NewSystemConnectionContext(ctx)
+	} else {
+		conn, err = systemd.NewUserConnectionContext(ctx)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("cannot establish connection to systemd: %v", err)
+	}
+
+	return &Conn{
+		ctx:  ctx,
+		conn: conn,
+	}, nil
+}
+
+func (c *Conn) Close() {
+	c.conn.Close()
+}
+
+// Reload instructs systemd to scan for and reload unit files.
+func (c *Conn) Reload() error {
+	return c.conn.ReloadContext(c.ctx)
+}
+
+// EnableUnit enables the named unit. If activate is true, it also starts the
+// unit. If runtime is true, the unit is enabled for the runtime only (/run). If
+// false, it is enabled persistently (/etc).
+func (c *Conn) EnableUnit(name string, activate bool, runtime bool) error {
+	if _, _, err := c.conn.EnableUnitFilesContext(c.ctx, []string{name}, runtime, true); err != nil {
+		return fmt.Errorf("cannot enable unit %v: %v", name, err)
+	}
+
+	if activate {
+		if err := c.StartUnit(name, true); err != nil {
+			return fmt.Errorf("cannot start unit %v: %v", name, err)
+		}
+	}
+
+	return nil
+}
+
+// StartUnit starts the named unit. If wait is true, the method waits until the
+// unit state becomes "active".
+func (c *Conn) StartUnit(name string, wait bool) error {
+	jobComplete := make(chan string)
+	_, err := c.conn.StartUnitContext(c.ctx, name, "replace", jobComplete)
+	if err != nil {
+		return fmt.Errorf("cannot start unit %v: %v", name, err)
+	}
+	result := <-jobComplete
+	switch result {
+	case "done":
+		// The job successfully started, break to proceed
+		break
+	default:
+		return fmt.Errorf("failed to start unit with reason: %v", result)
+	}
+
+	if wait {
+		if err := c.waitForState(name, "active", 1*time.Second); err != nil {
+			return fmt.Errorf("timed out waiting for state 'active': %v", err)
+		}
+	}
+
+	return nil
+}
+
+// DisableUnit disables the named unit. If deactivate is true, it also stops the
+// unit. If runtime is true, the unit is disabled for the runtime only (/run).
+// If false, it is disabled persistently (/etc).
+func (c *Conn) DisableUnit(name string, deactivate bool, runtime bool) error {
+	if _, err := c.conn.DisableUnitFilesContext(c.ctx, []string{name}, runtime); err != nil {
+		return fmt.Errorf("cannot disable unit %v: %v", name, err)
+	}
+
+	if deactivate {
+		if err := c.StopUnit(name, true); err != nil {
+			return fmt.Errorf("cannot stop unit %v: %v", name, err)
+		}
+	}
+
+	return nil
+}
+
+// StopUnit stops the named unit. If wait is true, the method waits until the
+// unit state becomes "inactive".
+func (c *Conn) StopUnit(name string, wait bool) error {
+	jobComplete := make(chan string)
+	_, err := c.conn.StopUnitContext(c.ctx, name, "replace", jobComplete)
+	if err != nil {
+		return fmt.Errorf("cannot stop unit %v: %v", name, err)
+	}
+	result := <-jobComplete
+	switch result {
+	case "done":
+		break
+	default:
+		return fmt.Errorf("failed to stop unit with reason: %v", result)
+	}
+
+	if wait {
+		if err := c.waitForState(name, "inactive", 5*time.Second); err != nil {
+			return fmt.Errorf("timed out waiting for state 'inactive': %v", err)
+		}
+	}
+
+	return nil
+}
+
+// getUnitState checks the given unit's "ActiveState" property.
+func (c *Conn) getUnitState(name string) (string, error) {
+	prop, err := c.conn.GetUnitPropertyContext(c.ctx, name, "ActiveState")
+	if err != nil {
+		return "", fmt.Errorf("cannot get unit property 'ActiveState': %v", err)
+	}
+	var state string
+	if err := prop.Value.Store(&state); err != nil {
+		return "", fmt.Errorf("cannot store property %v (%v) to string: %v", prop.Name, prop.Value.String(), err)
+	}
+	return state, nil
+}
+
+// waitForState checks the unit state, waiting until it matches the given state,
+// or the timeout occurs.
+func (c *Conn) waitForState(unit string, wantState string, timeout time.Duration) error {
+	after := time.After(timeout)
+	for {
+		select {
+		case <-after:
+			return fmt.Errorf("timed out waiting %v for unit state '%v'", timeout, wantState)
+		default:
+			state, err := c.getUnitState(unit)
+			if err != nil {
+				return fmt.Errorf("cannot get unit state: %v", err)
+			}
+			if state == wantState {
+				return nil
+			} else {
+				log.Tracef("got unit state %v", state)
+			}
+		}
+	}
+}

--- a/internal/systemd/systemd_test.go
+++ b/internal/systemd/systemd_test.go
@@ -1,0 +1,84 @@
+package systemd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestUnit(t *testing.T) {
+	if _, has := os.LookupEnv("DBUS_SESSION_BUS_ADDRESS"); !has {
+		t.Skip("DBUS_SESSION_BUS_ADDRESS undefined")
+	}
+
+	tests := []struct {
+		description string
+		input       struct {
+			unitFile string
+			now      bool
+		}
+		want      string
+		wantError error
+	}{
+		{
+			description: "activate simple.service",
+			input: struct {
+				unitFile string
+				now      bool
+			}{
+				unitFile: "testdata/simple.service",
+				now:      true,
+			},
+			want: "active",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			conn, err := NewConnectionContext(context.Background(), ConnectionTypeUser)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			abs, err := filepath.Abs(test.input.unitFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Link the testdata unit files into the search paths so they can be
+			// referenced by name. This simulates the context in which this
+			// package is more likely to be run.
+			_, err = conn.conn.LinkUnitFilesContext(conn.ctx, []string{abs}, true, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = conn.EnableUnit(filepath.Base(test.input.unitFile), test.input.now, true)
+			defer func(t *testing.T) {
+				if err := conn.DisableUnit(filepath.Base(test.input.unitFile), test.input.now, true); err != nil {
+					t.Fatal(err)
+				}
+			}(t)
+			if test.wantError != nil {
+				if !cmp.Equal(err, test.wantError, cmpopts.EquateErrors()) {
+					t.Errorf("%#v != %#v", err, test.wantError)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				got, err := conn.getUnitState(filepath.Base(test.input.unitFile))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !cmp.Equal(got, test.want) {
+					t.Errorf("%v", cmp.Diff(got, test.want))
+				}
+			}
+		})
+	}
+}

--- a/internal/systemd/testdata/simple.service
+++ b/internal/systemd/testdata/simple.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Testdata Unit
+
+[Service]
+Type=simple
+ExecStart=tail -f /dev/null


### PR DESCRIPTION
A collection of small changes to the rhc-canonical-facts service and timer. These changes are intended to ensure the timer and services run appropriately. Instead of trying to start rhc-canonical-facts.service as a requirement of yggdrasil.service, this PR changes the behavior of `rhc connect` so that first the `rhc-canonical-facts.timer` is started, followed by the `yggdrasil.service`.

## How to test this PR

This PR makes additional code run when `rhc connect` is run, so it should be testable running `rhc connect` using whichever credentials you prefer (username/password or activation-key/org-id).

## How to verify changes are happening

No visible changes are made to the output of `rhc connect`, so to verify this PR is doing what it says, you'll need to check for the status of a few systemd units.

After successfully running `rhc connect`, check the status of the following two systemd units:
- `rhc-canonical-facts.timer`
- `rhc-canonical-facts.service`

The timer should be active and waiting. The service should have last executed successfully.

Additionally, the file `/var/lib/yggdrasil/canonical-facts.json` should have JSON content in it.

Card ID: CCT-291