### PR TITLE
test(fix): Install insights-client as test dependency

### DIFF
--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -11,7 +11,7 @@ if ! command -v bootc >/dev/null || bootc status | grep -q 'type: null'; then
   [ -z "${ghprbPullId+x}" ] || ./systemtest/copr-setup.sh
 
   dnf --setopt install_weak_deps=False install -y \
-    podman git-core python3-pip python3-pytest logrotate
+    podman git-core python3-pip python3-pytest logrotate insights-client
 fi
 
 


### PR DESCRIPTION
This change adds insights-client as a dependency in the testing environment to prevent failures in downstream Jenkins jobs. Testing Farm occasionally provides composed environments without insights-client pre-installed, causing tests to fail. Explicitly installing it ensures our testing remains consistent and reliable.