### PR TITLE
fix: Return non-zero exit code for wrong usage of CLI options

### DIFF
--- a/connect_cmd.go
+++ b/connect_cmd.go
@@ -79,7 +79,12 @@ func beforeConnectAction(ctx *cli.Context) error {
 
 	if len(activationKeys) > 0 {
 		if username != "" {
-			return fmt.Errorf("--username and --activation-key can not be used together")
+			exitErr := cli.Exit(
+				"--username and --activation-key can not be used together",
+				ExitCodeUsage,
+			)
+			return exitErr
+
 		}
 		if organization == "" {
 			return fmt.Errorf("--organization is required, when --activation-key is used")

--- a/constants.go
+++ b/constants.go
@@ -2,6 +2,59 @@ package main
 
 import "path/filepath"
 
+const (
+	// ExitCodeOK for successful termination
+	ExitCodeOK = 0
+
+	// ExitCodeErr for generic error
+	ExitCodeErr = 1
+
+	// ExitCodeUsage for command line usage error
+	ExitCodeUsage = 64
+
+	// ExitCodeDataErr for data format error
+	ExitCodeDataErr = 65
+
+	// ExitCodeNoInput for cannot open input
+	ExitCodeNoInput = 66
+
+	// ExitCodeNoUser for addressee unknown
+	ExitCodeNoUser = 67
+
+	// ExitCodeNoHost for host name unknown
+	ExitCodeNoHost = 68
+
+	// ExitCodeUnavailable for service unavailable
+	ExitCodeUnavailable = 69
+
+	// ExitCodeSoftware for internal software error
+	ExitCodeSoftware = 70
+
+	// ExitCodeOSErr system error (e.g., can't fork)
+	ExitCodeOSErr = 71
+
+	// ExitCodeOSFile critical OS file missing
+	ExitCodeOSFile = 72
+
+	// ExitCodeCantCreat for can't create (user) output file
+	ExitCodeCantCreat = 73
+
+	// ExitCodeIOErr for input/output error
+	ExitCodeIOErr = 74
+
+	// ExitCodeTempFail for temp failure; user is invited to retry
+	ExitCodeTempFail = 75
+
+	// ExitCodeProtocol for remote error in protocol
+	ExitCodeProtocol = 76
+
+	// ExitCodeNoPerm for permission denied
+	ExitCodeNoPerm = 77
+
+	// ExitCodeConfig for configuration error
+	ExitCodeConfig = 78
+)
+
 var (
 	// Version is the version as described by git.
 	Version string

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"github.com/subpop/go-log"
 	"github.com/urfave/cli/v2"
@@ -234,6 +235,14 @@ func main() {
 	app.Before = beforeAction
 
 	if err := app.Run(os.Args); err != nil {
-		log.Error(err)
+		var exitErr cli.ExitCoder
+		if errors.As(err, &exitErr) {
+			log.Error(exitErr.Error())
+			os.Exit(exitErr.ExitCode())
+		} else {
+			log.Error(err)
+			// When it is generic error, then return 1
+			os.Exit(ExitCodeErr)
+		}
 	}
 }


### PR DESCRIPTION
* Card ID: CCT-1155
* When wrong combination of CLI option is used, then return non-zero exit code
* Added set of constants for exit codes (copy pasted from `sysexits.h`
* Use `cli.Exit()` for generating exit error and code. The code used in this case is `64` (`ExitCodeUsage`) that should be used, when e.g. wron combination of CLI options is used
* TODO: modify all errors returned from `BeforeAction()` functions to use right code