### PR TITLE
feat: Improved UX experience during 'rhc disconnect'

### DIFF
--- a/activate.go
+++ b/activate.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-
 	systemd "github.com/redhatinsights/rhc/internal/systemd"
 )
 
@@ -35,6 +34,25 @@ func activateService() error {
 	}
 
 	return nil
+}
+
+// isServiceInState returns true, when yggdrasil.service is in given state
+func isServiceInState(wantedState string) (bool, error) {
+	conn, err := systemd.NewConnectionContext(context.Background(), systemd.ConnectionTypeSystem)
+	if err != nil {
+		return false, fmt.Errorf("cannot connect to systemd: %v", err)
+	}
+	defer conn.Close()
+
+	state, err := conn.GetUnitState("yggdrasil.service")
+	if err != nil {
+		return false, fmt.Errorf("cannot get unit state: %v", err)
+	}
+	if state == wantedState {
+		return true, nil
+	} else {
+		return false, nil
+	}
 }
 
 // deactivateService tries to stop and disable the rhc-canonical-facts.timer,

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -137,8 +137,8 @@ func (c *Conn) StopUnit(name string, wait bool) error {
 	return nil
 }
 
-// getUnitState checks the given unit's "ActiveState" property.
-func (c *Conn) getUnitState(name string) (string, error) {
+// GetUnitState checks the given unit's "ActiveState" property.
+func (c *Conn) GetUnitState(name string) (string, error) {
 	prop, err := c.conn.GetUnitPropertyContext(c.ctx, name, "ActiveState")
 	if err != nil {
 		return "", fmt.Errorf("cannot get unit property 'ActiveState': %v", err)
@@ -159,7 +159,7 @@ func (c *Conn) waitForState(unit string, wantState string, timeout time.Duration
 		case <-after:
 			return fmt.Errorf("timed out waiting %v for unit state '%v'", timeout, wantState)
 		default:
-			state, err := c.getUnitState(unit)
+			state, err := c.GetUnitState(unit)
 			if err != nil {
 				return fmt.Errorf("cannot get unit state: %v", err)
 			}

--- a/internal/systemd/systemd_test.go
+++ b/internal/systemd/systemd_test.go
@@ -71,7 +71,7 @@ func TestUnit(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				got, err := conn.getUnitState(filepath.Base(test.input.unitFile))
+				got, err := conn.GetUnitState(filepath.Base(test.input.unitFile))
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/rhsm.go
+++ b/rhsm.go
@@ -517,3 +517,15 @@ func registerRHSM(ctx *cli.Context, enableContent bool) (string, error) {
 	}
 	return successMsg, nil
 }
+
+// isRHSMRegistered returns true, when system is registered
+func isRHSMRegistered() (bool, error) {
+	uuid, err := getConsumerUUID()
+	if err != nil {
+		return false, err
+	}
+	if uuid != "" {
+		return true, nil
+	}
+	return false, nil
+}


### PR DESCRIPTION
* Card ID: CCt-1162
* When some feature (e.g. analytics) was disabled during
  `rhc connect`, using `--disable-feature "analytics"` CLI option,
  then later do not try to unregister insights-client, when
  `rhc disconnect` is run. There is printed only informative
  message that given "feature" has been already disconnected.
* This change also improve the case, when system is connected
  using `rhc connect`, but later user run command
  `insights-client --unregister`. No error should be printed
  in such case.
* TODO: Fix integration tests
* When you run `rhc disconnect` multiple times, then output
  looks like this:

```
root@localhost:/# rhc disconnect
Disconnecting localhost from Red Hat.
This might take a few seconds.

 [●] The yggdrasil service is already inactive
 [●] Already disconnected from Red Hat Insights
 [●] Already disconnected from Red Hat Subscription Management

Manage your connected systems: https://red.ht/connector
```