### PR TITLE
Remove rhc disconnect `Manage your connections...` message

### DIFF
--- a/cmd/rhc/disconnect_cmd.go
+++ b/cmd/rhc/disconnect_cmd.go
@@ -234,7 +234,6 @@ func disconnectAction(ctx *cli.Context) error {
 	durations["rhsm"] = time.Since(start)
 
 	if !ui.IsOutputMachineReadable() {
-		fmt.Printf("\nManage your connected systems: https://red.ht/connector\n")
 		showTimeDuration(durations)
 
 		err = showErrorMessages("disconnect", disconnectResult.errorMessages())


### PR DESCRIPTION
* Card ID: CCT-1998

## Description

Hi team,

this PR removes the `Manage your connected systems: https://red.ht/connector` message printed when `rhc disconnect` is run.

No modification is needed in the `rhc/integration-tests/test_disconnect.py` since this test wasn't checking the presence of the removed message.

## Testing
Locate in the repository:
```console
[vagrant@lv-rhel101-go-lab rhc]$ pwd
/vagrant/repos/rhc
```

Build tool from sources:
```console
[vagrant@lv-rhel101-go-lab rhc]$ go build ./cmd/rhc
[vagrant@lv-rhel101-go-lab rhc]$ 
```

Test fixed command:
```console
[vagrant@lv-rhel101-go-lab rhc]$ sudo ./rhc disconnect
Disconnecting lv-rhel101-go-lab from Red Hat.
This might take a few seconds.

 [●] The yggdrasil service is already inactive
 [●] Already disconnected from Red Hat Lightspeed (formerly Insights)
 [●] Already disconnected from Red Hat Subscription Management
```




