### PR TITLE
feat(tests): use activation-key as default auth in integration tests

### DIFF
--- a/integration-tests/test_connect.py
+++ b/integration-tests/test_connect.py
@@ -417,8 +417,8 @@ def test_connect_proxy(
     yggdrasil_proxy_config(proxy_url)
 
     rhc.connect(
-        username=test_config.get("candlepin.username"),
-        password=test_config.get("candlepin.password"),
+        activationkey=test_config.get("candlepin.activation_keys")[0],
+        org=test_config.get("candlepin.org"),
     )
     # validate the connection
     assert rhc.is_registered
@@ -763,7 +763,7 @@ def test_connect_with_feature_enabled_disabled_combinations(
     with contextlib.suppress(Exception):
         rhc.disconnect()
 
-    command_args = prepare_args_for_connect(test_config, auth="basic", output_format="json")
+    command_args = prepare_args_for_connect(test_config, auth="activation-key", output_format="json")
 
     # Add --enable-feature flags for enabled features
     for feature in enabled_features:

--- a/integration-tests/utils/__init__.py
+++ b/integration-tests/utils/__init__.py
@@ -36,13 +36,22 @@ def check_yggdrasil_journalctl_logs(
 
 def prepare_args_for_connect(
     test_config,
-    auth: str = None,
+    auth: str = "activation-key",
     credentials: dict = None,
     output_format: str = None,
     content_template: str = None,
 ):
-    """Method to create arguments to be passed in 'rhc connect' command
-    This method expects either auth type or custom credentials
+    """Method to create arguments to be passed in 'rhc connect' command.
+
+    This method expects either auth type or custom credentials.
+
+    Args:
+        test_config: Test configuration object
+        auth: Authentication method. Default is "activation-key" (preferred).
+              Use "basic" only when specifically testing username/password auth.
+        credentials: Custom credentials dict (overrides auth parameter)
+        output_format: Output format (e.g., "json")
+        content_template: Content template name
     """
     args = []
     if credentials:


### PR DESCRIPTION
Change the default authentication method from username/password to activation-key for integration tests. This aligns with the recommended approach for rhc registration, especially for Satellite compatibility.