### PR TITLE
feat: register with content templates

### DIFF
--- a/main.go
+++ b/main.go
@@ -157,6 +157,11 @@ func main() {
 					Usage:   "register with `KEY`",
 					Aliases: []string{"a"},
 				},
+				&cli.StringSliceFlag{
+					Name:    "content-template",
+					Usage:   "register with `CONTENT_TEMPLATE`",
+					Aliases: []string{"c"},
+				},
 				&cli.StringFlag{
 					Name:   "server",
 					Hidden: true,


### PR DESCRIPTION
Card ID: CCT-769.

This is dependent on [this PR](https://github.com/candlepin/subscription-manager/pull/3462), which the requirements are still being discussed, so I'm leaving this in draft for now.    

This PR implements a new option to register with a content template, given the content template name. Since content templates are implemented as environments in candlepin, I've tried to implement this such that some code could be re-used in the future for registering with environments.

Feedback is appreciated and welcome :)

Still needs

- [x] To handle activation keys
- [x] To handle when GetEnvironments() is not available

