### PR TITLE
fix: Return non-zero code, when wrong cli options are used.

### DIFF
--- a/integration-tests/test_connect.py
+++ b/integration-tests/test_connect.py
@@ -115,20 +115,20 @@ def test_connect(external_candlepin, rhc, test_config, auth, output_format):
                 "username": "candlepin.username",
                 "activation-key": "candlepin.activation_keys",
             },
-            None,
+            64,
         ),
         (  # invalid combination of parameters (password & activation-key)
             {
                 "activation-key": "candlepin.activation_keys",
                 "password": "candlepin.password",
             },
-            None,
+            64,
         ),
         (  # invalid combination of parameters (activation-key without organization)
             {
                 "activation-key": "candlepin.activation_keys",
             },
-            None,
+            64,
         ),
     ],
 )

--- a/util.go
+++ b/util.go
@@ -116,6 +116,6 @@ func setupFormatOption(ctx *cli.Context) error {
 			format,
 			`"json"`,
 		)
-		return cli.Exit(err, 1)
+		return cli.Exit(err, ExitCodeDataErr)
 	}
 }


### PR DESCRIPTION
* Card ID: CCT-1329
* The `rhc` returned 0 exit code in cases, when e.g. not allowed
  combinations of CLI options were used.
* When e.g. wrong combination of CLI option is used and it is
  detected in `beforeConnectAction()` function then this function
  has to return `cli.Exit()` error with appropriate exit code.

## Summary by Sourcery

Improve error handling and exit codes for the RHC CLI tool to provide more accurate and informative error responses when incorrect command-line options are used.

Bug Fixes:
- Ensure the CLI returns non-zero exit codes when invalid or conflicting command-line options are provided
- Improve error handling to return appropriate exit codes for different error scenarios

Enhancements:
- Refactor error handling in beforeConnectAction to use cli.Exit() for more precise error reporting
- Add more specific error handling for various CLI option validation scenarios

Chores:
- Update error handling to log connection and file closing errors
- Improve error message clarity for CLI option validation