### PR TITLE
fix: "rhc disconnect --format json" prints incorrect rhsm_disconnecte…

### DIFF
--- a/disconnect_cmd.go
+++ b/disconnect_cmd.go
@@ -127,7 +127,7 @@ func disconnectRHSM(disconnectResult *DisconnectResult, errorMessages *map[strin
 	}
 	if !isRegistered {
 		infoMsg := "Already disconnected from Red Hat Subscription Management"
-		disconnectResult.InsightsDisconnected = true
+		disconnectResult.RHSMDisconnected = true
 		interactivePrintf(" [%v] %v\n", uiSettings.iconInfo, infoMsg)
 		return nil
 	}


### PR DESCRIPTION
rhc disconnect command with json format shows incorrect value of rhsm_disconnected on an already disconnected system.
* fixes - CCT-1616
Steps to reproduce the issue-
run "rhc disconnect --format json" twice