### PR TITLE
fix: Report any unknown options found on the command line.

### DIFF
--- a/main.go
+++ b/main.go
@@ -253,7 +253,7 @@ func beforeConnectAction(ctx *cli.Context) error {
 		}
 	}
 
-	return nil
+	return checkForUnknownArgs(ctx)
 }
 
 // connectAction tries to register system against Red Hat Subscription Management,
@@ -487,7 +487,12 @@ func (connectResult ConnectResult) Error() string {
 
 // beforeDisconnectAction ensures the used has supplied a correct `--format` flag
 func beforeDisconnectAction(ctx *cli.Context) error {
-	return setupFormatOption(ctx)
+	err := setupFormatOption(ctx)
+	if err != nil {
+		return err
+	}
+
+	return checkForUnknownArgs(ctx)
 }
 
 // interactivePrintf is method for printing human-readable output. It suppresses output, when
@@ -648,7 +653,12 @@ func printJSONStatus(systemStatus *SystemStatus) error {
 
 // beforeStatusAction ensures the user has supplied a correct `--format` flag.
 func beforeStatusAction(ctx *cli.Context) error {
-	return setupFormatOption(ctx)
+	err := setupFormatOption(ctx)
+	if err != nil {
+		return err
+	}
+
+	return checkForUnknownArgs(ctx)
 }
 
 // statusAction tries to print status of system. It means that it gives

--- a/util.go
+++ b/util.go
@@ -154,3 +154,12 @@ func getLocale() string {
 	locale := os.Getenv("LANG")
 	return locale
 }
+
+// checkForUnknownArgs returns an error if any unknown arguments are present.
+func checkForUnknownArgs(ctx *cli.Context) error {
+	if ctx.Args().Len() != 0 {
+		return fmt.Errorf("error: unknown option(s): %s",
+			strings.Join(ctx.Args().Slice(), " "))
+	}
+	return nil
+}


### PR DESCRIPTION
Card ID: CCT-524

The rhc subcommands, connect, disconnect and status ignore any unknown options given. This PR will fix this by returning an error when any unknown options are found.

The following tests were performed:

Test 1:  One unknown argument give.
```
% sudo  ./rhc connect activation-key 
error: unknown option(s): activation-key 
```

Test 2: Valid arguments given but unknown arguments were also given. The extra unknown
            arguments will produce an error.
```
% sudo  ./rhc connect --activation-key ${MY_KEY} --organization ${MY_ORG}  bobs your uncle
error: unknown option(s): bobs your uncle 

```