### PR TITLE
fix: Content template cannot be used, when content is disabled

### DIFF
--- a/connect_cmd.go
+++ b/connect_cmd.go
@@ -76,6 +76,7 @@ func beforeConnectAction(ctx *cli.Context) error {
 	activationKeys := ctx.StringSlice("activation-key")
 	enabledFeatures := ctx.StringSlice("enable-feature")
 	disabledFeatures := ctx.StringSlice("disable-feature")
+	contentTemplates := ctx.StringSlice("content-template")
 
 	if len(activationKeys) > 0 {
 		if username != "" {
@@ -96,6 +97,10 @@ func beforeConnectAction(ctx *cli.Context) error {
 	err = checkFeatureInput(&enabledFeatures, &disabledFeatures)
 	if err != nil {
 		return err
+	}
+
+	if !ContentFeature.Enabled && len(contentTemplates) > 0 {
+		return fmt.Errorf("'--content-template' can not be used together with '--disable-feature content'")
 	}
 
 	return checkForUnknownArgs(ctx)


### PR DESCRIPTION
* When content is disabled with --disable-feature content, then --content-template CLI option cannot be used, because it does not have any sense to use content-template environment with content, when content is disabled.