### PR TITLE
fix(tests): use proxy for content template API calls in stage env

### DIFF
--- a/systemtest/configure_proxy_stage.py
+++ b/systemtest/configure_proxy_stage.py
@@ -114,14 +114,6 @@ Environment=HTTP_PROXY={proxy_url}
     subprocess.run(["systemctl", "daemon-reload"], check=True)
 
 
-def configure_profile_proxy(proxy_url: str):
-    """Add proxy env vars to /etc/profile.d for future shell sessions."""
-    content = f"""export HTTPS_PROXY={proxy_url}
-export HTTP_PROXY={proxy_url}
-"""
-    PROFILE_PROXY.write_text(content)
-
-
 def main() -> int:
     env_value = os.environ.get(ENV_VAR, "").lower()
     if env_value != TARGET_ENV:
@@ -136,7 +128,6 @@ def main() -> int:
         update_rhsm_conf(host, port)
         update_insights_conf(proxy_url)
         configure_yggdrasil_service(proxy_url)
-        configure_profile_proxy(proxy_url)
     except Exception as exc:
         print(f"Failed to configure proxy: {exc}", file=sys.stderr)
         return 1


### PR DESCRIPTION
- Pass noauth_proxy to RestClient when fetching content templates in stage env
- Remove unnecessary configure_profile_proxy function and its usage

Related PR in pytest_client_tools - https://github.com/RedHatInsights/pytest-client-tools/pull/44
https://issues.redhat.com/browse/CCT-1954