### PR TITLE
test: Skipping test test_rhc_worker_playbook_install_after_rhc_connect

### DIFF
--- a/integration-tests/test_connect.py
+++ b/integration-tests/test_connect.py
@@ -111,6 +111,7 @@ def test_connect_wrong_parameters(
     assert not yggdrasil_service_is_active()
 
 
+@pytest.mark.skip("Test cannot be run due to unresolved issues CCT-696")
 @pytest.mark.parametrize("auth", ["basic", "activation-key"])
 def test_rhc_worker_playbook_install_after_rhc_connect(
     external_candlepin, rhc, test_config, auth


### PR DESCRIPTION
This test is failing due to unresolved issue CCT-696, After the issue is fixed the test might need to be rewritten also, so disabling the test unless issue is fixed.