### PR TITLE
feat: Remove hidden CLI option --server from connect command

### DIFF
--- a/integration-tests/utils/__init__.py
+++ b/integration-tests/utils/__init__.py
@@ -36,7 +36,7 @@ def check_yggdrasil_journalctl_logs(
 
 
 def prepare_args_for_connect(
-    test_config, auth: str = None, credentials: dict = None, output_format: str = None, server: str = None
+    test_config, auth: str = None, credentials: dict = None, output_format: str = None
 ):
     """Method to create arguments to be passed in 'rhc connect' command
     This method expects either auth type or custom credentials
@@ -75,8 +75,5 @@ def prepare_args_for_connect(
 
     if output_format:
         args.extend(["--format", output_format])
-
-    if server:
-        args.extend(["--server", server])
 
     return args

--- a/main.go
+++ b/main.go
@@ -180,11 +180,6 @@ func main() {
 					Aliases: []string{"d"},
 				},
 				&cli.StringFlag{
-					Name:   "server",
-					Hidden: true,
-					Usage:  "register against `URL`",
-				},
-				&cli.StringFlag{
 					Name:    "format",
 					Usage:   "prints output of connection in machine-readable format (supported formats: \"json\")",
 					Aliases: []string{"f"},


### PR DESCRIPTION
* Card ID: CCT-1335
* This CLI option could never been used in production, because configuring satellite server requires more actions. Thus, this CLI option was useless. The connect command should not have any unexpected side effect like changing of configuration file.
* Do not use `--server` in integration tests, because this CLI option was removed from connect command