### PR TITLE
feat(collector): Implement timer cache functionality

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -15,7 +15,7 @@ import (
 )
 
 // ConfigDir is the default directory path where collector configuration files are stored.
-const ConfigDir = "/usr/lib/rhc/collector/"
+const ConfigDir = "/usr/lib/rhc/collectors/"
 
 // TimerDir is the default directory path where information about collectors execution are stored.
 const TimerDir = "/var/cache/rhc/collectors/"

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -339,31 +339,31 @@ func TestGetCollectorConfigName(t *testing.T) {
 			name:       "directory with toml extension",
 			configFile: mockDirEntry{name: "com.directory.toml", isDir: true},
 			want:       "",
-			wantError:  "invalid config file /usr/lib/rhc/collector/com.directory.toml",
+			wantError:  "invalid config file /usr/lib/rhc/collectors/com.directory.toml",
 		},
 		{
 			name:       "file without json extension",
 			configFile: mockDirEntry{name: "com.config.json", isDir: false},
 			want:       "",
-			wantError:  "invalid config file /usr/lib/rhc/collector/com.config.json",
+			wantError:  "invalid config file /usr/lib/rhc/collectors/com.config.json",
 		},
 		{
 			name:       "file with toml in name but different extension",
 			configFile: mockDirEntry{name: "com.config.toml.bak", isDir: false},
 			want:       "",
-			wantError:  "invalid config file /usr/lib/rhc/collector/com.config.toml.bak",
+			wantError:  "invalid config file /usr/lib/rhc/collectors/com.config.toml.bak",
 		},
 		{
 			name:       "file ending with toml but no dot",
 			configFile: mockDirEntry{name: "configtoml", isDir: false},
 			want:       "",
-			wantError:  "invalid config file /usr/lib/rhc/collector/configtoml",
+			wantError:  "invalid config file /usr/lib/rhc/collectors/configtoml",
 		},
 		{
 			name:       "directory without extension",
 			configFile: mockDirEntry{name: "config.directory", isDir: true},
 			want:       "",
-			wantError:  "invalid config file /usr/lib/rhc/collector/config.directory",
+			wantError:  "invalid config file /usr/lib/rhc/collectors/config.directory",
 		},
 		{
 			name:       "file starting with uppercase character",
@@ -375,7 +375,7 @@ func TestGetCollectorConfigName(t *testing.T) {
 			name:       "case sensitivity - uppercase extension",
 			configFile: mockDirEntry{name: "config.TOML", isDir: false},
 			want:       "",
-			wantError:  "invalid config file /usr/lib/rhc/collector/config.TOML",
+			wantError:  "invalid config file /usr/lib/rhc/collectors/config.TOML",
 		},
 	}
 


### PR DESCRIPTION
* Card ID: CCT-1843

Implement timer cache functionality to track collector execution start or finish times. This commit includes two public API methods - one for reading the cache and the other one for writing to the cache.