### PR TITLE
Added preliminary `.pot` template for localization

### DIFF
--- a/po/rhc.pot
+++ b/po/rhc.pot
@@ -1,0 +1,150 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: rhc\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-02-16 16:35+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: cmd/rhc/connect_cmd.go:83
+#, c-format
+msgid "cannot connect to Red Hat Subscription Management: %s"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:87
+msgid "%s[%v] Cannot connect to Red Hat Subscription Management\n"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:93
+msgid "%s[%v] Skipping generation of Red Hat repository file\n"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:100
+msgid "%s[%v] %s\n"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:104
+msgid "%s[%v] Content ... Red Hat repository file generated\n"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:108
+#, c-format
+msgid "%s[ ] Content ... Red Hat repository file not generated\n"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:120
+#, c-format
+msgid ""
+"%s[ ] Analytics ... Connecting to Red Hat Lightspeed (formerly Insights) "
+"disabled\n"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:127
+msgid "%s[%v] Skipping connection to Red Hat Lightspeed (formerly Insights)\n"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:138
+msgid "cannot connect to Red Hat Lightspeed (formerly Insights): %v"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:139
+msgid "cannot connect to Red Hat Lightspeed: %v"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:141
+msgid ""
+"%s[%v] Analytics ... Cannot connect to Red Hat Lightspeed (formerly "
+"Insights)\n"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:150
+msgid ""
+"%s[%v] Analytics ... Connected to Red Hat Lightspeed (formerly Insights)\n"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:160
+#, c-format
+msgid "Starting yggdrasil service disabled (%s)"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:162 cmd/rhc/connect_cmd.go:166
+#, c-format
+msgid "%s[ ] Management .... %s\n"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:178
+msgid "%s[%v] Skipping activation of yggdrasil service\n"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:189
+msgid "cannot activate the yggdrasil service: %v"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:192
+msgid "%s[%v] Remote Management ... Cannot activate the yggdrasil service\n"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:202
+msgid "%s[%v] Remote Management ... %s\n"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:224
+#, c-format
+msgid "unable to get consumer UUID: %s"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:318
+#, c-format
+msgid "error: %s"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:328
+msgid "Error retrieving system hostname: %v"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:337
+msgid ""
+"Connecting %v to Red Hat.\n"
+"This might take a few seconds.\n"
+"\n"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:353
+#, c-format
+msgid "Feature '%s' marked enabled"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:366
+#, c-format
+msgid "Feature '%s' marked disabled"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:370
+#, c-format
+msgid ""
+"Features preferences: %s\n"
+"\n"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:390
+msgid ""
+"\n"
+"Successfully connected to Red Hat!\n"
+msgstr ""
+
+#: cmd/rhc/connect_cmd.go:394
+msgid ""
+"\n"
+"Manage your connected systems: https://red.ht/connector\n"
+msgstr ""


### PR DESCRIPTION
* Card ID: CCT-150

## Description

Hi team, 

this PR adds a preliminary `.pot` template to enable localization support.

The template only covers the printable messages from the `cmd/rhc/connect_cmd.go` file. It has been extracted with the following command:
 ```console
xgettext --keyword=Printf:1 --keyword=Println:1 --keyword=Errorf:1 --keyword=Sprintf:1 --keyword=Fatal:1 --output=po/rhc.pot cmd/rhc/connect_cmd.go
```