### PR TITLE
Fix several lint issues

### DIFF
--- a/connect_cmd.go
+++ b/connect_cmd.go
@@ -95,9 +95,6 @@ func beforeConnectAction(ctx *cli.Context) error {
 			return exitErr
 
 		}
-		if password != "" {
-			return fmt.Errorf("--password and --activation-key can not be used together")
-		}
 		if organization == "" {
 			exitErr := cli.Exit(
 				"--organization is required, when --activation-key is used",
@@ -111,8 +108,12 @@ func beforeConnectAction(ctx *cli.Context) error {
 	// User has to provide username & password or at least one activation key and organization,
 	// because no interaction with user is possible in this case.
 	if uiSettings.isMachineReadable {
-		if !((username != "" && password != "") || (len(activationKeys) > 0 && organization != "")) {
-			return fmt.Errorf("--username/--password or --organization/--activation-key are required when a machine-readable format is used")
+		if (username == "" || password == "") && (len(activationKeys) == 0 || organization == "") {
+			exitErr := cli.Exit(
+				"--username/--password or --organization/--activation-key are required when a machine-readable format is used",
+				ExitCodeUsage,
+			)
+			return exitErr
 		}
 	}
 

--- a/util.go
+++ b/util.go
@@ -23,7 +23,7 @@ func isTerminal(fd uintptr) bool {
 // and then recursively calls itself on each subcommand.
 func BashCompleteCommand(cmd *cli.Command, w io.Writer) {
 	for _, name := range cmd.Names() {
-		fmt.Fprintf(w, "%v\n", name)
+		_, _ = fmt.Fprintf(w, "%v\n", name)
 	}
 
 	PrintFlagNames(cmd.VisibleFlags(), w)
@@ -38,9 +38,9 @@ func PrintFlagNames(flags []cli.Flag, w io.Writer) {
 	for _, flag := range flags {
 		for _, name := range flag.Names() {
 			if len(name) > 1 {
-				fmt.Fprintf(w, "--%v\n", name)
+				_, _ = fmt.Fprintf(w, "--%v\n", name)
 			} else {
-				fmt.Fprintf(w, "-%v\n", name)
+				_, _ = fmt.Fprintf(w, "-%v\n", name)
 			}
 		}
 	}


### PR DESCRIPTION
* Fix several lint issues discovered in PR #225
* Do not ignore error returned by `Close()`
* Ignore error returned by `Fprintf()`, when `io.Writer` is stdout.
* Simplified some checks