### PR TITLE
chore(ci): Update GitHub testing matrix of golang

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.23", "1.24"]
+        go: ["1.24", "1.25"]
     steps:
       - name: Updating ...
         run: sudo apt-get -qq update


### PR DESCRIPTION
* Drop testing of golang 1.23 and start to test golang 1.25, because only two last minor versions of Go are supported. More details here: https://go.dev/doc/devel/release#policy
* When you install golang on RHEL-10.0, then 1.24.6 is installed. When you install golang on CentOS Stream 10, then 1.25.0 is installed