### PR TITLE
fix: The "rhc status" should handle errors properly

### DIFF
--- a/rhsm.go
+++ b/rhsm.go
@@ -329,7 +329,7 @@ func unpackRHSMError(err error) error {
 			}
 			return rhsmError
 		}
-		return fmt.Errorf("unable to parse D-Bus error due to unsupported error name: %s", e.Name)
+		return err
 	}
 	return err
 }


### PR DESCRIPTION
* Card ID: CCT-1526
* When there is some issue e.g. with rhsm.service, then the
  "rhc status" should not terminate immediately, but it
  should print error for given feature and continue with
  printing statuses of other feature
* When `--format json` is used, then errors should be filled
  for related features
* Refactored calling `insightStatus()` function to be consistent
  with other functions
* When it is not possible to access RHSM D-Bus API due
  to e.g. masked `rhsm.service`, then return error as is.
* When yggdrasil wasn't possible to start for various reasons,
  then `rhc status` did not print any error at all. The
  service was indicated as inactive despite the service was
  not present at all. When the service was masked, then
  it was also indicated as inactive
* When there is any problem with yggdrasil service, then
  appropriate message is printed. The message is gathered
  from D-Bus property
* Added integration tests of "rhc status" for the cases, when
  `rhsm.service` is masked