### PR TITLE
feat(test): Adding rhc-compat sub-package to copr setup for PR tetsing

### DIFF
--- a/systemtest/copr-setup.sh
+++ b/systemtest/copr-setup.sh
@@ -22,4 +22,4 @@ dnf install -y rhc
 # These PR packit builds have an older version number for some reason than the released...
 dnf remove -y --noautoremove rhc
 dnf copr -y enable packit/RedHatInsights-rhc-${ghprbPullId} ${COPR_REPO}
-dnf install -y rhc --disablerepo=* --enablerepo=*rhc*
+dnf install -y rhc rhc-compat --disablerepo=* --enablerepo=*rhc*


### PR DESCRIPTION
rhc-compat sub package was introduced to support the migration from rhcd to yggdrasil.
For more information https://issues.redhat.com/browse/CCT-639