### PR TITLE
feat: support logging to systemd journal

### DIFF
--- a/cmd/rhc/interactive.go
+++ b/cmd/rhc/interactive.go
@@ -27,22 +27,24 @@ func showTimeDuration(durations map[string]time.Duration) {
 }
 
 // showErrorMessages shows table with all error messages gathered during action
-func showErrorMessages(action string, errorMessages map[string]LogMessage) error {
-	if hasPriorityErrors(errorMessages, conf.Config.LogLevel) {
-		if !ui.IsOutputMachineReadable() {
-			fmt.Println()
-			fmt.Printf("The following errors were encountered during %s:\n\n", action)
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-			_, _ = fmt.Fprintln(w, "TYPE\tSTEP\tERROR\t")
-			for step, logMsg := range errorMessages {
-				if logMsg.level >= conf.Config.LogLevel {
-					_, _ = fmt.Fprintf(w, "%v\t%v\t%v\n", logMsg.level, step, logMsg.message)
-				}
-			}
-			_ = w.Flush()
-			if hasPriorityErrors(errorMessages, slog.LevelError) {
-				return cli.Exit("", 1)
-			}
+func showErrorMessages(action string, errorMessages map[string]string) error {
+	if conf.Config.LogLevel > slog.LevelError || len(errorMessages) == 0 {
+		return nil
+	}
+	if !ui.IsOutputMachineReadable() {
+		fmt.Println()
+		fmt.Printf("The following errors were encountered during %s:\n\n", action)
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(w, "STEP\tERROR\t")
+		for step, errMsg := range errorMessages {
+			_, _ = fmt.Fprintf(w, "%v\t%v\n", step, errMsg)
+		}
+		_ = w.Flush()
+		// Direct users to the journal for full details
+		fmt.Println()
+		fmt.Println("Please see 'journalctl -t rhc' for full details.")
+		if len(errorMessages) > 0 {
+			return cli.Exit("", 1)
 		}
 	}
 	return nil

--- a/cmd/rhc/interactive.go
+++ b/cmd/rhc/interactive.go
@@ -28,24 +28,20 @@ func showTimeDuration(durations map[string]time.Duration) {
 
 // showErrorMessages shows table with all error messages gathered during action
 func showErrorMessages(action string, errorMessages map[string]string) error {
-	if conf.Config.LogLevel > slog.LevelError || len(errorMessages) == 0 {
+	if ui.IsOutputMachineReadable() || len(errorMessages) == 0 {
 		return nil
 	}
-	if !ui.IsOutputMachineReadable() {
-		fmt.Println()
-		fmt.Printf("The following errors were encountered during %s:\n\n", action)
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		_, _ = fmt.Fprintln(w, "STEP\tERROR\t")
-		for step, errMsg := range errorMessages {
-			_, _ = fmt.Fprintf(w, "%v\t%v\n", step, errMsg)
-		}
-		_ = w.Flush()
-		// Direct users to the journal for full details
-		fmt.Println()
-		fmt.Println("Please see 'journalctl -t rhc' for full details.")
-		if len(errorMessages) > 0 {
-			return cli.Exit("", 1)
-		}
+
+	fmt.Println()
+	fmt.Printf("The following errors were encountered during %s:\n\n", action)
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "STEP\tERROR\t")
+	for step, errMsg := range errorMessages {
+		_, _ = fmt.Fprintf(w, "%v\t%v\n", step, errMsg)
 	}
-	return nil
+	_ = w.Flush()
+	// Direct users to the journal for full details
+	fmt.Println()
+	fmt.Println("Please see 'journalctl -t rhc' for full details.")
+	return cli.Exit("", 1)
 }

--- a/cmd/rhc/logging.go
+++ b/cmd/rhc/logging.go
@@ -2,9 +2,45 @@ package main
 
 import (
 	"log/slog"
+	"strings"
+
+	"github.com/coreos/go-systemd/v22/journal"
+	slogjournal "github.com/systemd/slog-journal"
 )
 
-type LogMessage struct {
-	level   slog.Level
-	message error
+// setupJournalLogging configures slog to write to the systemd journal
+// instead of stdout/stderr. This allows detailed logging while keeping
+// the CLI output clean and user-friendly.
+func setupJournalLogging(level slog.Level) error {
+	// Create a journal handler that writes to systemd journal
+	// The syslog identifier "rhc" will be used, allowing filtering with:
+	// journalctl -t rhc
+	handler, err := slogjournal.NewHandler(&slogjournal.Options{
+		Level: level,
+		ReplaceGroup: func(k string) string {
+			// Convert group names to uppercase, replace hyphens with underscores,
+			// and prefix with RHC_
+			return strings.ReplaceAll(strings.ToUpper(k), "-", "_")
+		},
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			// Convert attribute keys to uppercase, replace hyphens with underscores,
+			// and prefix with RHC_ for application-specific namespace isolation
+			a.Key = strings.ReplaceAll(strings.ToUpper(a.Key), "-", "_")
+			return a
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	// Set the default logger to use the journal handler
+	logger := slog.New(handler)
+	slog.SetDefault(logger)
+
+	return nil
+}
+
+// isJournalAvailable checks if systemd journal is available on the system
+func isJournalAvailable() bool {
+	return journal.Enabled()
 }

--- a/cmd/rhc/status_cmd.go
+++ b/cmd/rhc/status_cmd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"reflect"
 	"time"
@@ -24,6 +25,7 @@ import (
 // output in machine-readable format, then we only set files in SystemStatus
 // structure and content of this structure will be printed later
 func rhsmStatus(systemStatus *SystemStatus) error {
+	slog.Info("Checking status of Red Hat Subscription Management")
 
 	uuid, err := rhsm.GetConsumerUUID()
 	if err != nil {
@@ -34,17 +36,14 @@ func rhsmStatus(systemStatus *SystemStatus) error {
 	if uuid == "" {
 		systemStatus.returnCode += 1
 		systemStatus.RHSMConnected = false
-		ui.Printf(
-			"%s[ ] Not connected to Red Hat Subscription Management\n",
-			ui.Indent.Small,
-		)
+		warnMsg := "Not connected to Red Hat Subscription Management"
+		slog.Warn(warnMsg)
+		ui.Printf("%s[ ] %v\n", ui.Indent.Small, warnMsg)
 	} else {
 		systemStatus.RHSMConnected = true
-		ui.Printf(
-			"%s[%v] Connected to Red Hat Subscription Management\n",
-			ui.Indent.Small,
-			ui.Icons.Ok,
-		)
+		infoMsg := "Connected to Red Hat Subscription Management"
+		slog.Info(infoMsg)
+		ui.Printf("%s[%v] %v\n", ui.Indent.Small, ui.Icons.Ok, infoMsg)
 	}
 	return nil
 }
@@ -53,6 +52,8 @@ func rhsmStatus(systemStatus *SystemStatus) error {
 // and get the manage_repos option from the section [rhsm]. If the option is equal
 // to "1", then content is managed by subscription-manager/RHSM
 func isContentEnabled(systemStatus *SystemStatus) error {
+	slog.Info("Checking content status")
+
 	conn, err := dbus.SystemBus()
 	if err != nil {
 		return fmt.Errorf("cannot connect to system D-Bus: %w", err)
@@ -82,23 +83,19 @@ func isContentEnabled(systemStatus *SystemStatus) error {
 
 	if contentEnabled == "1" && uuid != "" {
 		systemStatus.ContentEnabled = true
-		ui.Printf(
-			"%s[%v] Content ... Red Hat repository file generated\n",
-			ui.Indent.Medium,
-			ui.Icons.Ok,
-		)
+		infoMsg := "Red Hat repository file generated"
+		slog.Info(infoMsg)
+		ui.Printf("%s[%v] Content ... %v\n", ui.Indent.Medium, ui.Icons.Ok, infoMsg)
 	} else {
 		systemStatus.ContentEnabled = false
 		if uuid != "" {
-			ui.Printf(
-				"%s[ ] Content ... Generating of Red Hat repository file disabled in rhsm.conf\n",
-				ui.Indent.Medium,
-			)
+			warnMsg := "Generating of Red Hat repository file disabled in rhsm.conf"
+			slog.Warn(warnMsg)
+			ui.Printf("%s[ ] Content ... %v\n", ui.Indent.Medium, warnMsg)
 		} else {
-			ui.Printf(
-				"%s[ ] Content ... Red Hat repository file not generated\n",
-				ui.Indent.Medium,
-			)
+			warnMsg := "Red Hat repository file not generated"
+			slog.Warn(warnMsg)
+			ui.Printf("%s[ ] Content ... %v\n", ui.Indent.Medium, warnMsg)
 		}
 	}
 	return nil
@@ -106,6 +103,8 @@ func isContentEnabled(systemStatus *SystemStatus) error {
 
 // insightStatus tries to print status of insights client
 func insightStatus(systemStatus *SystemStatus) error {
+	slog.Info("Checking status of Red Hat Insights")
+
 	var s *spinner.Spinner
 	if ui.IsOutputRich() {
 		s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
@@ -119,19 +118,16 @@ func insightStatus(systemStatus *SystemStatus) error {
 	}
 	if isRegistered {
 		systemStatus.InsightsConnected = true
-		ui.Printf(
-			"%s[%v] Analytics ... Connected to Red Hat Insights\n",
-			ui.Indent.Medium,
-			ui.Icons.Ok,
-		)
+		infoMsg := "Connected to Red Hat Insights"
+		slog.Info(infoMsg)
+		ui.Printf("%s[%v] Analytics ... %v\n", ui.Indent.Medium, ui.Icons.Ok, infoMsg)
 	} else {
 		systemStatus.returnCode += 1
 		if err == nil {
 			systemStatus.InsightsConnected = false
-			ui.Printf(
-				"%s[ ] Analytics ... Not connected to Red Hat Insights\n",
-				ui.Indent.Medium,
-			)
+			warnMsg := "Not connected to Red Hat Insights"
+			slog.Warn(warnMsg)
+			ui.Printf("%s[ ] Analytics ... %v\n", ui.Indent.Medium, warnMsg)
 		} else {
 			systemStatus.InsightsConnected = false
 			systemStatus.InsightsError = err.Error()
@@ -143,6 +139,8 @@ func insightStatus(systemStatus *SystemStatus) error {
 
 // serviceStatus tries to print status of yggdrasil.service or rhcd.service
 func serviceStatus(systemStatus *SystemStatus) error {
+	slog.Info(fmt.Sprintf("Checking status of %s service", ServiceName))
+
 	ctx := context.Background()
 	conn, err := systemd.NewSystemConnectionContext(ctx)
 	if err != nil {
@@ -162,22 +160,17 @@ func serviceStatus(systemStatus *SystemStatus) error {
 	activeState := properties["ActiveState"]
 	if activeState.(string) == "active" {
 		systemStatus.YggdrasilRunning = true
-		ui.Printf(
-			"%s[%v] Remote Management ... The %v service is active\n",
-			ui.Indent.Medium,
-			ui.Icons.Ok,
-			ServiceName,
-		)
+		infoMsg := fmt.Sprintf("The %v service is active", ServiceName)
+		slog.Info(infoMsg)
+		ui.Printf("%s[%v] Remote Management ... %v\n", ui.Indent.Medium, ui.Icons.Ok, infoMsg)
 	} else {
 		systemStatus.returnCode += 1
 		loadState := properties["LoadState"]
 		if loadState == "loaded" {
 			systemStatus.YggdrasilRunning = false
-			ui.Printf(
-				"%s[ ] Remote Management ... The %v service is inactive\n",
-				ui.Indent.Medium,
-				ServiceName,
-			)
+			warnMsg := fmt.Sprintf("The %v service is inactive but not loaded", ServiceName)
+			slog.Warn(warnMsg)
+			ui.Printf("%s[ ] Remote Management ... %v\n", ui.Indent.Medium, warnMsg)
 		} else {
 			loadError := properties["LoadError"]
 			// This part of the systemd D-Bus API is a little bit tricky. It returns
@@ -195,6 +188,7 @@ func serviceStatus(systemStatus *SystemStatus) error {
 						loadErrorString := loadErrorSlice[1].(string)
 						systemStatus.YggdrasilRunning = false
 						systemStatus.YggdrasilError = loadErrorString
+						slog.Error(loadErrorString)
 						ui.Printf(
 							"%s[%s] Remote Management ... %v\n",
 							ui.Indent.Medium,
@@ -299,10 +293,12 @@ func statusAction(ctx *cli.Context) (err error) {
 
 	systemStatus.SystemHostname = hostname
 	ui.Printf("Connection status for %v:\n\n", hostname)
+	slog.Info("Checking system connection status")
 
 	/* 1. Get Status of RHSM */
 	err = rhsmStatus(&systemStatus)
 	if err != nil {
+		slog.Error(fmt.Sprintf("Cannot detect Red Hat Subscription Management status: %v", err))
 		ui.Printf(
 			"%s[%s] Red Hat Subscription Management ... %s\n",
 			ui.Indent.Small,
@@ -314,6 +310,7 @@ func statusAction(ctx *cli.Context) (err error) {
 	/* 2. Is content enabled */
 	err = isContentEnabled(&systemStatus)
 	if err != nil {
+		slog.Error(fmt.Sprintf("Cannot detect content management status: %v", err))
 		ui.Printf(
 			"%s[%s] Content ... %s\n",
 			ui.Indent.Medium,
@@ -325,12 +322,9 @@ func statusAction(ctx *cli.Context) (err error) {
 	/* 3. Get status of insights-client */
 	err = insightStatus(&systemStatus)
 	if err != nil {
-		ui.Printf(
-			"%s[%v] Analytics ... Cannot detect Red Hat Insights status: %v\n",
-			ui.Indent.Medium,
-			ui.Icons.Error,
-			err,
-		)
+		errMsg := fmt.Sprintf("Cannot detect Red Hat Insights status: %v", err)
+		slog.Error(errMsg)
+		ui.Printf("%s[%v] Analytics ... %v\n", ui.Indent.Medium, ui.Icons.Error, errMsg)
 	}
 
 	/* 3. Get status of yggdrasil (rhcd) service */

--- a/cmd/rhc/util.go
+++ b/cmd/rhc/util.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -65,17 +64,6 @@ func ConfigPath() (string, error) {
 	}
 
 	return filePath, nil
-}
-
-// hasPriorityErrors checks if the errorMessage map has any error
-// with a higher priority than the logLevel configure.
-func hasPriorityErrors(errorMessages map[string]LogMessage, level slog.Level) bool {
-	for _, logMsg := range errorMessages {
-		if logMsg.level >= level {
-			return true
-		}
-	}
-	return false
 }
 
 // checkForUnknownArgs returns an error if any unknown arguments are present.

--- a/dist/srpm/rhc.spec.in
+++ b/dist/srpm/rhc.spec.in
@@ -37,11 +37,7 @@ Version: @VERSION@
 %global dist %{distprefix}.fc%{fedora}
 %endif
 
-%if 0%{?fedora}
-%global setup_flags -Dvendor=False
-%else
 %global setup_flags -Dvendor=True
-%endif
 
 %if %{with rhcd_compat}
 %global setup_flags %{setup_flags} -Drhcd_compatibility=True
@@ -92,11 +88,6 @@ BuildRequires:  /usr/bin/dbus-launch
 %goprep
 %else
 %autosetup
-%endif
-
-%if 0%{?fedora}
-%generate_buildrequires
-%go_generate_buildrequires
 %endif
 
 %build

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/systemd/slog-journal v0.1.1 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/systemd/slog-journal v0.1.1 h1:6QmoeO/G/9ewZCWe6DQyeS8Q7sV7bEUaGncDJcAFcyU=
+github.com/systemd/slog-journal v0.1.1/go.mod h1:RroeO1jghpRimGgddhGx+TS/CmRJdPjK9g2ZeYLr9P8=
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=


### PR DESCRIPTION
* Card ID: CCT-1565
* add structured logging with `log/slog` throughout connect, disconnect, and status commands
* reconfigure `log/slog` to write to systemd journal
* add `github.com/systemd/slog-journal` dependency which provides a slog.Handler implementation
* fall back to default logging when journald is not available
* bring log content to parity with current CLI output
