### PR TITLE
fix: Temporary hide --content-template CLI option of connect

### DIFF
--- a/main.go
+++ b/main.go
@@ -160,6 +160,7 @@ func main() {
 				&cli.StringSliceFlag{
 					Name:    "content-template",
 					Usage:   "register with `CONTENT_TEMPLATE`",
+					Hidden:  true,
 					Aliases: []string{"c"},
 				},
 				&cli.StringFlag{


### PR DESCRIPTION
* It is not possible to use content templates in production ATM. For this reason, we decided to mark `--content-template` CLI option as hidden. Thus, it will be possible to test it, but it will not be exposed to users and customers.