### PR TITLE
chore: Move canonical facts to own internal package

### DIFF
--- a/canonical_facts_cmd.go
+++ b/canonical_facts_cmd.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/redhatinsights/rhc/internal/canonical_facts"
 	"github.com/urfave/cli/v2"
 )
 
@@ -11,7 +12,7 @@ import (
 // and it prints JSON with facts to stdout.
 func canonicalFactAction(_ *cli.Context) error {
 	// NOTE: CLI context is not useful for anything
-	facts, err := GetCanonicalFacts()
+	facts, err := canonical_facts.GetCanonicalFacts()
 	if err != nil {
 		return cli.Exit(fmt.Errorf("cannot generate canonical facts: %v", err), 1)
 	}

--- a/internal/canonical_facts/canonical_facts.go
+++ b/internal/canonical_facts/canonical_facts.go
@@ -1,4 +1,4 @@
-package main
+package canonical_facts
 
 import (
 	"crypto/x509"

--- a/internal/canonical_facts/canonical_facts_test.go
+++ b/internal/canonical_facts/canonical_facts_test.go
@@ -1,4 +1,4 @@
-package main
+package canonical_facts
 
 import (
 	"encoding/json"


### PR DESCRIPTION
* Card ID: CCT-1591
* Moved canonical_facts.go and canonical_facts_test.go to ./internal/canonical_facts/
* Modified usage of package accordingly
* No functional changes