### PR TITLE
chore(ci): Fix whitespace in Betelgeuse job

### DIFF
--- a/.github/workflows/betelgeuse_dry-run.yml
+++ b/.github/workflows/betelgeuse_dry-run.yml
@@ -9,8 +9,8 @@ on:
 jobs:
   betelgeuse:
     name: "betelgeuse dry-run"
-	permissions:
-		contents: read
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     container:
       image: fedora:latest


### PR DESCRIPTION
By using tabs instead of spaces, the file was not parsable.