### PR TITLE
Arpandey/add custom markers to tests

### DIFF
--- a/integration-tests/pytest.ini
+++ b/integration-tests/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers = 
+	tier1: mark a test to run as tier1 priority
+	tier2: mark a test to run as tier2 priority
+

--- a/integration-tests/test_connect.py
+++ b/integration-tests/test_connect.py
@@ -19,7 +19,7 @@ from utils import (
 
 logger = logging.getLogger(__name__)
 
-
+@pytest.mark.tier1
 @pytest.mark.parametrize(
     "auth, output_format",
     [

--- a/integration-tests/test_disconnect.py
+++ b/integration-tests/test_disconnect.py
@@ -9,6 +9,7 @@ import pytest
 from utils import yggdrasil_service_is_active
 
 
+@pytest.mark.tier1
 def test_rhc_disconnect(external_candlepin, rhc, test_config):
     """Verify that RHC disconnect command disconnects host from server
     and deactivates yggdrasil service.

--- a/integration-tests/test_status.py
+++ b/integration-tests/test_status.py
@@ -9,6 +9,7 @@ from pytest_client_tools import util
 from utils import yggdrasil_service_is_active
 
 
+@pytest.mark.tier1
 def test_status_connected(external_candlepin, rhc, test_config):
     """Test RHC Status command when the host is connected.
     test_steps:
@@ -47,7 +48,7 @@ def test_status_connected_format_json(external_candlepin, rhc, test_config):
     """
     rhc.connect(
         username=test_config.get("candlepin.username"),
-        password=test_config.get("candlepin.password")
+        password=test_config.get("candlepin.password"),
     )
     status_result = rhc.run("status", "--format", "json", check=False)
     assert status_result.returncode == 0
@@ -65,6 +66,7 @@ def test_status_connected_format_json(external_candlepin, rhc, test_config):
         assert type(status_json["yggdrasil_running"]) == bool
 
 
+@pytest.mark.tier1
 def test_status_disconnected(rhc):
     """Test RHC Status command when the host is disconnected.
     Ref: https://issues.redhat.com/browse/CCT-525


### PR DESCRIPTION
Currently all tests are running for gating jobs. Some of the tests continue to fail due to infra/test issue and can be skipped from gating. I am adding custom markers to run gating tests. Downstream jobs in jenkins have already been modified to be able to use these markers via PYTEST_ADDOPTS

## Summary by Sourcery

Introduce custom pytest markers for test prioritization and tag specific integration tests as tier1 to support selective gating.

Enhancements:
- Define custom 'tier1' and 'tier2' markers in pytest.ini for test categorization.

Tests:
- Annotate integration tests in test_status.py, test_connect.py, and test_disconnect.py with @pytest.mark.tier1.