### PR TITLE
chore: Remove `rhcd service` related code and docstrings

### DIFF
--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -5,23 +5,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def pytest_configure():
-    """Setting the name of service available on the system with rhc installed
-    Name of the service in upstream package is 'yggdrasil'
-    and downstream is 'rhcd'
-    """
-    proc = subprocess.run(
-        ["systemctl", "status", "yggdrasil"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        universal_newlines=True,
-    )
-    if "Unit yggdrasil.service could not be found" in proc.stderr:
-        pytest.service_name = "rhcd"
-    else:
-        pytest.service_name = "yggdrasil"
-
-
 @pytest.fixture(scope="session", autouse=True)
 def install_katello_rpm(test_config):
     if "satellite" in test_config.environment:

--- a/integration-tests/test_connect.py
+++ b/integration-tests/test_connect.py
@@ -39,7 +39,7 @@ def test_connect(external_candlepin, rhc, test_config, auth, output_format):
     :description:
         This test verifies that RHC can successfully connect to CRC using either
         basic authentication or an activation key. It also checks that the
-        yggdrasil/rhcd service is in active state after a successful
+        yggdrasil service is in active state after a successful
         connection. The test covers both default text output and machine-readable
         JSON output formats.
     :tags: Tier 1
@@ -47,17 +47,16 @@ def test_connect(external_candlepin, rhc, test_config, auth, output_format):
         1.  Ensure the system is disconnected from RHC.
         2.  Run the 'rhc connect' command using the given authentication method and output format.
         3.  Verify that RHC reports being registered.
-        4.  Verify that the yggdrasil or rhcd service is active.
+        4.  Verify that the yggdrasil service is active.
         5.  Verify the command output based on the specified format (text or JSON).
     :expectedresults:
         1.  The system is successfully disconnected (if previously connected).
         2.  The 'rhc connect' command executes without error.
         3.  RHC indicates the system is registered.
-        4.  The yggdrasil/rhcd service is in an active state.
+        4.  The yggdrasil service is in an active state.
         5.  For text output, stdout contains "Connected to Red Hat Insights",
             "Connected to Red Hat Subscription Management",
-            "Activated the yggdrasil service" or "Activated the Remote Host Configuration daemon"
-            and "Successfully connected to Red Hat!".
+            "Activated the yggdrasil service", and "Successfully connected to Red Hat!".
             For JSON output, no specific assertions are made due to a known issue (CCT-1191).
      """
 
@@ -76,31 +75,15 @@ def test_connect(external_candlepin, rhc, test_config, auth, output_format):
     if output_format is None:
         assert "Connected to Red Hat Subscription Management" in result.stdout
         assert "Connected to Red Hat Insights" in result.stdout
+        assert "Activated the yggdrasil service" in result.stdout
+        assert "Successfully connected to Red Hat!" in result.stdout
+
     elif output_format == "json":
         pass
         # TODO: parse result.stdout, when CCT-1191 is fixed. It is not possible now, because
         #       "rhc connect --format json" prints JSON document to stderr (not stdout)
         # json_output = json.loads(result.stdout)
         # assert json_output["rhsm_connected"] is True
-
-    if pytest.service_name == "rhcd":
-        if output_format is None:
-            assert "Activated the Remote Host Configuration daemon" in result.stdout
-        elif output_format == "json":
-            pass
-            # TODO: parse result.stdout, when CCT-1191 is fixed
-    else:
-        if output_format is None:
-            assert "Activated the yggdrasil service" in result.stdout
-        elif output_format == "json":
-            pass
-            # TODO: parse result.stdout, when CCT-1191 is fixed
-
-    if output_format is None:
-        assert "Successfully connected to Red Hat!" in result.stdout
-    elif output_format == "json":
-        pass
-        # TODO: parse result.stdout, when CCT-1191 is fixed
 
 
 @pytest.mark.parametrize(
@@ -168,20 +151,20 @@ def test_connect_wrong_parameters(
         scenarios involving invalid credentials (wrong username/password or
         organization/activation key) and invalid parameter combinations (e.g.,
         using both username and activation key). It checks that the command fails
-        and the yggdrasil/rhcd service does not become active.
+        and the yggdrasil service does not become active.
     :tags:
     :steps:
         1.  Ensure the system is disconnected from RHC.
         2.  Run the 'rhc connect' command using invalid credentials or parameters,
             expecting it to fail.
         3.  Verify the command's return code.
-        4.  Verify that the yggdrasil/rhcd service is not active.
+        4.  Verify that the yggdrasil service is not active.
     :expectedresults:
         1.  The system is successfully disconnected (if previously connected).
         2.  The 'rhc connect' command fails.
         3.  The command's return code matches the expected non-zero value
             (or a specific code if provided).
-        4.  The yggdrasil/rhcd service is not in an active state.
+        4.  The yggdrasil service is not in an active state.
     """
 
     # An attempt to bring system in disconnected state in case it is not.
@@ -235,7 +218,7 @@ def test_rhc_worker_playbook_install_after_rhc_connect(
 
     start_date_time = datetime.now().strftime(
         "%Y-%m-%d %H:%M:%S"
-    )  # current date and time for observing yggdrasil/rhcd logs
+    )  # current date and time for observing yggdrasil logs
     command_args = prepare_args_for_connect(test_config, auth=auth)
     command = ["connect"] + command_args
     rhc.run(*command, check=False)
@@ -261,6 +244,6 @@ def test_rhc_worker_playbook_install_after_rhc_connect(
     pkg_version = sh.rpm("-qa", "rhc-worker-playbook")
     logger.info(f"successfully installed rhc_worker_playbook package {pkg_version}")
     logger.info(
-        f"time taken to start yggdrasil/rhcd service and install "
+        f"time taken to start yggdrasil service and install "
         f"rhc_worker_playbook : {total_runtime} s"
     )

--- a/integration-tests/test_disconnect.py
+++ b/integration-tests/test_disconnect.py
@@ -16,27 +16,26 @@ def test_rhc_disconnect(external_candlepin, rhc, test_config):
     """
     :id: 3eb1c32c-fff4-40ae-a659-8b2872d409bf
     :title: Verify that RHC disconnect command disconnects host from server
-        and deactivates yggdrasil/rhcd service
+        and deactivates yggdrasil service
     :description:
         Tests the 'rhc disconnect' command to ensure it unregisters the system
         and stops the associated service.
     :tags: Tier 1
     :steps:
         1.  Connect the system using rhc connect.
-        2.  Verify the system is registered and the yggdrasil/rhcd service is active.
+        2.  Verify the system is registered and the yggdrasil service is active.
         3.  Run the rhc disconnect command.
         4.  Verify the command exit code.
-        5.  Verify the system is no longer registered and the yggdrasil/rhcd service is inactive.
+        5.  Verify the system is no longer registered and the yggdrasil service is inactive.
         6.  Verify specific output strings in stdout.
     :expectedresults:
         1.  System connects successfully and is registered.
-        2.  The system is registered and the yggdrasil/rhcd service is active.
+        2.  The system is registered and the yggdrasil service is active.
         3.  The command executes.
         4.  The exit code is 0.
-        5.  The system is unregistered and the yggdrasil/rhcd service is inactive.
-        6.  Stdout contains "Deactivated the yggdrasil service" or "Deactivated
-            the Remote Host Configuration daemon", "Disconnected from Red Hat Insights",
-            and "Disconnected from Red Hat Subscription Management".
+        5.  The system is unregistered and the yggdrasil service is inactive.
+        6.  Stdout contains "Deactivated the yggdrasil service", "Disconnected from
+            Red Hat Insights", and "Disconnected from Red Hat Subscription Management".
     """
 
     # Connect first to perform disconnect operation
@@ -50,13 +49,7 @@ def test_rhc_disconnect(external_candlepin, rhc, test_config):
     assert disconnect_result.returncode == 0
     assert not rhc.is_registered
     assert not yggdrasil_service_is_active()
-    if pytest.service_name == "rhcd":
-        assert (
-            "Deactivated the Remote Host Configuration daemon"
-            in disconnect_result.stdout
-        )
-    else:
-        assert "Deactivated the yggdrasil service" in disconnect_result.stdout
+    assert "Deactivated the yggdrasil service" in disconnect_result.stdout
     assert "Disconnected from Red Hat Insights" in disconnect_result.stdout
     assert (
         "Disconnected from Red Hat Subscription Management" in disconnect_result.stdout
@@ -82,7 +75,7 @@ def test_disconnect_when_already_disconnected(rhc):
         2.  The command executes.
         3.  The exit code 0
         4.  The system is unregistered.
-        5.  Stdout contains "Deactivated the yggdrasil/rhcd service",
+        5.  Stdout contains "Deactivated the yggdrasil service",
             "The yggdrasil service is already inactive",
             "Already disconnected from Red Hat Insights",
             and "Already disconnected from Red Hat Subscription Management".

--- a/integration-tests/test_e2e.py
+++ b/integration-tests/test_e2e.py
@@ -25,21 +25,21 @@ def test_rhc_client_connect_e2e(rhc, test_config, auth, external_inventory, subm
     :description:
         This test verifies the end-to-end functionality of the RHC client connect command
         using both basic authentication and an activation key. It checks if the client
-        registers successfully, the yggdrasil/rhcd service starts, the host appears in Inventory,
+        registers successfully, the yggdrasil service starts, the host appears in Inventory,
         and the client ID in the system profile matches the subscription manager UUID.
     :tags:
     :steps:
         1.  Attempt to disconnect the RHC client to ensure a clean state.
         2.  Run the 'rhc connect' command with the prepared arguments.
         3.  Verify that the RHC client reports a registered status.
-        4.  Verify that the yggdrasil/rhcd service is running and active.
+        4.  Verify that the yggdrasil service is running and active.
         5.  Check if the system profile contains the 'rhc_client_id'.
         6.  Verify that the 'rhc_client_id' in the system profile matches the subscription manager UUID.
     :expectedresults:
         1.  The client is disconnected, or the action is suppressed if no connection exists.
         2.  The 'rhc connect' command executes successfully.
         3.  The RHC client status indicates registration.
-        4.  The yggdrasil/rhcd service is active.
+        4.  The yggdrasil service is active.
         5.  The 'rhc_client_id' field is present in the system profile.
         6.  The 'rhc_client_id' in the system profile is identical to the
             subscription manager UUID within the timeout period.

--- a/integration-tests/test_status.py
+++ b/integration-tests/test_status.py
@@ -24,19 +24,19 @@ def test_status_connected(external_candlepin, rhc, test_config):
     :tags: Tier 1
     :steps:
         1.  Connect the system using 'rhc connect'.
-        2.  Ensure the yggdrasil/rhcd service is active.
+        2.  Ensure the yggdrasil service is active.
         3.  Run the 'rhc status' command.
         4.  Verify the command exit code.
         5.  Verify specific strings are present in the standard output
-            indicating connectivity and yggdrasil/rhcd service status.
+            indicating connectivity and yggdrasil service status.
     :expectedresults:
         1.  RHC connects successfully.
-        2.  The yggdrasil/rhcd service is active.
+        2.  The yggdrasil service is active.
         3.  The 'rhc status' command executes successfully.
         4.  The exit code is 0.
         5.  The output contains "Connected to Red Hat Subscription Management",
             "Connected to Red Hat Insights", "Red Hat repository file generated",
-            and "The yggdrasil service is active" or "The Remote Host Configuration daemon is active".
+            and "The yggdrasil service is active".
     """
 
     rhc.connect(
@@ -49,10 +49,7 @@ def test_status_connected(external_candlepin, rhc, test_config):
     assert "Connected to Red Hat Subscription Management" in status_result.stdout
     assert "Red Hat repository file generated" in status_result.stdout
     assert "Connected to Red Hat Insights" in status_result.stdout
-    if pytest.service_name == "rhcd":
-        assert "The Remote Host Configuration daemon is active" in status_result.stdout
-    else:
-        assert "The yggdrasil service is active" in status_result.stdout
+    assert "The yggdrasil service is active" in status_result.stdout
 
 
 def test_status_connected_format_json(external_candlepin, rhc, test_config):
@@ -76,7 +73,7 @@ def test_status_connected_format_json(external_candlepin, rhc, test_config):
         3.  The exit code is 0.
         4.  The output is a valid JSON document.
         5.  The JSON contains 'hostname', 'rhsm_connected' (true), 'content_enabled' (true),
-            'insights_connected' (true), and 'rhcd_running' or 'yggdrasil_running' (true)
+            'insights_connected' (true), and 'yggdrasil_running' (true)
             with correct boolean types.
     """
 
@@ -97,14 +94,9 @@ def test_status_connected_format_json(external_candlepin, rhc, test_config):
     assert "insights_connected" in status_json
     assert type(status_json["insights_connected"]) == bool
     assert status_json["insights_connected"] == True
-    if pytest.service_name == "rhcd":
-        assert "rhcd_running" in status_json
-        assert type(status_json["rhcd_running"]) == bool
-        assert status_json["rhcd_running"] == True
-    else:
-        assert "yggdrasil_running" in status_json
-        assert type(status_json["yggdrasil_running"]) == bool
-        assert status_json["yggdrasil_running"] == True
+    assert "yggdrasil_running" in status_json
+    assert type(status_json["yggdrasil_running"]) == bool
+    assert status_json["yggdrasil_running"] == True
 
 
 def test_status_disconnected_format_json(external_candlepin, rhc, test_config):
@@ -128,7 +120,7 @@ def test_status_disconnected_format_json(external_candlepin, rhc, test_config):
         3.  The exit code is not 0.
         4.  The output is a valid JSON document.
         5.  The JSON contains 'hostname', 'rhsm_connected' (false), 'content_enabled' (false),
-            'insights_connected' (false), and 'rhcd_running' or 'yggdrasil_running' (false)
+            'insights_connected' (false), and 'yggdrasil_running' (false)
             with correct boolean types.
     """
 
@@ -146,14 +138,9 @@ def test_status_disconnected_format_json(external_candlepin, rhc, test_config):
     assert "insights_connected" in status_json
     assert type(status_json["insights_connected"]) == bool
     assert status_json["insights_connected"] == False
-    if pytest.service_name == "rhcd":
-        assert "rhcd_running" in status_json
-        assert type(status_json["rhcd_running"]) == bool
-        assert status_json["rhcd_running"] == False
-    else:
-        assert "yggdrasil_running" in status_json
-        assert type(status_json["yggdrasil_running"]) == bool
-        assert status_json["yggdrasil_running"] == False
+    assert "yggdrasil_running" in status_json
+    assert type(status_json["yggdrasil_running"]) == bool
+    assert status_json["yggdrasil_running"] == False
 
 
 @pytest.mark.tier1
@@ -164,7 +151,7 @@ def test_status_disconnected(rhc):
     :description:
         This test verifies the output of the 'rhc status' command when the host
         is disconnected from Red Hat Subscription Management and Red Hat Insights,
-        and the yggdrasil/rhcd service is inactive.
+        and the yggdrasil service is inactive.
     :reference: https://issues.redhat.com/browse/CCT-525
     :tags: Tier 1
     :steps:
@@ -178,7 +165,7 @@ def test_status_disconnected(rhc):
         3.  The exit code is not 0.
         4.  The status command output contains "Not connected to Red Hat Subscription Management",
             "Red Hat repository file not generated", "Not connected to Red Hat Insights",
-            and a message indicating that the yggdrasil/rhcd service is inactive.
+            and a message indicating that the yggdrasil service is inactive.
     """
 
     # 'rhc disconnect' to ensure system is already disconnected
@@ -188,10 +175,7 @@ def test_status_disconnected(rhc):
     assert "Not connected to Red Hat Subscription Management" in status_result.stdout
     assert "Red Hat repository file not generated" in status_result.stdout
     assert "Not connected to Red Hat Insights" in status_result.stdout
-    if pytest.service_name == "rhcd":
-        assert "The Remote Host Configuration daemon is active" in status_result.stdout
-    else:
-        assert "The yggdrasil service is inactive" in status_result.stdout
+    assert "The yggdrasil service is inactive" in status_result.stdout
 
 
 @pytest.fixture
@@ -229,7 +213,7 @@ def test_status_connected_rhsm_masked(external_candlepin, rhc, test_config):
         4.  The exit code is not 0 because there were errors.
         5.  The status command output contains "Could not activate remote peer",
             "Connected to Red Hat Insights", and a message indicating
-            that the yggdrasil/rhcd service is active.
+            that the yggdrasil service is active.
         6.  The 'rhsm.service' is unmasked.
     """
 
@@ -279,7 +263,7 @@ def test_status_disconnected_rhsm_masked(rhc):
         4.  The exit code is not 0.
         5.  The status command output contains "Could not activate remote peer",
             "Not connected to Red Hat Insights", and a message indicating
-            that the yggdrasil/rhcd service is inactive.
+            that the yggdrasil service is inactive.
         6.  The 'rhsm.service' is unmasked.
     """
 
@@ -322,7 +306,7 @@ def test_status_disconnected_rhsm_masked_format_json(rhc):
         4.  The exit code is not 0.
         5.  The output is a valid JSON document.
         6.  The JSON contains 'hostname', 'rhsm_connected' (false), 'content_enabled' (false),
-            'insights_connected' (false), and 'rhcd_running' or 'yggdrasil_running' (false)
+            'insights_connected' (false), and 'yggdrasil_running' (false)
             with correct boolean types. It also contains 'rhsm_error' and 'content_error' messages.
         7.  The 'rhsm.service' is unmasked.
     """
@@ -361,7 +345,7 @@ def test_status_disconnected_rhsm_masked_format_json(rhc):
     assert type(status_json["insights_connected"]) == bool
     assert status_json["insights_connected"] == False
 
-    # yggdrasil/rhcd
+    # yggdrasil
     assert "yggdrasil_running" in status_json
     assert type(status_json["yggdrasil_running"]) == bool
     assert status_json["yggdrasil_running"] == False
@@ -427,6 +411,7 @@ def test_status_connected_yggdrasil_masked(external_candlepin, rhc, test_config)
     assert not yggdrasil_service_is_active()
     assert "Unit yggdrasil.service is masked" in status_result.stdout
 
+
 @pytest.mark.tier1
 @pytest.mark.usefixtures("unmask_yggdrasil_service")
 def test_status_connected_yggdrasil_masked_format_json(external_candlepin, rhc, test_config):
@@ -488,53 +473,49 @@ def test_status_connected_yggdrasil_masked_format_json(external_candlepin, rhc, 
     assert type(status_json["yggdrasil_error"]) == str
     assert "Unit yggdrasil.service is masked" in status_json["yggdrasil_error"]
 
-@pytest.mark.skipif(
-    pytest.service_name != "rhcd",
-    reason="This test only supports restart of rhcd and not yggdrasil",
-)
-def test_rhcd_service_restart(external_candlepin, rhc, test_config):
+
+def test_yggdrasil_service_restart(external_candlepin, rhc, test_config):
     """
     :id: 92dbb5e7-c16c-4f5f-9c33-84e9e1269dde
-    :title: Verify rhcd service restart functionality
+    :title: Verify yggdrasil service restart functionality
     :description:
-        This test verifies that the rhcd service can be successfully restarted
+        This test verifies that the yggdrasil service can be successfully restarted
         when the system is connected and that its status is correctly reflected
-        after restart. This test is specifically for the 'rhcd' service and skips
-        if the service name is not 'rhcd'.
+        after restart.
     :tags:
     :steps:
         1. Disconnect the system using 'rhc disconnect' to ensure a clean state.
-        2. Restart the rhcd service using 'systemctl restart rhcd'.
+        2. Restart the yggdrasil service using 'systemctl restart yggdrasil'.
         3. Connect the system using 'rhc connect'.
-        4. Restart the rhcd service again using 'systemctl restart rhcd'.
+        4. Restart the yggdrasil service again using 'systemctl restart yggdrasil'.
     :expectedresults:
         1. RHC disconnects successfully.
-        2. The rhcd service restarts successfully, and it's inactive.
+        2. The yggdrasil service restarts successfully, and it's inactive.
         3. The system connects successfully and is registered.
-        4. The rhcd service restarts successfully, and it's active.
+        4. The yggdrasil service restarts successfully, and it's active.
     """
 
     # 'rhc disconnect' to ensure system is already disconnected
     rhc.run("disconnect", check=False)
-    util.logged_run("systemctl status rhcd --no-pager".split())
+    util.logged_run("systemctl status yggdrasil --no-pager".split())
     try:
 
-        util.logged_run("systemctl restart rhcd".split())
+        util.logged_run("systemctl restart yggdrasil".split())
         assert not yggdrasil_service_is_active()
     except AssertionError as exc:
-        # for debugging lets check current state of rhcd service
-        util.logged_run("systemctl status rhcd --no-pager".split())
+        # for debugging lets check current state of yggdrasil service
+        util.logged_run("systemctl status yggdrasil --no-pager".split())
         raise exc
 
-    # test rhcd service restart on a connected system
+    # test yggdrasil service restart on a connected system
     rhc.connect(
         username=test_config.get("candlepin.username"),
         password=test_config.get("candlepin.password"),
     )
     assert rhc.is_registered
     try:
-        util.logged_run("systemctl restart rhcd".split())
+        util.logged_run("systemctl restart yggdrasil".split())
         assert yggdrasil_service_is_active()
     except AssertionError as exc:
-        util.logged_run("systemctl status rhcd --no-pager".split())
+        util.logged_run("systemctl status yggdrasil --no-pager".split())
         raise exc

--- a/integration-tests/utils/__init__.py
+++ b/integration-tests/utils/__init__.py
@@ -1,14 +1,12 @@
-import pytest
 import sh
 
 
 def yggdrasil_service_is_active():
-    """Method to verify if yggdrasil/rhcd is in active/inactive state
-    :return: True if yggdrasil/rhcd in active state else False
-    Note: upstream name of service is yggdrasil and downstream is rhcd
+    """Method to verify if yggdrasil is in active/inactive state
+    :return: True if yggdrasil in active state else False
     """
     try:
-        stdout = sh.systemctl(f"is-active {pytest.service_name}".split()).strip()
+        stdout = sh.systemctl(f"is-active yggdrasil".split()).strip()
         return stdout == "active"
     except sh.ErrorReturnCode_3:
         return False
@@ -22,12 +20,11 @@ def check_yggdrasil_journalctl_logs(
     :param since_datetime: start time for logs
     :param must_exist_in_log: True if str_to_check should exist in log else false
     :return: True/False
-    Note: upstream name of service is yggdrasil and downstream is rhcd
     """
     if since_datetime:
-        logs = sh.journalctl("-u", pytest.service_name, "--since", since_datetime)
+        logs = sh.journalctl("-u", "yggdrasil", "--since", since_datetime)
     else:
-        logs = sh.journalctl("-u", pytest.service_name)
+        logs = sh.journalctl("-u", "yggdrasil")
 
     if must_exist_in_log:
         return str_to_check in logs


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/CCT-1558

This PR removes all `rhcd service` related code and docstrings, as RHEL10 (rhc main branch) only uses the `yggdrasil service`.