### PR TITLE
feat[PoC]: Enable analytics on demand

### DIFF
--- a/feature.go
+++ b/feature.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/subpop/go-log"
+	"github.com/urfave/cli/v2"
+)
+
+// FeaturesStatePath points to a filesystem location where the state file is stored.
+var FeaturesStatePath = "/var/lib/rhc/features.json"
+
+// RequiredFeatures contains a list of features that cannot be disabled.
+var RequiredFeatures = []Feature{IdentityFeature}
+
+// DefaultFeatures contains a list of features that are enabled by default.
+var DefaultFeatures = []Feature{IdentityFeature, ContentFeature, AnalyticsFeature}
+
+type FeaturesState struct {
+	Enabled []string `json:"enabled"`
+}
+
+func (s *FeaturesState) IsEnabled(featureID string) bool {
+	for _, feature := range s.Enabled {
+		if feature == featureID {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *FeaturesState) IsDefault(featureID string) bool {
+	for _, defaultFeature := range DefaultFeatures {
+		if defaultFeature.ID == featureID {
+			return true
+		}
+	}
+	return false
+}
+
+func GetFeaturesState() *FeaturesState {
+	content, err := os.ReadFile(FeaturesStatePath)
+	if err != nil {
+		var state = &FeaturesState{Enabled: []string{}}
+		for _, defaultFeature := range DefaultFeatures {
+			state.Enabled = append(state.Enabled, defaultFeature.ID)
+		}
+		if err = state.Save(); err != nil {
+			log.Errorf("could not create features cache: %v", err)
+			panic(err)
+		}
+		return state
+	}
+
+	var state = FeaturesState{
+		Enabled: []string{},
+	}
+
+	if err = json.Unmarshal(content, &state); err != nil {
+		panic(err)
+	}
+	return &state
+}
+
+func (s *FeaturesState) Save() error {
+	content, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(FeaturesStatePath, content, 0644)
+}
+
+// KnownFeatures is a sorted list of features, ordered from least to the most dependent.
+var KnownFeatures = []*Feature{
+	&IdentityFeature,
+	&ContentFeature,
+	&AnalyticsFeature,
+	&ManagementFeature,
+	&MalwareFeature,
+	&ComplianceFeature,
+}
+
+func GetFeature(featureID string) (*Feature, bool) {
+	for _, feature := range KnownFeatures {
+		if feature.ID == featureID {
+			return feature, true
+		}
+	}
+	return nil, false
+}
+
+// Feature manages optional features of rhc.
+//
+// ID is an identifier of the feature.
+// Description is human-readable description of the feature.
+// Requires is a list of IDs of other features that are required for this feature. Feature
+// dependencies are not resolved.
+// EnableFunc is called when the feature should transition into enabled state.
+// DisableFunc is called when the feature should transition into disabled state.
+type Feature struct {
+	ID          string
+	Description string
+	Requires    []*Feature
+	EnableFunc  func(ctx *cli.Context) error
+	DisableFunc func(ctx *cli.Context) error
+}
+
+func (f *Feature) String() string {
+	return fmt.Sprintf("Feature{ID:%s}", f.ID)
+}
+
+var IdentityFeature = Feature{
+	ID:          "identity",
+	Requires:    []*Feature{},
+	Description: "Identify a RHEL system",
+	EnableFunc: func(ctx *cli.Context) error {
+		log.Debug("'identity' is currently a meta feature implicitly requiring 'content'")
+		return nil
+	},
+	DisableFunc: func(ctx *cli.Context) error {
+		log.Debug("'identity' is currently a meta feature implicitly requiring 'content'")
+		return nil
+	},
+}
+
+var ContentFeature = Feature{
+	ID:          "content",
+	Requires:    []*Feature{&IdentityFeature},
+	Description: "Get access to RHEL content",
+	EnableFunc: func(ctx *cli.Context) error {
+		log.Debug("'content' feature not implemented")
+		return nil
+	},
+	DisableFunc: func(ctx *cli.Context) error {
+		log.Debug("'content' feature not implemented")
+		return nil
+	},
+}
+
+var ManagementFeature = Feature{
+	ID:          "management",
+	Requires:    []*Feature{&IdentityFeature, &ContentFeature, &AnalyticsFeature},
+	Description: "Remote management",
+	EnableFunc: func(ctx *cli.Context) error {
+		log.Debug("'management' feature not implemented")
+		return nil
+	},
+	DisableFunc: func(ctx *cli.Context) error {
+		log.Debug("'management' feature not implemented")
+		return nil
+	},
+}
+
+var MalwareFeature = Feature{
+	ID:          "malware",
+	Requires:    []*Feature{&IdentityFeature, &AnalyticsFeature},
+	Description: "Malware analytics",
+	EnableFunc: func(ctx *cli.Context) error {
+		log.Debug("'malware' feature not implemented")
+		return nil
+	},
+	DisableFunc: func(ctx *cli.Context) error {
+		log.Debug("'malware' feature not implemented")
+		return nil
+	},
+}
+
+var ComplianceFeature = Feature{
+	ID:          "compliance",
+	Requires:    []*Feature{&IdentityFeature, &AnalyticsFeature},
+	Description: "Compliance analytics and management",
+	EnableFunc: func(ctx *cli.Context) error {
+		log.Debug("'compliance' feature not implemented")
+		return nil
+	},
+	DisableFunc: func(ctx *cli.Context) error {
+		log.Debug("'compliance' feature not implemented")
+		return nil
+	},
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func featureIDs(feature []*Feature) []string {
+	result := make([]string, len(feature))
+	for i, f := range feature {
+		result[i] = f.ID
+	}
+	return result
+}
+
+// TestResolveFeatureInput tests that feature dependencies are correctly resolved.
+// When feature is added, all its dependencies are added.
+// When feature is removed, all its dependents are removed.
+// When feature is requested to be both added and removed, error is returned.
+func TestResolveFeatureInput(t *testing.T) {
+	shouldWord := []struct {
+		description string
+		inEnable    []string
+		inDisable   []string
+		wantEnable  []string
+		wantDisable []string
+	}{
+		{
+			description: "+identity",
+			inEnable:    []string{"identity"},
+			inDisable:   []string{},
+			wantEnable:  []string{"identity"},
+			wantDisable: []string{},
+		},
+		{
+			description: "+content",
+			inEnable:    []string{"content"},
+			inDisable:   []string{},
+			wantEnable:  []string{"content", "identity"},
+			wantDisable: []string{},
+		},
+		{
+			description: "+management",
+			inEnable:    []string{"management"},
+			inDisable:   []string{},
+			wantEnable:  []string{"analytics", "content", "identity", "management"},
+			wantDisable: []string{},
+		},
+		{
+			description: "-analytics",
+			inEnable:    []string{},
+			inDisable:   []string{"analytics"},
+			wantEnable:  []string{},
+			wantDisable: []string{"analytics", "compliance", "malware", "management"},
+		},
+		{
+			description: "-content",
+			inEnable:    []string{},
+			inDisable:   []string{"content"},
+			wantEnable:  []string{},
+			wantDisable: []string{"content", "management"},
+		},
+		{
+			description: "-management",
+			inEnable:    []string{},
+			inDisable:   []string{"management"},
+			wantEnable:  []string{},
+			wantDisable: []string{"management"},
+		},
+	}
+
+	for _, test := range shouldWord {
+		t.Run(test.description, func(t *testing.T) {
+			gotEnableF, gotDisableF, err := resolveFeatureInput(test.inEnable, test.inDisable)
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotEnable := featureIDs(gotEnableF)
+			gotDisable := featureIDs(gotDisableF)
+			slices.Sort(gotEnable)
+			slices.Sort(gotDisable)
+
+			if !reflect.DeepEqual(gotEnable, test.wantEnable) {
+				t.Errorf("want <%s>, got <%s>", test.wantEnable, gotEnable)
+			}
+			if !reflect.DeepEqual(gotDisable, test.wantDisable) {
+				t.Errorf("want <%s>, got <%s>", test.wantDisable, gotDisable)
+			}
+		})
+	}
+
+	shouldFail := []struct {
+		description string
+		inEnable    []string
+		inDisable   []string
+		error       string
+	}{
+		{
+			description: "identity cannot be disabled",
+			inEnable:    []string{},
+			inDisable:   []string{"identity"},
+			error:       "feature 'identity' cannot be disabled",
+		},
+		{
+			description: "management needs analytics",
+			inEnable:    []string{"management"},
+			inDisable:   []string{"analytics"},
+			error:       "features can't be enabled and disabled at the same time: analytics, management",
+		},
+		{
+			description: "malware needs analytics",
+			inEnable:    []string{"malware"},
+			inDisable:   []string{"analytics"},
+			error:       "features can't be enabled and disabled at the same time: analytics, malware",
+		},
+	}
+
+	for _, test := range shouldFail {
+		t.Run(test.description, func(t *testing.T) {
+			_, _, err := resolveFeatureInput(test.inEnable, test.inDisable)
+
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if err.Error() != test.error {
+				t.Errorf("want <%v>, got <%v>", test.error, err)
+			}
+		})
+	}
+}

--- a/status.go
+++ b/status.go
@@ -3,11 +3,35 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/briandowns/spinner"
 	systemd "github.com/coreos/go-systemd/v22/dbus"
+	"github.com/subpop/go-log"
 )
+
+var StatePath = "/var/lib/rhc/connected"
+
+func IsConnected() bool {
+	_, err := os.Stat(StatePath)
+	return err == nil
+}
+
+func SetConnected(state bool) {
+	if state {
+		timestamp := time.Now().Format("2006-01-02T15:04:05")
+		err := os.WriteFile(StatePath, []byte(timestamp), 0664)
+		if err != nil {
+			log.Errorf("error writing state file: %v", err)
+		}
+	} else {
+		err := os.Remove(StatePath)
+		if err != nil {
+			log.Errorf("error removing state file: %v", err)
+		}
+	}
+}
 
 // rhsmStatus tries to print status provided by RHSM D-Bus API. If we provide
 // output in machine-readable format, then we only set files in SystemStatus


### PR DESCRIPTION
* Card ID: CCT-941

This patch explores the possibility of using 'configure features' subcommand to perform rhc configuration to provide more options to connecting users. It shouldn't be merged as-is, as it contains features that may conflict with current use-cases and may not handle all of them correctly.