### PR TITLE
chore(packit): Build on Fedora Rawhide only

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -31,8 +31,8 @@ jobs:
     additional_repos:
       - "copr://@go-sig/go-vendor-tools-dev"
     targets:
-      fedora-all-aarch64: {}
-      fedora-all-x86_64: {}
+      fedora-development-aarch64: {}
+      fedora-development-x86_64: {}
       epel-10-aarch64:
         distros: [CentOS-Stream-10, RHEL-10]
       epel-10-x86_64:
@@ -43,8 +43,8 @@ jobs:
     additional_repos:
       - "copr://@go-sig/go-vendor-tools-dev"
     targets:
-      fedora-all-aarch64: {}
-      fedora-all-x86_64: {}
+      fedora-development-aarch64: {}
+      fedora-development-x86_64: {}
       epel-10-aarch64:
         distros: [CentOS-Stream-10, RHEL-10-Nightly]
       epel-10-x86_64:
@@ -65,7 +65,6 @@ jobs:
     trigger: pull_request
     identifier: "integration-tests/fedora"
     targets:
-      - fedora-stable
       - fedora-rawhide
     labels:
       - unit


### PR DESCRIPTION
Fedora builds and tests usually tell us nothing of value. Rawhide may introduce changes that are relevant for the future of RHEL, but stable releases provide no new information to the development lifecycle.