### PR TITLE
chore: Move rhsm.go to own internal module

### DIFF
--- a/connect_cmd.go
+++ b/connect_cmd.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/redhatinsights/rhc/internal/rhsm"
 	"github.com/urfave/cli/v2"
 
 	"github.com/redhatinsights/rhc/internal/datacollection"
@@ -71,7 +72,7 @@ func beforeConnectAction(ctx *cli.Context) error {
 	configureUI(ctx)
 
 	// When machine is already connected, then return error
-	uuid, err := getConsumerUUID()
+	uuid, err := rhsm.GetConsumerUUID()
 	if err != nil {
 		return cli.Exit(
 			fmt.Sprintf("unable to get consumer UUID: %s", err),
@@ -221,7 +222,7 @@ func connectAction(ctx *cli.Context) error {
 	/* 1. Register to RHSM, because we need to get consumer certificate. This blocks following action */
 	start = time.Now()
 	var returnedMsg string
-	returnedMsg, err = registerRHSM(ctx, ContentFeature.Enabled)
+	returnedMsg, err = rhsm.RegisterRHSM(ctx, ContentFeature.Enabled)
 	if err != nil {
 		connectResult.RHSMConnected = false
 		errorMessages["rhsm"] = LogMessage{

--- a/disconnect_cmd.go
+++ b/disconnect_cmd.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/redhatinsights/rhc/internal/rhsm"
 	"github.com/urfave/cli/v2"
 
 	"github.com/redhatinsights/rhc/internal/datacollection"
@@ -124,7 +125,7 @@ func disconnectInsightsClient(disconnectResult *DisconnectResult, errorMessages 
 // disconnectRHSM tries to unregister system from RHSM if the client hasn't been already
 // unregistered from RHSM
 func disconnectRHSM(disconnectResult *DisconnectResult, errorMessages *map[string]LogMessage) error {
-	isRegistered, err := isRHSMRegistered()
+	isRegistered, err := rhsm.IsRHSMRegistered()
 	if err != nil {
 		return err
 	}
@@ -135,7 +136,7 @@ func disconnectRHSM(disconnectResult *DisconnectResult, errorMessages *map[strin
 		return nil
 	}
 	err = ui.Spinner(
-		unregister,
+		rhsm.Unregister,
 		ui.Indent.Small,
 		"Disconnecting from Red Hat Subscription Management...",
 	)

--- a/status_cmd.go
+++ b/status_cmd.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/godbus/dbus/v5"
+	"github.com/redhatinsights/rhc/internal/rhsm"
 	"github.com/urfave/cli/v2"
 
 	"github.com/briandowns/spinner"
@@ -24,7 +25,7 @@ import (
 // structure and content of this structure will be printed later
 func rhsmStatus(systemStatus *SystemStatus) error {
 
-	uuid, err := getConsumerUUID()
+	uuid, err := rhsm.GetConsumerUUID()
 	if err != nil {
 		systemStatus.returnCode += 1
 		systemStatus.RHSMError = err.Error()
@@ -69,10 +70,10 @@ func isContentEnabled(systemStatus *SystemStatus) error {
 		locale).Store(&contentEnabled); err != nil {
 		systemStatus.returnCode += 1
 		systemStatus.ContentError = err.Error()
-		return unpackRHSMError(err)
+		return rhsm.UnpackDBusError(err)
 	}
 
-	uuid, err := getConsumerUUID()
+	uuid, err := rhsm.GetConsumerUUID()
 	if err != nil {
 		systemStatus.returnCode += 1
 		systemStatus.ContentError = err.Error()


### PR DESCRIPTION
* Card ID: CCT-1590
* Moved the rhsm.go to internal/rhsm/rhsm.go
* Renamed some functions to be available as API
* No functional change