### PR TITLE
fix: Allow to use activation key(s) and org with --format json

### DIFF
--- a/connect_cmd.go
+++ b/connect_cmd.go
@@ -82,14 +82,19 @@ func beforeConnectAction(ctx *cli.Context) error {
 		if username != "" {
 			return fmt.Errorf("--username and --activation-key can not be used together")
 		}
+		if password != "" {
+			return fmt.Errorf("--password and --activation-key can not be used together")
+		}
 		if organization == "" {
 			return fmt.Errorf("--organization is required, when --activation-key is used")
 		}
 	}
 
-	// When machine-readable format is used, then additional requirements have to be met
+	// When machine-readable format is used, then additional requirements have to be met.
+	// User has to provide username & password or at least one activation key and organization,
+	// because no interaction with user is possible in this case.
 	if uiSettings.isMachineReadable {
-		if username == "" || password == "" {
+		if !((username != "" && password != "") || (len(activationKeys) > 0 && organization != "")) {
 			return fmt.Errorf("--username/--password or --organization/--activation-key are required when a machine-readable format is used")
 		}
 	}

--- a/integration-tests/utils/__init__.py
+++ b/integration-tests/utils/__init__.py
@@ -36,7 +36,7 @@ def check_yggdrasil_journalctl_logs(
 
 
 def prepare_args_for_connect(
-    test_config, auth: str = None, credentials: dict = None, server: str = None
+    test_config, auth: str = None, credentials: dict = None, output_format: str = None, server: str = None
 ):
     """Method to create arguments to be passed in 'rhc connect' command
     This method expects either auth type or custom credentials
@@ -72,6 +72,9 @@ def prepare_args_for_connect(
                     test_config.get("candlepin.org"),
                 ]
             )
+
+    if output_format:
+        args.extend(["--format", output_format])
 
     if server:
         args.extend(["--server", server])


### PR DESCRIPTION
* Card ID: CCT-1161
* When `--format json` is used, then all credentials has to be provided. Not only `username` & `password` has to be considered, but also `activation-key` and `organization` has to be allowed to use in such case.
* Added one more check: combination of activation-key and password should not be allowed.