### PR TITLE
chore: Vendor packages on Fedora 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ rhc.spec
 /SRPMS
 settings.toml
 .secrets.toml
+/rhc*.tar.*
+/vendor/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,36 @@
-# Prerequisites
+# CONTRIBUTING
 
-Currently `rhc` is written under the assumption that it is running on a Red Hat
-Enterprise Linux distribution. It will likely work on other RHEL-compatible
-distributions, but may require additional packages or adjustments in order to
-fully function.
+## Prerequisites
 
-# Building
+`rhc` is written under the assumption it is running on Red Hat Enterprise Linux,
+CentOS Stream or Fedora. Only RHEL is officially supported.
 
-It is possible to build `rhc` binary simply by running:
+## Building
 
+The easiest way to create a development build of `rhc` is to call `go build` directly:
+
+```shell
+$ go build ./cmd/rhc
 ```
-meson setup builddir
-meson compile -C builddir
+
+## Packaging
+
+```shell
+$ sudo dnf copr enable @go-sig/go-vendor-tools-dev
+$ sudo dnf install go-vendor-tools
+$ # Create source code and vendor tarballs
+$ #  Alternatively, you can download already release tarball by calling `spectool -g rhc.spec`
+$ make archive
+$ # Prepare source RPM
+$ make srpm
+$ # Build binary RPMs
+$ mock -r fedora-43-x86_64 ~/rpmbuild/SRPMS/rhc-*.src.rpm
 ```
 
