### PR TITLE
fix: collector test failing when run as root

### DIFF
--- a/cmd/rhc-collector/rhc-collector_test.go
+++ b/cmd/rhc-collector/rhc-collector_test.go
@@ -231,6 +231,9 @@ func TestCleanup(t *testing.T) {
 	})
 
 	t.Run("handles error gracefully", func(t *testing.T) {
+		if os.Getuid() == 0 {
+			t.Skip("this test does not work when run as root")
+		}
 		tmpDir := t.TempDir()
 		testDir := filepath.Join(tmpDir, "test")
 		if err := os.Mkdir(testDir, 0755); err != nil {


### PR DESCRIPTION
This is a workaround for a unit test that works well when run as a regular user, but fails for a root (i.e., in containers).
