### PR TITLE
test(fix): Install insights-client for integration tests

### DIFF
--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -7,7 +7,7 @@ cd ../../../
 # Check for bootc/image-mode deployments which should not run dnf
 if ! command -v bootc >/dev/null || bootc status | grep -q 'type: null'; then
   dnf --setopt install_weak_deps=False install -y \
-    podman git-core python3-pip python3-pytest logrotate
+    podman git-core python3-pip python3-pytest logrotate insights-client
 fi
 
 


### PR DESCRIPTION
This change adds insights-client as a dependency in the testing environment to prevent failures in downstream Jenkins jobs. Testing Farm occasionally provides composed environments without insights-client pre-installed, causing tests to fail. Explicitly installing it ensures our testing remains consistent and reliable.