### PR TITLE
chore(ci): Set Packit to track RHEL 10

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -30,14 +30,12 @@ jobs:
     additional_repos:
       - "copr://@yggdrasil/latest"
     targets:
-      - centos-stream-9-aarch64
-      - centos-stream-9-x86_64
       - centos-stream-10-aarch64
       - centos-stream-10-x86_64
       - fedora-all-aarch64
       - fedora-all-x86_64
-      - rhel-9-aarch64
-      - rhel-9-x86_64
+      - rhel-10-aarch64
+      - rhel-10-x86_64
 
   - job: copr_build
     trigger: commit
@@ -47,21 +45,17 @@ jobs:
     owner: "@yggdrasil"
     project: latest
     targets:
-      - centos-stream-9-aarch64
-      - centos-stream-9-x86_64
       - centos-stream-10-aarch64
       - centos-stream-10-x86_64
       - fedora-all-aarch64
       - fedora-all-x86_64
-      - rhel-9-aarch64
-      - rhel-9-x86_64
+      - rhel-10-aarch64
+      - rhel-10-x86_64
 
   - job: tests
     trigger: pull_request
     identifier: "unit/centos-stream"
     targets:
-      - centos-stream-9-aarch64
-      - centos-stream-9-x86_64
       - centos-stream-10-aarch64
       - centos-stream-10-x86_64
     labels:
@@ -90,7 +84,7 @@ jobs:
     trigger: pull_request
     identifier: "unit/rhel"
     targets:
-      centos-stream-10-x86_64: # TODO: Change me back to RHEL
+      rhel-10-x86_64:
         distros:
           - RHEL-10-Nightly
     labels:


### PR DESCRIPTION
Since the last time the .packit.yaml file has been updated, RHEL 10 has been released, and RHEL 9 has been branched off 'main'.

This patch ensures we only run tests on Fedora, c10s and el10.