### PR TITLE
feat: Added no-op configure sub-command

### DIFF
--- a/cmd/rhc/configure_cmd.go
+++ b/cmd/rhc/configure_cmd.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/redhatinsights/rhc/internal/features"
+	"github.com/urfave/cli/v2"
+)
+
+// beforeEnableFeaturesAction is called before enableFeaturesAction
+func beforeEnableFeaturesAction(ctx *cli.Context) error {
+	slog.Debug("Command 'rhc configure features enable' started")
+
+	err := setupFormatOption(ctx)
+	if err != nil {
+		return err
+	}
+
+	configureUI(ctx)
+
+	if ctx.Args().Len() == 0 {
+		err = fmt.Errorf("error: required argument 'FEATURE' is missing")
+		return cli.Exit(err, ExitCodeDataErr)
+	}
+
+	return nil
+}
+
+// enableFeaturesAction enables features
+func enableFeaturesAction(ctx *cli.Context) error {
+	args := ctx.Args()
+	for _, arg := range args.Slice() {
+		slog.Info(fmt.Sprintf("Enabling feature: %s", arg))
+	}
+	return nil
+}
+
+func beforeDisableFeaturesAction(ctx *cli.Context) error {
+	slog.Debug("Command 'rhc configure features disable' started")
+
+	err := setupFormatOption(ctx)
+	if err != nil {
+		return err
+	}
+
+	configureUI(ctx)
+
+	if ctx.Args().Len() == 0 {
+		err = fmt.Errorf("error: required argument 'FEATURE' is missing")
+		return cli.Exit(err, ExitCodeDataErr)
+	}
+
+	return nil
+}
+
+// disableFeaturesAction disables features
+func disableFeaturesAction(ctx *cli.Context) error {
+	args := ctx.Args()
+	for _, arg := range args.Slice() {
+		slog.Info(fmt.Sprintf("Disabling feature: %s", arg))
+	}
+	return nil
+}
+
+// beforeShowFeaturesAction is called before showFeaturesAction
+func beforeShowFeaturesAction(ctx *cli.Context) error {
+	slog.Debug("Command 'rhc configure features show' started")
+
+	err := setupFormatOption(ctx)
+	if err != nil {
+		return err
+	}
+
+	configureUI(ctx)
+
+	return checkForUnknownArgs(ctx)
+}
+
+// showFeaturesAction shows features
+func showFeaturesAction(ctx *cli.Context) error {
+	featuresConfig, err := features.GetFeaturesFromFile("/etc/rhc/config.toml.d/01-features.toml")
+	if err != nil {
+		slog.Warn(fmt.Sprintf("failed to get features from drop-in config file: %s", err.Error()))
+		return err
+	}
+	if featuresConfig != nil {
+		if *featuresConfig.Content {
+			slog.Info("Content is enabled")
+		} else {
+			slog.Info("Content is disabled")
+		}
+		if *featuresConfig.Analytics {
+			slog.Info("Analytics is enabled")
+		} else {
+			slog.Info("Analytics is disabled")
+		}
+		if *featuresConfig.Management {
+			slog.Info("Management is enabled")
+		} else {
+			slog.Info("Management is disabled")
+		}
+	}
+	return nil
+}

--- a/cmd/rhc/main.go
+++ b/cmd/rhc/main.go
@@ -295,6 +295,71 @@ func main() {
 			Before:      beforeStatusAction,
 			Action:      statusAction,
 		},
+		{
+			Name:        "configure",
+			Usage:       "Configure the system's connection to " + Provider,
+			UsageText:   fmt.Sprintf("%v configure", app.Name),
+			Description: fmt.Sprintf("The configure command allows you to set up the system's connection to %v.", Provider),
+			Subcommands: []*cli.Command{
+				{
+					Name:        "features",
+					Usage:       "Configure the system's connection to " + Provider + " features",
+					UsageText:   fmt.Sprintf("%v configure features", app.Name),
+					Description: "The features command allows you to enable or disable " + Provider + " features.",
+					Subcommands: []*cli.Command{
+						{
+							Name:        "enable",
+							Usage:       "Enable given feature(s)",
+							UsageText:   fmt.Sprintf("%v configure features enable FEATURE", app.Name),
+							Description: "Enable given feature(s).",
+							Args:        true,
+							ArgsUsage:   "FEATURE...",
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:    "format",
+									Usage:   "print output in machine-readable format (supported formats: \"json\")",
+									Aliases: []string{"f"},
+								},
+							},
+							Before: beforeEnableFeaturesAction,
+							Action: enableFeaturesAction,
+						},
+						{
+							Name:        "disable",
+							Usage:       "Disable given feature(s)",
+							UsageText:   fmt.Sprintf("%v configure features disable FEATURE", app.Name),
+							Description: "Disable given feature(s).",
+							Args:        true,
+							ArgsUsage:   "FEATURE...",
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:    "format",
+									Usage:   "print output in machine-readable format (supported formats: \"json\")",
+									Aliases: []string{"f"},
+								},
+							},
+							Before: beforeDisableFeaturesAction,
+							Action: disableFeaturesAction,
+						},
+						{
+							Name:        "show",
+							Usage:       "Show features state",
+							UsageText:   fmt.Sprintf("%v configure features show", app.Name),
+							Description: "Show features configured for the system.",
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:    "format",
+									Usage:   "show features in machine-readable format (supported formats: \"json\")",
+									Aliases: []string{"f"},
+								},
+							},
+							Before: beforeShowFeaturesAction,
+							Action: showFeaturesAction,
+						},
+					},
+				},
+			},
+		},
 	}
 	app.EnableBashCompletion = true
 	app.BashComplete = BashComplete


### PR DESCRIPTION
* Card ID: CCT-1806
* Implemented `rhc configure features` sub-command and all required sub-sub-subcommands: `enable`, `disable` and `show`
* There is basic checking of arguments and CLI options like `--format json`
* Commands do nothing except some logging to rhc.log
* More functionality will follow tomorrow