### PR TITLE
fix: Do not output machine readable output to stderr

### DIFF
--- a/connect_cmd.go
+++ b/connect_cmd.go
@@ -364,5 +364,9 @@ func connectAction(ctx *cli.Context) error {
 		return err
 	}
 
-	return cli.Exit(connectResult, 0)
+	if uiSettings.isMachineReadable {
+		fmt.Println(connectResult.Error())
+	}
+
+	return nil
 }

--- a/disconnect_cmd.go
+++ b/disconnect_cmd.go
@@ -159,5 +159,9 @@ func disconnectAction(ctx *cli.Context) error {
 		}
 	}
 
-	return cli.Exit(disconnectResult, 0)
+	if uiSettings.isMachineReadable {
+		fmt.Println(disconnectResult.Error())
+	}
+
+	return nil
 }


### PR DESCRIPTION
* Card ID: CCT-1191
* When no error happens and `--format json` is used, then do not output JSON document to `stderr`. It should be printed to `stdout`.
* Open questions:
  * Should we output JSON document to `stderr`, when some error happens?
  * Should be all errors printed to `stderr` valid JSON documents?