### PR TITLE
test : Changing repo name in copr setup for running PR tests on …

### DIFF
--- a/systemtest/copr-setup.sh
+++ b/systemtest/copr-setup.sh
@@ -6,10 +6,13 @@ dnf install -y dnf-plugins-core
 # 'centos-stream-9-x86_64', 'rhel-9-x86_64', 'fedora-40-x86_64',
 # 'fedora-39-x86_64', 'fedora-rawhide-x86_64'
 source /etc/os-release
-if [ "$ID" == "centos" ]; then
+
+VERSION_MAJOR=$(echo ${VERSION_ID} | cut -d '.' -f 1)
+
+if [[ "$ID" == "centos" ]] || { [[ "$ID" == "rhel" ]] && [[ "$VERSION_MAJOR" == "10" ]]; }; then
   ID='centos-stream'
 fi
-VERSION_MAJOR=$(echo ${VERSION_ID} | cut -d '.' -f 1)
+
 COPR_REPO="${ID}-${VERSION_MAJOR}-$(uname -m)"
 
 #get yggdrasil


### PR DESCRIPTION
…rhel10

	Currently rhel-10-x86_64 repo does not exit for RHEL 10, enabling
	centos-stream-10-x86_64 will enable PR tests to run against rhel 10.
	This Change should be reverted once rhel-10-x86_64 repo is available.