-The resulting binary will be in the `builddir` directory.
+You can create an RPM package using [packit](https://packit.dev/docs/cli) CLI too:
 
-If you want to install `rhc` into system, then it is recommended to create
-RPM package and install rhc using package manager like dnf. You can
-create RPM package using [packit](https://packit.dev/docs/cli) CLI too:
-
-```
-packit build locally
+```shell
+$ packit build locally
 ```
 
 # Remote Debugging

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.ONESHELL:
+.SHELLFLAGS := -e -c
+
+VERSION := $(shell rpmspec rhc.spec --query --queryformat '%{version}')
+
+# The 'build' target is not used during packaging; it is present for upstream development purposes.
+.PHONY: build
+build:
+	go build -ldflags "-X main.Version=$(VERSION)" -o rhc ./cmd/rhc
+
+.PHONY: archive
+archive:
+	git archive --prefix rhc-$(VERSION)/ --format tar.gz HEAD > rhc-$(VERSION).tar.gz
+	go_vendor_archive create --output rhc-$(VERSION)-vendor.tar.bz2 .
+
+.PHONY: srpm
+srpm: archive
+	rpmbuild --define "_sourcedir $$(pwd)" -bs rhc.spec
+
+# The 'clean' target removes build artifacts.
+.PHONY: clean
+clean:
+	rm -f rhc
+	rm -f rhc-*.tar*

--- a/go-vendor-tools.toml
+++ b/go-vendor-tools.toml
@@ -1,0 +1,8 @@
+[archive]
+
+[licensing]
+detector = "askalono"
+[[licensing.licenses]]
+path = "vendor/gopkg.in/yaml.v3/LICENSE"
+sha256sum = "d18f6323b71b0b768bb5e9616e36da390fbd39369a81807cca352de4e4e6aa0b"
+expression = "MIT AND (MIT AND Apache-2.0)"

--- a/rhc.spec
+++ b/rhc.spec
@@ -1,0 +1,118 @@
+# Run unit tests during package build
+%global with_check 1
+# Include rhcd->yggdrasil compatibility patch
+%global with_rhcd_compat 0
+
+%global goipath         github.com/redhatinsights/rhc
+Version:                0.3.8
+
+%gometa -L -f
+
+Name:           rhc
+Release:        %autorelease
+Summary:        Tool for registering to Red Hat services
+License:        Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND GPL-3.0-only AND MIT
+URL:            %{gourl}
+Source0:        %{gosource}
+Source1:        %{archivename}-vendor.tar.bz2
+Source2:        go-vendor-tools.toml
+
+BuildRequires:  go-vendor-tools
+BuildRequires:  systemd-rpm-macros
+%if 0%{?with_check}
+BuildRequires:  /usr/bin/dbus-launch
+%endif
+
+Requires: subscription-manager
+# insights-client only exists in CentOS Stream and RHEL
+%if ! 0%{?fedora}
+Requires: insights-client
+%endif
+Requires: yggdrasil >= 0.4
+Requires: yggdrasil-worker-package-manager
+
+%description
+Client tool to register Fedora, CentOS Stream or Red Hat Enterprise Linux
+to Red Hat Subscription Management and Red Hat Lightspeed.
+
+%prep
+%goprep -A
+%setup -q -T -D -a1 %{forgesetupargs}
+
+%generate_buildrequires
+%go_vendor_license_buildrequires -c %{S:2}
+
+%build
+export GO_LDFLAGS="-X main.Version=%{version} -X main.ServiceName=yggdrasil"
+%gobuild -o %{gobuilddir}/bin/rhc %{goipath}/cmd/rhc
+
+# Generate man page
+%{gobuilddir}/bin/rhc --generate-man-page > rhc.1
+
+%install
+# Licenses
+%go_vendor_license_install -c %{S:2}
+# Binaries
+install -m 0755 -vd                     %{buildroot}%{_bindir}
+install -m 0755 -vp _build/bin/*        %{buildroot}%{_bindir}/
+# Bash completion
+install -m 0755 -vd                     %{buildroot}%{bash_completions_dir}/
+install -m 0644 -vp data/completion/rhc.bash  %{buildroot}%{bash_completions_dir}/%{name}
+# Logs
+install -m 0755 -vd                     %{buildroot}%{_localstatedir}/log/%{name}/
+# Man page
+install -m 0755 -vd                     %{buildroot}%{_mandir}/man1
+install -m 0644 -vp rhc.1               %{buildroot}%{_mandir}/man1/rhc.1
+# Systemd files
+install -m 0755 -vd                     %{buildroot}%{_unitdir}
+install -m 0644 -vp data/systemd/rhc-canonical-facts.*  %{buildroot}%{_unitdir}/
+# Configuration
+install -m 0755 -vd                     %{buildroot}%{_sysconfdir}/%{name}/
+# Yggdrasil
+%if 0%{?with_rhcd_compat}
+install -m 0755 -vd %{buildroot}%{_unitdir}/yggdrasil.service.d/
+install -m 0644 -vp %{buildroot}%{_unitdir}/yggdrasil.service.d/rhcd.conf %{buildroot}%{_unitdir}/yggdrasil.service.d/
+%endif
+
+%check
+%go_vendor_license_check -c %{S:2}
+%if 0%{?with_check}
+%gocheck2
+%endif
+
+%post
+%systemd_post rhc-canonical-facts.timer
+%if 0%{?with_rhcd_compat}
+# On package update, ensure yggdrasil (formerly rhcd) has its own configuration file
+if [ $1 -eq 2 ] && [ ! -f /etc/yggdrasil/config.toml ]; then
+	cp /etc/rhc/config.toml /etc/yggdrasil/config.toml.migrated
+	sed -E 's#^broker( ?=)#server\1#' /etc/yggdrasil/config.toml.migrated > /etc/yggdrasil/config.toml
+	echo 'facts-file = "/var/lib/yggdrasil/canonical-facts.json"' >> /etc/yggdrasil/config.toml
+	rm /etc/yggdrasil/config.toml.migrated
+fi
+%endif
+
+%preun
+%systemd_preun rhc-canonical-facts.timer
+
+%postun
+%systemd_postun_with_restart rhc-canonical-facts.timer
+
+%files -f %{go_vendor_license_filelist}
+# Binaries
+%{_bindir}/rhc
+# Bash completion
+%{bash_completions_dir}/%{name}
+# Man page
+%{_mandir}/man1/*
+# Systemd
+%{_unitdir}/rhc-canonical-facts.*
+# Configuration
+%{_sysconfdir}/%{name}/
+# Yggdrasil
+%if 0%{?with_rhcd_compat}
+%{_unitdir}/yggdrasil.service.d/rhcd.conf
+%endif
+
+%changelog
+%autochangelog


### PR DESCRIPTION
* Card ID: CCT-1886
* Card ID: CCT-1929

Since Fedora Rawhide/44+ now enforces Go dependency vendorization, update the .spec file to match those requirements.

Also, use the `%gocheck2` macro instead of deprecated `%gocheck`.

https://fedoraproject.org/wiki/Changes/GolangPackagesVendoredByDefault
https://docs.fedoraproject.org/en-US/packaging-guidelines/Golang/

This PR does _not_ switch Packit from using the dist/ version of .spec file.