### PR TITLE
feat(deps): replace go-log with standard library log/slog

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -1,5 +1,7 @@
 package main
 
+import "log/slog"
+
 const (
 	cliLogLevel  = "log-level"
 	cliCertFile  = "cert-file"
@@ -10,7 +12,7 @@ const (
 type Conf struct {
 	CertFile string
 	KeyFile  string
-	LogLevel string
+	LogLevel slog.Level
 	CADir    string
 }
 

--- a/connect_cmd.go
+++ b/connect_cmd.go
@@ -3,11 +3,11 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/subpop/go-log"
 	"github.com/urfave/cli/v2"
 )
 
@@ -220,7 +220,7 @@ func connectAction(ctx *cli.Context) error {
 	if err != nil {
 		connectResult.RHSMConnected = false
 		errorMessages["rhsm"] = LogMessage{
-			level: log.LevelError,
+			level: slog.LevelError,
 			message: fmt.Errorf("cannot connect to Red Hat Subscription Management: %w",
 				err)}
 		if uiSettings.isMachineReadable {
@@ -262,7 +262,7 @@ func connectAction(ctx *cli.Context) error {
 	/* 2. Register insights-client */
 	if AnalyticsFeature.Enabled {
 		if errors, exist := errorMessages["rhsm"]; exist {
-			if errors.level == log.LevelError {
+			if errors.level == slog.LevelError {
 				interactivePrintf(
 					"%s[%v] Skipping connection to Red Hat Insights\n",
 					mediumIndent,
@@ -275,7 +275,7 @@ func connectAction(ctx *cli.Context) error {
 			if err != nil {
 				connectResult.Features.Analytics.Successful = false
 				errorMessages["insights"] = LogMessage{
-					level:   log.LevelError,
+					level:   slog.LevelError,
 					message: fmt.Errorf("cannot connect to Red Hat Insights: %w", err)}
 				if uiSettings.isMachineReadable {
 					connectResult.Features.Analytics.Error = errorMessages["insights"].message.Error()
@@ -305,7 +305,7 @@ func connectAction(ctx *cli.Context) error {
 
 	if ManagementFeature.Enabled {
 		/* 3. Start yggdrasil (rhcd) service */
-		if rhsmErrMsg, exist := errorMessages["rhsm"]; exist && rhsmErrMsg.level == log.LevelError {
+		if rhsmErrMsg, exist := errorMessages["rhsm"]; exist && rhsmErrMsg.level == slog.LevelError {
 			connectResult.Features.RemoteManagement.Successful = false
 			interactivePrintf(
 				"%s[%v] Skipping activation of %v service\n",
@@ -320,7 +320,7 @@ func connectAction(ctx *cli.Context) error {
 			if err != nil {
 				connectResult.Features.RemoteManagement.Successful = false
 				errorMessages[ServiceName] = LogMessage{
-					level: log.LevelError,
+					level: slog.LevelError,
 					message: fmt.Errorf("cannot activate %s service: %w",
 						ServiceName, err)}
 				if uiSettings.isMachineReadable {

--- a/disconnect_cmd.go
+++ b/disconnect_cmd.go
@@ -3,10 +3,10 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"time"
 
-	"github.com/subpop/go-log"
 	"github.com/urfave/cli/v2"
 )
 
@@ -74,7 +74,7 @@ func disconnectService(disconnectResult *DisconnectResult, errorMessages *map[st
 	if err != nil {
 		errMsg := fmt.Sprintf("Cannot deactivate %s service: %v", ServiceName, err)
 		(*errorMessages)[ServiceName] = LogMessage{
-			level:   log.LevelError,
+			level:   slog.LevelError,
 			message: fmt.Errorf("%v", errMsg)}
 		disconnectResult.YggdrasilStopped = false
 		disconnectResult.YggdrasilStoppedError = errMsg
@@ -103,7 +103,7 @@ func disconnectInsightsClient(disconnectResult *DisconnectResult, errorMessages 
 	if err != nil {
 		errMsg := fmt.Sprintf("Cannot disconnect from Red Hat Insights: %v", err)
 		(*errorMessages)["insights"] = LogMessage{
-			level:   log.LevelError,
+			level:   slog.LevelError,
 			message: fmt.Errorf("%v", errMsg)}
 		disconnectResult.InsightsDisconnected = false
 		disconnectResult.InsightsDisconnectedError = errMsg
@@ -136,7 +136,7 @@ func disconnectRHSM(disconnectResult *DisconnectResult, errorMessages *map[strin
 	if err != nil {
 		errMsg := fmt.Sprintf("Cannot disconnect from Red Hat Subscription Management: %v", err)
 		(*errorMessages)["rhsm"] = LogMessage{
-			level:   log.LevelError,
+			level:   slog.LevelError,
 			message: fmt.Errorf("%v", errMsg)}
 
 		disconnectResult.RHSMDisconnected = false

--- a/features.go
+++ b/features.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 
-	"github.com/subpop/go-log"
 	"github.com/urfave/cli/v2"
 )
 
@@ -57,11 +57,11 @@ var ContentFeature = RhcFeature{
 	Enabled:     func() bool { return true }(),
 	Description: "Get access to RHEL content",
 	EnableFunc: func(ctx *cli.Context) error {
-		log.Debug("enabling 'content' feature not implemented")
+		slog.Debug("enabling 'content' feature not implemented")
 		return nil
 	},
 	DisableFunc: func(ctx *cli.Context) error {
-		log.Debug("disabling 'content' feature not implemented")
+		slog.Debug("disabling 'content' feature not implemented")
 		return nil
 	},
 }
@@ -73,11 +73,11 @@ var AnalyticsFeature = RhcFeature{
 	Enabled:     func() bool { return true }(),
 	Description: "Enable data collection for Red Hat Insights",
 	EnableFunc: func(ctx *cli.Context) error {
-		log.Debug("enabling 'analytics' feature not implemented")
+		slog.Debug("enabling 'analytics' feature not implemented")
 		return nil
 	},
 	DisableFunc: func(ctx *cli.Context) error {
-		log.Debug("disabling 'analytics' feature not implemented")
+		slog.Debug("disabling 'analytics' feature not implemented")
 		return nil
 	},
 }
@@ -90,11 +90,11 @@ var ManagementFeature = RhcFeature{
 	Enabled:     func() bool { return true }(),
 	Description: "Remote management",
 	EnableFunc: func(ctx *cli.Context) error {
-		log.Debug("enabling 'management' feature not implemented")
+		slog.Debug("enabling 'management' feature not implemented")
 		return nil
 	},
 	DisableFunc: func(ctx *cli.Context) error {
-		log.Debug("disabling 'management' feature not implemented")
+		slog.Debug("disabling 'management' feature not implemented")
 		return nil
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/subpop/go-log v0.1.2
 	github.com/urfave/cli/v2 v2.27.7
 	golang.org/x/sys v0.33.0
 	golang.org/x/term v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/subpop/go-log v0.1.2 h1:NgbZR6frmeDtC+96d+UxOkt4X/JxO626fokwL56Dff0=
-github.com/subpop/go-log v0.1.2/go.mod h1:uAEovif98swmWm/8qYGrzGFahUIRQ/KwlBUpJuoOdds=
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=

--- a/interactive.go
+++ b/interactive.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"text/tabwriter"
 	"time"
 
 	"github.com/briandowns/spinner"
-	"github.com/subpop/go-log"
 	"github.com/urfave/cli/v2"
 )
 
@@ -87,7 +87,7 @@ func showProgress(
 
 // showTimeDuration shows table with duration of each sub-action
 func showTimeDuration(durations map[string]time.Duration) {
-	if log.CurrentLevel() >= log.LevelDebug {
+	if config.LogLevel <= slog.LevelDebug {
 		fmt.Println()
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		_, _ = fmt.Fprintln(w, "STEP\tDURATION\t")
@@ -100,19 +100,19 @@ func showTimeDuration(durations map[string]time.Duration) {
 
 // showErrorMessages shows table with all error messages gathered during action
 func showErrorMessages(action string, errorMessages map[string]LogMessage) error {
-	if hasPriorityErrors(errorMessages, log.CurrentLevel()) {
+	if hasPriorityErrors(errorMessages, config.LogLevel) {
 		if !uiSettings.isMachineReadable {
 			fmt.Println()
 			fmt.Printf("The following errors were encountered during %s:\n\n", action)
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 			_, _ = fmt.Fprintln(w, "TYPE\tSTEP\tERROR\t")
 			for step, logMsg := range errorMessages {
-				if logMsg.level <= log.CurrentLevel() {
+				if logMsg.level >= config.LogLevel {
 					_, _ = fmt.Fprintf(w, "%v\t%v\t%v\n", logMsg.level, step, logMsg.message)
 				}
 			}
 			_ = w.Flush()
-			if hasPriorityErrors(errorMessages, log.LevelError) {
+			if hasPriorityErrors(errorMessages, slog.LevelError) {
 				return cli.Exit("", 1)
 			}
 		}

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -6,10 +6,10 @@ package systemd
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	systemd "github.com/coreos/go-systemd/v22/dbus"
-	"github.com/subpop/go-log"
 )
 
 type ConnectionType int
@@ -166,7 +166,7 @@ func (c *Conn) waitForState(unit string, wantState string, timeout time.Duration
 			if state == wantState {
 				return nil
 			} else {
-				log.Tracef("got unit state %v", state)
+				slog.Debug("got unit state", "state", state)
 			}
 		}
 	}

--- a/logging.go
+++ b/logging.go
@@ -1,8 +1,10 @@
 package main
 
-import "github.com/subpop/go-log"
+import (
+	"log/slog"
+)
 
 type LogMessage struct {
-	level   log.Level
+	level   slog.Level
 	message error
 }

--- a/main.go
+++ b/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/subpop/go-log"
-	"github.com/urfave/cli/v2"
-	"github.com/urfave/cli/v2/altsrc"
+	"log/slog"
 	"os"
 	"strings"
+
+	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v2/altsrc"
 )
 
 // mainAction is triggered in the case, when no sub-command is specified
@@ -43,16 +44,16 @@ func beforeAction(c *cli.Context) error {
 	}
 
 	config = Conf{
-		LogLevel: c.String(cliLogLevel),
 		CertFile: c.String(cliCertFile),
 		KeyFile:  c.String(cliKeyFile),
 	}
 
-	level, err := log.ParseLevel(config.LogLevel)
-	if err != nil {
-		return cli.Exit(err, 1)
+	logLevelStr := c.String(cliLogLevel)
+	if err := config.LogLevel.UnmarshalText([]byte(logLevelStr)); err != nil {
+		slog.Error(fmt.Sprintf("invalid log level: '%s'", logLevelStr))
 	}
-	log.SetLevel(level)
+
+	slog.SetLogLoggerLevel(config.LogLevel)
 
 	// When environment variable NO_COLOR or --no-color CLI option is set, then do not display colors
 	// and animations too. The NO_COLOR environment variable have to have value "1" or "true",
@@ -62,7 +63,7 @@ func beforeAction(c *cli.Context) error {
 	if !isTerminal(os.Stdout.Fd()) {
 		err := c.Set("no-color", "true")
 		if err != nil {
-			log.Debug("Unable to set no-color flag to \"true\"")
+			slog.Debug("Unable to set no-color flag to \"true\"")
 		}
 	}
 
@@ -86,9 +87,6 @@ func main() {
 		"\t" + app.Name + " disconnect\n\n" +
 		"Run '" + app.Name + " command --help' for more details."
 
-	log.SetFlags(0)
-	log.SetPrefix("")
-
 	var featureIdSlice []string
 	for _, featureID := range KnownFeatures {
 		featureIdSlice = append(featureIdSlice, featureID.ID)
@@ -97,7 +95,8 @@ func main() {
 
 	defaultConfigFilePath, err := ConfigPath()
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 
 	app.Flags = []cli.Flag{
@@ -236,6 +235,6 @@ func main() {
 	app.Before = beforeAction
 
 	if err := app.Run(os.Args); err != nil {
-		log.Error(err)
+		slog.Error(err.Error())
 	}
 }

--- a/rhsm.go
+++ b/rhsm.go
@@ -4,14 +4,15 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/briandowns/spinner"
-	"github.com/subpop/go-log"
-	"github.com/urfave/cli/v2"
-	"golang.org/x/term"
+	"log/slog"
 	"os"
 	"strings"
 	"text/tabwriter"
 	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/term"
 
 	"github.com/godbus/dbus/v5"
 )
@@ -125,7 +126,11 @@ func registerUsernamePassword(username, password, organization string, environme
 	defer func() {
 		err = privConn.Close()
 		if err != nil {
-			log.Errorf("unable to close connection to private dbus socket %v: %v", privateDbusSocketURI, err)
+			slog.Error(
+				"unable to close connection to private dbus socket",
+				"socket", privateDbusSocketURI,
+				"err", err,
+			)
 		}
 	}()
 
@@ -231,7 +236,11 @@ func registerActivationKey(orgID string, activationKeys []string, environments [
 	defer func() {
 		err = privConn.Close()
 		if err != nil {
-			log.Errorf("unable to close connection to private dbus socket %v: %v", privateDbusSocketURI, err)
+			slog.Error(
+				"unable to close connection to private dbus socket",
+				"socket", privateDbusSocketURI,
+				"err", err,
+			)
 		}
 	}()
 

--- a/util.go
+++ b/util.go
@@ -3,11 +3,10 @@ package main
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/subpop/go-log"
 
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sys/unix"
@@ -70,9 +69,9 @@ func ConfigPath() (string, error) {
 
 // hasPriorityErrors checks if the errorMessage map has any error
 // with a higher priority than the logLevel configure.
-func hasPriorityErrors(errorMessages map[string]LogMessage, level log.Level) bool {
+func hasPriorityErrors(errorMessages map[string]LogMessage, level slog.Level) bool {
 	for _, logMsg := range errorMessages {
-		if logMsg.level <= level {
+		if logMsg.level >= level {
 			return true
 		}
 	}


### PR DESCRIPTION
* Card ID: CCT-239
* github.com/subpop/go-log has been deprecated. This commit replaces its usage throughout the codebase with log/slog from the standard library
* replace `log.Debug`/`log.Info`/etc calls with `slog` counterparts. Calls to `log.Trace()` have been replaced with `slog.Debug()` since no `slog.Trace()` exists
* reference `config.LogLevel` as the currently set log level
* don't exit when an invalid log level is provided