### PR TITLE
[0.2] ci: fix packit configuration for versions & coprs

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -27,27 +27,46 @@ actions:
 jobs:
   - job: copr_build
     trigger: pull_request
+    identifier: "pr_build/el9"
     additional_repos:
-      - "copr://@yggdrasil/latest"
+      - "copr://@yggdrasil/el9"
     targets:
       - centos-stream-9-aarch64
       - centos-stream-9-x86_64
+      - rhel-9-aarch64
+      - rhel-9-x86_64
+
+  - job: copr_build
+    trigger: pull_request
+    identifier: "pr_build/el8"
+    additional_repos:
+      - "copr://@yggdrasil/el8"
+    targets:
       - rhel-8-aarch64
       - rhel-8-x86_64
+
+  - job: copr_build
+    trigger: commit
+    identifier: "build/el9"
+    additional_repos:
+      - "copr://@yggdrasil/el9"
+    branch: "release-0.2"
+    owner: "@yggdrasil"
+    project: el9
+    targets:
+      - centos-stream-9-aarch64
+      - centos-stream-9-x86_64
       - rhel-9-aarch64
       - rhel-9-x86_64
 
   - job: copr_build
     trigger: commit
+    identifier: "build/el8"
     additional_repos:
-      - "copr://@yggdrasil/latest"
-    branch: main
+      - "copr://@yggdrasil/el8"
+    branch: "release-0.2"
     owner: "@yggdrasil"
-    project: latest
+    project: el8
     targets:
-      - centos-stream-9-aarch64
-      - centos-stream-9-x86_64
       - rhel-8-aarch64
       - rhel-8-x86_64
-      - rhel-9-aarch64
-      - rhel-9-x86_64


### PR DESCRIPTION
The `@yggdrasil/latest` copr is used to build rhc/main, and only for newer versions of RHEL. Since this branch only builds for RHEL 8 & 9 currently, then let's amend the packit configuration to build in the right place:
- split the jobs for PRs and commit depending on the RHEL version, as they will need to use different copr's
- use the right copr's depending on the version built
- use unique identifier to avoid conflicts
