### PR TITLE
chore(ci): Fedora: insights-client is only recommended

### DIFF
--- a/dist/srpm/rhc.spec.in
+++ b/dist/srpm/rhc.spec.in
@@ -63,7 +63,11 @@ License: GPL-3.0-only
 URL:     %{gourl}
 Source0: %{gosource}
 
+%if 0%{?fedora}
+Recommends:    insights-client
+%else
 Requires:      insights-client
+%endif
 Requires:      yggdrasil >= 0.4
 Requires:      yggdrasil-worker-package-manager
 Requires:      subscription-manager


### PR DESCRIPTION
* Make the `insights-client` RPM only recommended on the Fedora, because required RPM package `insights-core` (required by `insights-client`) is not available on the Fedora ATM.