### PR TITLE
feat: Added list of features IDs to --help

### DIFF
--- a/integration-tests/test_man_page.py
+++ b/integration-tests/test_man_page.py
@@ -50,3 +50,18 @@ def test_man_page_connect_options(options):
     command_op = subprocess.check_output(["man", "rhc"]).decode("utf-8")
     for option in options:
         assert option in command_op
+
+@pytest.mark.parametrize(
+    "feature_id",
+    [
+        "content",
+        "analytics",
+        "remote-management",
+    ]
+)
+def test_man_page_feature_ids(feature_id):
+    """
+    Test verifies if man page contains IDs of features
+    """
+    command_op = subprocess.check_output(["man", "rhc"]).decode("utf-8")
+    assert feature_id in command_op

--- a/integration-tests/test_man_page.py
+++ b/integration-tests/test_man_page.py
@@ -32,19 +32,21 @@ def test_man_page_commands(command):
 
 
 @pytest.mark.parametrize(
-    "option",
+    "options",
     [
-        "--activation-key, -a",
-        "--organization, -o",
-        "--password, -p",
-        "--server",
-        "--username, -u",
+        ["--activation-key", "-a"],
+        ["--organization", "-o"],
+        ["--password", "-p"],
+        ["--username", "-u"],
+        ["--enable-feature", "-e"],
+        ["--disable-feature", "-d"],
+        ["--content-template", "-c"],
     ],
 )
-def test_man_page_connect_options(option):
-    """Test verifies if man page displays existing options for commands"""
+def test_man_page_connect_options(options):
+    """
+    Test verifies if man page displays existing options for commands
+    """
     command_op = subprocess.check_output(["man", "rhc"]).decode("utf-8")
-    if option == "--server":
-        assert option not in command_op
-    else:
+    for option in options:
         assert option in command_op

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
 	"os"
+	"strings"
 )
 
 // mainAction is triggered in the case, when no sub-command is specified
@@ -88,6 +89,12 @@ func main() {
 	log.SetFlags(0)
 	log.SetPrefix("")
 
+	var featureIdSlice []string
+	for _, featureID := range KnownFeatures {
+		featureIdSlice = append(featureIdSlice, featureID.ID)
+	}
+	featureIDs := strings.Join(featureIdSlice, ", ")
+
 	defaultConfigFilePath, err := ConfigPath()
 	if err != nil {
 		log.Fatal(err)
@@ -164,12 +171,12 @@ func main() {
 				},
 				&cli.StringSliceFlag{
 					Name:    "enable-feature",
-					Usage:   "enable `FEATURE` during connection",
+					Usage:   fmt.Sprintf("enable `FEATURE` during connection (allowed values: %s)", featureIDs),
 					Aliases: []string{"e"},
 				},
 				&cli.StringSliceFlag{
 					Name:    "disable-feature",
-					Usage:   "disable `FEATURE` during connection",
+					Usage:   fmt.Sprintf("disable `FEATURE` during connection (allowed values: %s)", featureIDs),
 					Aliases: []string{"d"},
 				},
 				&cli.StringFlag{


### PR DESCRIPTION
* Card ID: CCT-1167
* Added list of featured IDs to the help of "connect" command. Thus, users will be able to find values they can use with `--enabled-feature` and `--disable-feature`
* The man page also contains allowed values now, because man page is auto-generated from source code.
* Extended integration test to include checks of new CLI options and feature IDs
* TODO: Try to add these values to bash completion script somehow, but maybe it will be possible only with higher version of urfave/cli (not v2)