### PR TITLE
chore(ci): Fix meson build system

### DIFF
--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Try to go to MESON_DIST_ROOT if this env. variable is defined
+# and the directory exists
+if [[ -n "${MESON_DIST_ROOT}" && -d "${MESON_DIST_ROOT}" ]]; then
 pushd "${MESON_DIST_ROOT}" || exit 1
+fi
+
 go mod vendor
+
+if [[ -n "${MESON_DIST_ROOT}" && -d "${MESON_DIST_ROOT}" ]]; then
 popd || exit 1
+fi


### PR DESCRIPTION
* The authors of meson just decided to change behavior of
https://mesonbuild.com/Reference-manual_builtin_meson.html#mesonadd_dist_script
  The `MESON_DIST_ROOT` is just not set in this script.
  This change is not mentioned in the documentation
* This should change our CI testing of builds and integration tests