### PR TITLE
feat: Added levels of connectivity to connect command

### DIFF
--- a/connect_cmd.go
+++ b/connect_cmd.go
@@ -61,6 +61,15 @@ func beforeConnectAction(ctx *cli.Context) error {
 		return err
 	}
 
+	// When machine is already connected, then return error
+	uuid, err := getConsumerUUID()
+	if err != nil {
+		return fmt.Errorf("unable to get consumer UUID: %s", err)
+	}
+	if uuid != "" {
+		return fmt.Errorf("this system is already connected")
+	}
+
 	username := ctx.String("username")
 	password := ctx.String("password")
 	organization := ctx.String("organization")

--- a/disconnect_cmd.go
+++ b/disconnect_cmd.go
@@ -3,10 +3,11 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/subpop/go-log"
-	"github.com/urfave/cli/v2"
 	"os"
 	"time"
+
+	"github.com/subpop/go-log"
+	"github.com/urfave/cli/v2"
 )
 
 // DisconnectResult is structure holding information about result of
@@ -95,7 +96,7 @@ func disconnectAction(ctx *cli.Context) error {
 	/* 1. Deactivate yggdrasil (rhcd) service */
 	start = time.Now()
 	progressMessage := fmt.Sprintf(" Deactivating the %v service", ServiceName)
-	err = showProgress(progressMessage, deactivateService)
+	err = showProgress(progressMessage, deactivateService, smallIndent)
 	if err != nil {
 		errMsg := fmt.Sprintf("Cannot deactivate %s service: %v", ServiceName, err)
 		errorMessages[ServiceName] = LogMessage{
@@ -103,16 +104,16 @@ func disconnectAction(ctx *cli.Context) error {
 			message: fmt.Errorf("%v", errMsg)}
 		disconnectResult.YggdrasilStopped = false
 		disconnectResult.YggdrasilStoppedError = errMsg
-		interactivePrintf("%v %v\n", uiSettings.iconError, errMsg)
+		interactivePrintf(" [%v] %v\n", uiSettings.iconError, errMsg)
 	} else {
 		disconnectResult.YggdrasilStopped = true
-		interactivePrintf("%v Deactivated the %v service\n", uiSettings.iconOK, ServiceName)
+		interactivePrintf(" [%v] Deactivated the %v service\n", uiSettings.iconOK, ServiceName)
 	}
 	durations[ServiceName] = time.Since(start)
 
 	/* 2. Disconnect from Red Hat Insights */
 	start = time.Now()
-	err = showProgress(" Disconnecting from Red Hat Insights...", unregisterInsights)
+	err = showProgress(" Disconnecting from Red Hat Insights...", unregisterInsights, smallIndent)
 	if err != nil {
 		errMsg := fmt.Sprintf("Cannot disconnect from Red Hat Insights: %v", err)
 		errorMessages["insights"] = LogMessage{
@@ -120,16 +121,18 @@ func disconnectAction(ctx *cli.Context) error {
 			message: fmt.Errorf("%v", errMsg)}
 		disconnectResult.InsightsDisconnected = false
 		disconnectResult.InsightsDisconnectedError = errMsg
-		interactivePrintf("%v %v\n", uiSettings.iconError, errMsg)
+		interactivePrintf(" [%v] %v\n", uiSettings.iconError, errMsg)
 	} else {
 		disconnectResult.InsightsDisconnected = true
-		interactivePrintf("%v Disconnected from Red Hat Insights\n", uiSettings.iconOK)
+		interactivePrintf(" [%v] Disconnected from Red Hat Insights\n", uiSettings.iconOK)
 	}
 	durations["insights"] = time.Since(start)
 
 	/* 3. Unregister system from Red Hat Subscription Management */
 	err = showProgress(
-		" Disconnecting from Red Hat Subscription Management...", unregister,
+		" Disconnecting from Red Hat Subscription Management...",
+		unregister,
+		smallIndent,
 	)
 	if err != nil {
 		errMsg := fmt.Sprintf("Cannot disconnect from Red Hat Subscription Management: %v", err)
@@ -139,10 +142,10 @@ func disconnectAction(ctx *cli.Context) error {
 
 		disconnectResult.RHSMDisconnected = false
 		disconnectResult.RHSMDisconnectedError = errMsg
-		interactivePrintf("%v %v\n", uiSettings.iconError, errMsg)
+		interactivePrintf(" [%v] %v\n", uiSettings.iconError, errMsg)
 	} else {
 		disconnectResult.RHSMDisconnected = true
-		interactivePrintf("%v Disconnected from Red Hat Subscription Management\n", uiSettings.iconOK)
+		interactivePrintf(" [%v] Disconnected from Red Hat Subscription Management\n", uiSettings.iconOK)
 	}
 	durations["rhsm"] = time.Since(start)
 

--- a/features.go
+++ b/features.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/subpop/go-log"
+	"github.com/urfave/cli/v2"
+)
+
+// RhcFeature manages optional features of rhc.
+type RhcFeature struct {
+	// ID is an identifier of the feature.
+	ID string
+	// Description is human-readable description of the feature.
+	Description string
+	// Enabled represents the state of feature
+	Enabled bool
+	// Reason for disabling feature
+	Reason string
+	// Requires is a list of IDs of other features that are required for this feature. RhcFeature
+	// dependencies are not resolved.
+	Requires []*RhcFeature
+	// EnableFunc is callback function, and it is called when the feature should transition
+	// into enabled state.
+	EnableFunc func(ctx *cli.Context) error
+	// DisableFunc is also callback function, and it is called when the feature should transition
+	// into disabled state.
+	DisableFunc func(ctx *cli.Context) error
+}
+
+func (f *RhcFeature) String() string {
+	return fmt.Sprintf("Feature{ID:%s}", f.ID)
+}
+
+// KnownFeatures is a sorted list of features, ordered from least to the most dependent.
+var KnownFeatures = []*RhcFeature{
+	&ContentFeature,
+	&AnalyticsFeature,
+	&ManagementFeature,
+}
+
+// listKnownFeatureIds is helper function, and it returns the list of IDs of known feature
+func listKnownFeatureIds() []string {
+	var ids []string
+	for _, feature := range KnownFeatures {
+		ids = append(ids, feature.ID)
+	}
+	return ids
+}
+
+// ContentFeature allows to enable/disable content provided by Red Hat. It is
+// typically set of RPM repositories generated in /etc/yum.repos.d/redhat.repo
+var ContentFeature = RhcFeature{
+	ID:          "content",
+	Requires:    []*RhcFeature{},
+	Enabled:     func() bool { return true }(),
+	Description: "Get access to RHEL content",
+	EnableFunc: func(ctx *cli.Context) error {
+		log.Debug("enabling 'content' feature not implemented")
+		return nil
+	},
+	DisableFunc: func(ctx *cli.Context) error {
+		log.Debug("disabling 'content' feature not implemented")
+		return nil
+	},
+}
+
+// AnalyticsFeature allows to enable/disable collecting data for Red Hat Insights
+var AnalyticsFeature = RhcFeature{
+	ID:          "analytics",
+	Requires:    []*RhcFeature{},
+	Enabled:     func() bool { return true }(),
+	Description: "Enable data collection for Red Hat Insights",
+	EnableFunc: func(ctx *cli.Context) error {
+		log.Debug("enabling 'analytics' feature not implemented")
+		return nil
+	},
+	DisableFunc: func(ctx *cli.Context) error {
+		log.Debug("disabling 'analytics' feature not implemented")
+		return nil
+	},
+}
+
+// ManagementFeature allows to enable/disable remote management of the host
+// using yggdrasil service and various workers
+var ManagementFeature = RhcFeature{
+	ID:          "remote-management",
+	Requires:    []*RhcFeature{&ContentFeature, &AnalyticsFeature},
+	Enabled:     func() bool { return true }(),
+	Description: "Remote management",
+	EnableFunc: func(ctx *cli.Context) error {
+		log.Debug("enabling 'management' feature not implemented")
+		return nil
+	},
+	DisableFunc: func(ctx *cli.Context) error {
+		log.Debug("disabling 'management' feature not implemented")
+		return nil
+	},
+}
+
+// checkFeatureInput checks input of enabled and disabled features
+func checkFeatureInput(enabledFeaturesIDs *[]string, disabledFeaturesIDs *[]string) error {
+	// First check disabled features: check only correctness of IDs
+	for _, featureId := range *disabledFeaturesIDs {
+		isKnown := false
+		var disabledFeature *RhcFeature = nil
+		for _, rhcFeature := range KnownFeatures {
+			if featureId == rhcFeature.ID {
+				disabledFeature = rhcFeature
+				isKnown = true
+				break
+			}
+		}
+		if !isKnown {
+			supportedIds := listKnownFeatureIds()
+			hint := strings.Join(supportedIds, ",")
+			return fmt.Errorf("cannot disable feature \"%s\": no such feature exists (%s)", featureId, hint)
+		}
+		disabledFeature.Enabled = false
+	}
+
+	// Then check enabled features, and it is more tricky, because:
+	// 1) you cannot enable feature, which was already disabled
+	// 2) you cannot enable feature, which depends on disabled feature
+	for _, featureId := range *enabledFeaturesIDs {
+		isKnown := false
+		var enabledFeature *RhcFeature = nil
+		for _, rhcFeature := range KnownFeatures {
+			if featureId == rhcFeature.ID {
+				enabledFeature = rhcFeature
+				isKnown = true
+				break
+			}
+		}
+		if !isKnown {
+			supportedIds := listKnownFeatureIds()
+			hint := strings.Join(supportedIds, ",")
+			return fmt.Errorf("cannot enable feature \"%s\": no such feature exists (%s)", featureId, hint)
+		}
+		for _, disabledFeatureId := range *disabledFeaturesIDs {
+			if featureId == disabledFeatureId {
+				return fmt.Errorf("cannot enable feature: \"%s\": feature \"%s\" explicitly disabled",
+					featureId, disabledFeatureId)
+			}
+			for _, requiredFeature := range enabledFeature.Requires {
+				if requiredFeature.ID == disabledFeatureId {
+					return fmt.Errorf("cannot enable feature: \"%s\": required feature \"%s\" explicitly disabled",
+						enabledFeature.ID, disabledFeatureId)
+				}
+			}
+		}
+		enabledFeature.Enabled = true
+	}
+
+	for _, feature := range KnownFeatures {
+		for _, requiredFeature := range feature.Requires {
+			if !requiredFeature.Enabled {
+				feature.Enabled = false
+				feature.Reason = fmt.Sprintf("required feature \"%s\" is disabled", requiredFeature.ID)
+			}
+		}
+	}
+
+	return nil
+}

--- a/interactive.go
+++ b/interactive.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/briandowns/spinner"
-	"github.com/subpop/go-log"
-	"github.com/urfave/cli/v2"
 	"os"
 	"text/tabwriter"
 	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/subpop/go-log"
+	"github.com/urfave/cli/v2"
 )
 
 const (
@@ -16,6 +17,9 @@ const (
 	colorRed    = "\u001B[31m"
 	colorReset  = "\u001B[0m"
 )
+
+const smallIndent = " "
+const mediumIndent = "  "
 
 // userInterfaceSettings manages standard output preference.
 // It tracks colors, icons and machine-readable output (e.g. json).
@@ -36,6 +40,10 @@ type userInterfaceSettings struct {
 // It is managed by calling the configureUISettings method.
 var uiSettings = userInterfaceSettings{}
 
+const symbolOK string = "✓"
+const symbolInfo string = "●"
+const symbolError string = "𐄂"
+
 // configureUISettings is called by the CLI library when it loads up.
 // It sets up the uiSettings object.
 func configureUISettings(ctx *cli.Context) {
@@ -43,17 +51,17 @@ func configureUISettings(ctx *cli.Context) {
 		uiSettings = userInterfaceSettings{
 			isRich:            false,
 			isMachineReadable: false,
-			iconOK:            "✓",
-			iconInfo:          "·",
-			iconError:         "𐄂",
+			iconOK:            symbolOK,
+			iconInfo:          symbolInfo,
+			iconError:         symbolError,
 		}
 	} else {
 		uiSettings = userInterfaceSettings{
 			isRich:            true,
 			isMachineReadable: false,
-			iconOK:            colorGreen + "●" + colorReset,
-			iconInfo:          colorYellow + "●" + colorReset,
-			iconError:         colorRed + "●" + colorReset,
+			iconOK:            colorGreen + symbolOK + colorReset,
+			iconInfo:          colorYellow + symbolInfo + colorReset,
+			iconError:         colorRed + symbolError + colorReset,
 		}
 	}
 }
@@ -63,11 +71,13 @@ func configureUISettings(ctx *cli.Context) {
 func showProgress(
 	progressMessage string,
 	function func() error,
+	prefixSpaces string,
 ) error {
 	var s *spinner.Spinner
 	if uiSettings.isRich {
 		s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-		s.Suffix = progressMessage
+		s.Prefix = prefixSpaces + "["
+		s.Suffix = "]" + progressMessage
 		s.Start()
 		// Stop spinner after running function
 		defer func() { s.Stop() }()

--- a/main.go
+++ b/main.go
@@ -162,6 +162,16 @@ func main() {
 					Usage:   "register with `CONTENT_TEMPLATE`",
 					Aliases: []string{"c"},
 				},
+				&cli.StringSliceFlag{
+					Name:    "enable-feature",
+					Usage:   "enable `FEATURE` during connection",
+					Aliases: []string{"e"},
+				},
+				&cli.StringSliceFlag{
+					Name:    "disable-feature",
+					Usage:   "disable `FEATURE` during connection",
+					Aliases: []string{"d"},
+				},
 				&cli.StringFlag{
 					Name:   "server",
 					Hidden: true,


### PR DESCRIPTION
* Card ID: CCT-1005
* First step of levels of connectivity
* When connect command is used, then it is possible to
  enabled or disable three features using command line
  options `--enable-feature` or `--disable-feature`. Following
  features are supported
  - `content`
  - `analytics`
  - `remote-management`
* Added checks for allowed combination of CLI options
* Modified UI little bit to be able to visualize that
  feature was not started
* Output to JSON format is still supported
* When machine readable format is used, then add information
  about enabled/disabled content to generated JSON file
* When machine readable output is used, then list of
   enabled/disable features is added to the generated JSON doc
* Unified UI for colorful and not colorful mode
* Changed UI for `disconnect` command to looks similar to `connect` command
* Connecting looks like this in interactive mode:

```
Connecting localhost to Red Hat.
This might take a few seconds.

Features preferences: [✓]content, [✓]analytics, [✓]remote-management

 [✓] This system is already connected to Red Hat Subscription Management
  [✓] Content ... Red Hat repository file generated
  [✓] Analytics ... Connected to Red Hat Insights
  [✓] Remote Management ... Activated the yggdrasil service

Successfully connected to Red Hat!

Manage your connected systems: https://red.ht/connector
```