### PR TITLE
[release-0.2] feat(ci): using tmt to install test dependencies for image mode, removed

### DIFF
--- a/systemtest/Containerfile
+++ b/systemtest/Containerfile
@@ -1,0 +1,6 @@
+ARG IMAGE=images.paas.redhat.com/testingfarm/rhel-bootc:9.8
+FROM $IMAGE
+
+COPY install-test-deps.sh /install-test-deps.sh
+RUN sh /install-test-deps.sh
+RUN touch /test-deps-installed

--- a/systemtest/install-test-deps.sh
+++ b/systemtest/install-test-deps.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -ux
+
+source /etc/os-release
+
+# packages to install
+packages=(
+  "git-core"
+  "logrotate"
+  "man-db"
+  "podman"
+  "python3-pip"
+  "python3-pytest"
+  "rhc"
+)
+
+if [ "$ID" == "rhel" ]; then
+  packages+=(
+    "insights-client"
+  )
+fi
+
+get_image_name() {
+  if command -v jq > /dev/null; then
+    IMAGE=$(bootc status --format=json | jq -r '.status.booted.image.image.image')
+  else
+    IMAGE=$(bootc status --format=humanreadable | grep 'Booted image' | cut -d' ' -f 4)
+  fi
+  echo "$IMAGE"
+}
+
+is_bootc() {
+  command -v bootc > /dev/null &&
+    ! bootc status --format=humanreadable | grep -q 'System is not deployed via bootc'
+}
+
+if is_bootc; then
+  echo "info: running in bootc/image-mode, preparing new image"
+  IMAGE=$(get_image_name)
+  echo "info: current image is $IMAGE"
+
+  (podman pull $IMAGE || podman pull containers-storage:$IMAGE) || bootc image copy-to-storage --target $IMAGE
+  podman build --build-arg IMAGE=$IMAGE -t localhost/rhc-test:latest -f Containerfile systemtest/
+
+  echo "info: switching to new bootc image and rebooting"
+  bootc switch --transport containers-storage localhost/rhc-test:latest
+else
+  echo "info: installing dependencies"
+  dnf --setopt install_weak_deps=False install -y ${packages[@]}
+  echo "info: dependencies installed successfully"
+fi

--- a/systemtest/plans/main.fmf
+++ b/systemtest/plans/main.fmf
@@ -1,6 +1,17 @@
 summary: rhc test suite
+prepare:
+  - name: install test dependencies
+    how: shell
+    script: ./systemtest/install-test-deps.sh
+
 discover:
-    how: fmf
+  - how: shell
+    tests:
+      - name: check for image mode reboot
+        test: ./systemtest/prepare-reboot.sh
+        duration: 20m
+
+  - how: fmf
 
 execute:
-    how: tmt
+  how: tmt

--- a/systemtest/prepare-reboot.sh
+++ b/systemtest/prepare-reboot.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -x
+
+is_bootc() {
+  command -v bootc > /dev/null &&
+    ! bootc status --format=humanreadable | grep -q 'System is not deployed via bootc'
+}
+
+if is_bootc; then
+  if [ ! -f /test-deps-installed ]; then
+    echo "info: marking test dependencies as installed to prevent reboot loop"
+    tmt-reboot
+  else
+    echo "info: test dependencies already marked as installed"
+  fi
+else
+  echo "info: not a bootc system, skipping post-reboot setup"
+fi

--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -4,18 +4,79 @@ set -ux
 # get to project root
 cd ../../../
 
-# Check for bootc/image-mode deployments which should not run dnf
-if ! command -v bootc >/dev/null || bootc status | grep -q 'type: null'; then
-  dnf --setopt install_weak_deps=False install -y \
-    podman git-core python3-pip python3-pytest logrotate insights-client
+# Read information about release from standard release file
+if [[ -f "/etc/os-release" ]]; then
+  source /etc/os-release
 fi
 
+function mock_insights_client() {
+  # Create configuration directory, when it does not exists
+  if [[ ! -d "/etc/insights-client/" ]]; then
+    mkdir -p /etc/insights-client/
+  fi
+  # Create empty configuration file
+  if [[ ! -f "/etc/insights-client/insights-client.conf" ]]; then
+    touch /etc/insights-client/insights-client.conf
+  fi
 
-# TEST_RPMS is set in jenkins jobs after parsing CI Messages in gating Jobs.
-# If TEST_RPMS is set then install the RPM builds for gating.
-if [[ -v TEST_RPMS ]]; then
-	echo "Installing RPMs: ${TEST_RPMS}"
-	dnf -y install --allowerasing ${TEST_RPMS}
+  # Create a mock of insights-client.
+  #
+  # To mimic behavior of original client we return 0, when
+  # the system is registered (the consumer cert is installed)
+  # Otherwise, it returns non-zero value. The original
+  # insights-client also creates hidden files in
+  # the /etc/insights-client directory. When the insights-client
+  # is registered, then there is .registered file, and when
+  # the insights-client is unregistered, then there is
+  # .unregistered file. This behavior should be enough
+  # to make rhc happy.
+  if [[ ! -f "/bin/insights-client" ]]; then
+    cat >/bin/insights-client << 'EOF'
+#!/bin/bash
+
+if [[ -f /etc/pki/consumer/cert.pem ]]
+then
+	touch /etc/insights-client/.registered
+	rm -f /etc/insights-client/.unregistered
+	exit 0
+else
+	touch /etc/insights-client/.unregistered
+	rm -f /etc/insights-client/.registered
+	exit 1
+fi
+EOF
+    chmod a+x /bin/insights-client
+  fi
+}
+
+is_bootc() {
+  command -v bootc > /dev/null && \
+  ! bootc status --format=humanreadable | grep -q 'System is not deployed via bootc'
+}
+
+if is_bootc; then
+  echo "System is deployed via bootc, skipping dnf install"
+else
+  # In most cases these should already be installed by tmt, see systemtest/plans/main.fmf
+  # This is for running this script without tmt.
+  dnf --setopt install_weak_deps=False install -y \
+    podman git-core python3-pip python3-pytest logrotate
+
+  if [[ "${ID}" = "fedora" ]]; then
+    # Do not try to install insights-client on Fedora, because it cannot be installed there.
+    # Try to only mock insights-client to be able to test behavior of rhc on Fedora.
+    mock_insights_client
+  else
+    # Try to install insights-client on other Linux distributions
+    dnf --setopt install_weak_deps=False install -y insights-client
+  fi
+
+  # TEST_RPMS is set in jenkins jobs after parsing CI Messages in gating Jobs.
+  # If TEST_RPMS is set then install the RPM builds for gating.
+  if [[ -v TEST_RPMS ]]; then
+    echo "Installing RPMs: ${TEST_RPMS}"
+    dnf -y install --allowerasing ${TEST_RPMS}
+  fi
 fi
 
 python3 -m venv venv


### PR DESCRIPTION
unused downstream PR job logic, skipping man page tests if they're not installed.

Card: CCT-1744
cherry pick of: https://github.com/RedHatInsights/rhc/pull/290

Will be in draft until that PR has been settled.