### PR TITLE
test: WIP: Added simple Varlink method without paramaters

### DIFF
--- a/cmd/rhc-server/rhc-server.go
+++ b/cmd/rhc-server/rhc-server.go
@@ -25,3 +25,7 @@ func (b *Backend) Test(in *internalapi.TestIn) (*internalapi.TestOut, error) {
 	output := fmt.Sprintf("Echo from rhc-server: %s", in.Input)
 	return &internalapi.TestOut{Output: output}, nil
 }
+
+func (b *Backend) Foo(_ *internalapi.FooIn) (*internalapi.FooOut, error) {
+	return &internalapi.FooOut{Output: "bar"}, nil
+}

--- a/varlink/internalapi/com.redhat.rhc.internal.go
+++ b/varlink/internalapi/com.redhat.rhc.internal.go
@@ -15,6 +15,11 @@ func (err *InvalidParameterError) Error() string {
 	return "varlink call failed: com.redhat.rhc.internal.InvalidParameter"
 }
 
+type FooIn struct{}
+type FooOut struct {
+	Output string `json:"output"`
+}
+
 type TestIn struct {
 	Input string `json:"input"`
 }
@@ -43,6 +48,14 @@ func unmarshalError(err error) error {
 	}
 	return v
 }
+func (c Client) Foo(in *FooIn) (*FooOut, error) {
+	if in == nil {
+		in = new(FooIn)
+	}
+	out := new(FooOut)
+	err := c.Client.Do("com.redhat.rhc.internal.Foo", in, out)
+	return out, unmarshalError(err)
+}
 func (c Client) Test(in *TestIn) (*TestOut, error) {
 	if in == nil {
 		in = new(TestIn)
@@ -53,6 +66,7 @@ func (c Client) Test(in *TestIn) (*TestOut, error) {
 }
 
 type Backend interface {
+	Foo(*FooIn) (*FooOut, error)
 	Test(*TestIn) (*TestOut, error)
 }
 
@@ -79,6 +93,12 @@ func (h Handler) HandleVarlink(call *govarlink.ServerCall, req *govarlink.Server
 		err error
 	)
 	switch req.Method {
+	case "com.redhat.rhc.internal.Foo":
+		in := new(FooIn)
+		if err := json.Unmarshal(req.Parameters, in); err != nil {
+			return err
+		}
+		out, err = h.Backend.Foo(in)
 	case "com.redhat.rhc.internal.Test":
 		in := new(TestIn)
 		if err := json.Unmarshal(req.Parameters, in); err != nil {
@@ -99,7 +119,7 @@ func (h Handler) HandleVarlink(call *govarlink.ServerCall, req *govarlink.Server
 
 func (h Handler) Register(reg *govarlink.Registry) {
 	reg.Add(&govarlink.RegistryInterface{
-		Definition: "interface com.redhat.rhc.internal\n# Internal API for rhc-server\n# This API is temporary and unstable\n\n# Generic error for invalid parameters\nerror InvalidParameter (parameter: string)\n\n# Test method - returns the input string as-is\nmethod Test(input: string) -> (output: string)\n",
+		Definition: "interface com.redhat.rhc.internal\n# Internal API for rhc-server\n# This API is temporary and unstable\n\n# Generic error for invalid parameters\nerror InvalidParameter (parameter: string)\n\n# Test method - returns the input string as-is\nmethod Test(input: string) -> (output: string)\n\n# Foo method - does not have any parameter\nmethod Foo() -> (output: string)\n",
 		Name:       "com.redhat.rhc.internal",
 	}, h)
 }

--- a/varlink/internalapi/com.redhat.rhc.internal.varlink
+++ b/varlink/internalapi/com.redhat.rhc.internal.varlink
@@ -7,3 +7,6 @@ error InvalidParameter (parameter: string)
 
 # Test method - returns the input string as-is
 method Test(input: string) -> (output: string)
+
+# Foo method - does not have any parameter
+method Foo() -> (output: string)


### PR DESCRIPTION
* This commit introduced new Foo() Varlink method for testing purpose
* I just tried to add testing method without any parameters in my own testing project and it did not work. Thus, I wanted to know if I do something wrong, or if it is generic problem of github.com/emersion/go-varlink
* It is generic of github.com/emersion/go-varlink
* Try to run:

```console
$ varlinkctl introspect /run/rhc/com.redhat.rhc

$ varlinkctl call /run/rhc/com.redhat.rhc \
    com.redhat.rhc.internal.Foo {}
```

You will get error:

```
Failed to issue com.redhat.rhc.internal.Foo() call: Connection reset by peer
```

The server will print following error:

```
2026/03/25 10:07:00 varlink: serving connection: handling call: unexpected end of JSON input
```

* I am personally not impressed from github.com/emersion/go-varlink :-(