### PR TITLE
Identify rhc while uploading to ingress

### DIFF
--- a/cmd/rhc-collector/main.go
+++ b/cmd/rhc-collector/main.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 
 	"github.com/redhatinsights/rhc/internal/collector"
+	httpapi "github.com/redhatinsights/rhc/internal/http"
 )
 
 // FIXME: Make these configurable (use the values from "rhc configure")
@@ -15,6 +16,11 @@ const (
 	clientCertPath = "/etc/pki/consumer/cert.pem"
 	clientKeyPath  = "/etc/pki/consumer/key.pem"
 	rhcTmpDir      = "/var/tmp/rhc"
+)
+
+var (
+	// Version is set at build time.
+	Version = "dev"
 )
 
 func main() {
@@ -48,7 +54,7 @@ func run(collectorId, command string) error {
 		return err
 	}
 	defer cleanup(archivePath)
-	if err = uploadArchive(archivePath, config.ContentType); err != nil {
+	if err = uploadArchive(archivePath, config); err != nil {
 		return err
 	}
 	return nil
@@ -107,17 +113,18 @@ func getArchivePath(tmpDir string) (string, error) {
 
 // uploadArchive uploads the created archive to Red Hat Hybrid Cloud Console.
 // Returns an error if the upload fails.
-func uploadArchive(archivePath, contentType string) error {
+func uploadArchive(archivePath string, collectorConfig collector.Config) error {
 	archive := collector.ArchiveDto{
 		Path:        archivePath,
-		ContentType: contentType,
+		ContentType: collectorConfig.ContentType,
 	}
 	serviceConfig := collector.ServiceConfig{
 		URL:            ingressUrl,
 		ClientCertPath: clientCertPath,
 		ClientKeyPath:  clientKeyPath,
 	}
-	if err := collector.UploadArchive(archive, serviceConfig); err != nil {
+	userAgent := httpapi.GetUserAgent("rhc-collector", Version, collectorConfig.ID)
+	if err := collector.UploadArchive(archive, serviceConfig, userAgent); err != nil {
 		slog.Error("failed to upload archive", "error", err)
 		return fmt.Errorf("failed to upload archive: %w", err)
 	}

--- a/cmd/rhc-collector/rhc-collector_test.go
+++ b/cmd/rhc-collector/rhc-collector_test.go
@@ -187,17 +187,21 @@ func getArchivePathFromTmpDir(t *testing.T) string {
 }
 
 func TestUploadArchive(t *testing.T) {
+	testConfig := collector.Config{
+		ID:          "test.collector",
+		Name:        "Test Collector",
+		ContentType: "application/vnd.redhat.advisor.collection",
+	}
+
 	t.Run("upload with valid parameters", func(t *testing.T) {
 		archivePath := getArchivePathFromTmpDir(t)
-		contentType := "application/vnd.redhat.advisor.collection"
-		err := uploadArchive(archivePath, contentType)
+		err := uploadArchive(archivePath, testConfig)
 		t.Logf("UploadArchive() result: %v", err)
 	})
 
 	t.Run("upload with nonexistent archive", func(t *testing.T) {
 		nonexistentArchive := "/nonexistent/archive.tar.xz"
-		contentType := "application/vnd.redhat.advisor.collection"
-		err := uploadArchive(nonexistentArchive, contentType)
+		err := uploadArchive(nonexistentArchive, testConfig)
 		if err == nil {
 			t.Error("uploadArchive() expected error for nonexistent archive")
 		}
@@ -205,7 +209,12 @@ func TestUploadArchive(t *testing.T) {
 
 	t.Run("upload with empty content type", func(t *testing.T) {
 		archivePath := getArchivePathFromTmpDir(t)
-		err := uploadArchive(archivePath, "")
+		emptyContentTypeConfig := collector.Config{
+			ID:          "test.collector",
+			Name:        "Test Collector",
+			ContentType: "",
+		}
+		err := uploadArchive(archivePath, emptyContentTypeConfig)
 		if err == nil {
 			t.Error("uploadArchive() expected error for empty content type")
 		}

--- a/internal/collector/ingress.go
+++ b/internal/collector/ingress.go
@@ -39,7 +39,7 @@ type ServiceConfig struct {
 }
 
 // UploadArchive uploads an archive file to the Red Hat Hybrid Cloud Console.
-func UploadArchive(archive ArchiveDto, config ServiceConfig) error {
+func UploadArchive(archive ArchiveDto, config ServiceConfig, userAgent string) error {
 	if err := validateArchive(archive); err != nil {
 		return err
 	}
@@ -54,7 +54,7 @@ func UploadArchive(archive ArchiveDto, config ServiceConfig) error {
 		return err
 	}
 	client := httpapi.NewHTTPClient(tlsConfig)
-	req, err := createUploadRequest(formData, config)
+	req, err := createUploadRequest(formData, config, userAgent)
 	if err != nil {
 		return err
 	}
@@ -165,8 +165,7 @@ func createMultipartForm(archive ArchiveDto) (multipartData, error) {
 
 // createUploadRequest creates an HTTP POST request for uploading multipart form data.
 // Returns an error if request creation fails.
-func createUploadRequest(formData multipartData, config ServiceConfig) (*http.Request, error) {
-	// FIXME: Add proper User-Agent header to identify the rhc
+func createUploadRequest(formData multipartData, config ServiceConfig, userAgent string) (*http.Request, error) {
 	req, err := http.NewRequest("POST", config.URL, formData.Buffer)
 	if err != nil {
 		slog.Error("Failed to create request", "error", err)
@@ -174,6 +173,8 @@ func createUploadRequest(formData multipartData, config ServiceConfig) (*http.Re
 	}
 	req.Header.Set("Content-Type", formData.ContentType)
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", userAgent)
+
 	return req, nil
 }
 

--- a/internal/collector/ingress_test.go
+++ b/internal/collector/ingress_test.go
@@ -93,50 +93,91 @@ func TestSendUploadRequest(t *testing.T) {
 }
 
 func TestCreateUploadRequest(t *testing.T) {
-	testData := multipartData{
-		Buffer:      bytes.NewBufferString("test form data"),
-		ContentType: "multipart/form-data; boundary=test123",
-	}
 	testConfig := ServiceConfig{
 		URL:            "https://test.example.com/upload",
 		ClientCertPath: "/test/cert.pem",
 		ClientKeyPath:  "/test/key.pem",
 	}
 
-	req, err := createUploadRequest(testData, testConfig)
-	if err != nil {
-		t.Fatalf("createUploadRequest failed: %v", err)
+	tests := []struct {
+		name                string
+		userAgent           string
+		expectedComponent   string
+		expectedTriggeredBy string
+	}{
+		{
+			name:                "collector upload",
+			userAgent:           "rhc-collector/1.2.3 (triggered-by: test.collector) rhel/9.3",
+			expectedComponent:   "rhc-collector",
+			expectedTriggeredBy: "test.collector",
+		},
+		{
+			name:                "varlink upload",
+			userAgent:           "rhc-server/1.2.3 (triggered-by: sample.api.method) rhel/9.3",
+			expectedComponent:   "rhc-server",
+			expectedTriggeredBy: "sample.api.method",
+		},
 	}
 
-	// Verify HTTP method
-	if req.Method != "POST" {
-		t.Errorf("Expected method POST, got %s", req.Method)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fresh buffer for each test case
+			testData := multipartData{
+				Buffer:      bytes.NewBufferString("test form data"),
+				ContentType: "multipart/form-data; boundary=test123",
+			}
 
-	// Verify URL
-	if req.URL.String() != testConfig.URL {
-		t.Errorf("Expected URL %s, got %s", testConfig.URL, req.URL.String())
-	}
+			req, err := createUploadRequest(testData, testConfig, tt.userAgent)
+			if err != nil {
+				t.Fatalf("createUploadRequest failed: %v", err)
+			}
 
-	// Verify Content-Type header
-	contentType := req.Header.Get("Content-Type")
-	if contentType != testData.ContentType {
-		t.Errorf("Expected Content-Type %s, got %s", testData.ContentType, contentType)
-	}
+			// Verify HTTP method
+			if req.Method != "POST" {
+				t.Errorf("Expected method POST, got %s", req.Method)
+			}
 
-	// Verify Accept header
-	accept := req.Header.Get("Accept")
-	if accept != "application/json" {
-		t.Errorf("Expected Accept application/json, got %s", accept)
-	}
+			// Verify URL
+			if req.URL.String() != testConfig.URL {
+				t.Errorf("Expected URL %s, got %s", testConfig.URL, req.URL.String())
+			}
 
-	// Verify body
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		t.Fatalf("Failed to read request body: %v", err)
-	}
-	if string(body) != "test form data" {
-		t.Errorf("Expected body 'test form data', got %s", string(body))
+			// Verify Content-Type header
+			contentType := req.Header.Get("Content-Type")
+			if contentType != testData.ContentType {
+				t.Errorf("Expected Content-Type %s, got %s", testData.ContentType, contentType)
+			}
+
+			// Verify Accept header
+			accept := req.Header.Get("Accept")
+			if accept != "application/json" {
+				t.Errorf("Expected Accept application/json, got %s", accept)
+			}
+
+			// Verify User-Agent header is set
+			userAgent := req.Header.Get("User-Agent")
+			if userAgent == "" {
+				t.Error("Expected User-Agent header to be set")
+			}
+			if !strings.Contains(userAgent, tt.expectedComponent) {
+				t.Errorf("Expected User-Agent to contain '%s', got %s", tt.expectedComponent, userAgent)
+			}
+			if !strings.Contains(userAgent, "triggered-by:") {
+				t.Errorf("Expected User-Agent to contain 'triggered-by:', got %s", userAgent)
+			}
+			if !strings.Contains(userAgent, tt.expectedTriggeredBy) {
+				t.Errorf("Expected User-Agent to contain '%s', got %s", tt.expectedTriggeredBy, userAgent)
+			}
+
+			// Verify body
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("Failed to read request body: %v", err)
+			}
+			if string(body) != "test form data" {
+				t.Errorf("Expected body 'test form data', got %s", string(body))
+			}
+		})
 	}
 }
 

--- a/internal/http/useragent.go
+++ b/internal/http/useragent.go
@@ -1,0 +1,108 @@
+package httpapi
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+)
+
+const (
+	// unknownOS is returned when OS information cannot be determined.
+	unknownOS = "unknown"
+)
+
+var (
+	// osReleasePath is the path to the os-release file.
+	// Can be overridden in tests to use a mock file.
+	osReleasePath = "/etc/os-release"
+
+	// cachedOSVersion stores the OS version to avoid repeated file I/O.
+	cachedOSVersion string
+	// cacheOnce ensures OS version is loaded only once.
+	cacheOnce sync.Once
+)
+
+// GetUserAgent constructs a User-Agent header string according to ADR-009.
+// Format: {component}/{version} (triggered-by: {trigger-id}) {os-id}/{os-version}
+// Example: rhc-collector/1.0.0 (triggered-by: com.redhat.advisor) rhel/9.3
+//
+// Parameters:
+//   - component: hardcoded component identifier (e.g., "rhc-collector", "rhc-server")
+//   - version: build-time version string injected via ldflags
+//   - triggeredBy: validated collector ID or Varlink method name
+//
+// All inputs must be pre-validated. Collector IDs are validated by ValidateID(),
+// Varlink method names follow protocol conventions, and component names are hardcoded literals.
+func GetUserAgent(component, version, triggeredBy string) string {
+	osVersion := getOSIdentifier()
+	return fmt.Sprintf("%s/%s (triggered-by: %s) %s",
+		component,
+		version,
+		triggeredBy,
+		osVersion,
+	)
+}
+
+// getOSIdentifier reads the OS version from /etc/os-release.
+// Returns ID/VERSION_ID (e.g., "rhel/9.3", "fedora/39", "centos/9").
+// The result is cached to avoid repeated file I/O.
+func getOSIdentifier() string {
+	cacheOnce.Do(func() {
+		env, err := loadEnv(osReleasePath)
+		if err != nil {
+			slog.Debug("Failed to load os-release", "path", osReleasePath, "error", err)
+			cachedOSVersion = unknownOS
+			return
+		}
+
+		id := env["ID"]
+		version := env["VERSION_ID"]
+
+		if id == "" || version == "" {
+			slog.Debug("Missing required fields in os-release", "path", osReleasePath, "ID", id, "VERSION_ID", version)
+			cachedOSVersion = unknownOS
+			return
+		}
+
+		cachedOSVersion = fmt.Sprintf("%s/%s", id, version)
+	})
+
+	return cachedOSVersion
+}
+
+// loadEnv parses a simple environment-style file and returns a map of key-value pairs.
+// Handles both quoted (KEY="value") and unquoted (KEY=value) values.
+// Skips empty lines and comments (lines starting with #).
+// Returns an error if the file cannot be read.
+//
+// This is suitable for files with simple KEY=VALUE format like os-release,
+// but does not handle complex shell constructs like multiline strings.
+func loadEnv(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	env := make(map[string]string)
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := parts[0]
+		value := strings.Trim(parts[1], `"'`)
+
+		env[key] = value
+	}
+
+	return env, nil
+}

--- a/internal/http/useragent_test.go
+++ b/internal/http/useragent_test.go
@@ -1,0 +1,107 @@
+package httpapi
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// setupMockOSRelease creates a temporary os-release file for testing.
+// Returns a cleanup function that should be called with defer.
+func setupMockOSRelease(t *testing.T, id, version string) func() {
+	t.Helper()
+
+	// Save original values
+	originalPath := osReleasePath
+
+	// Reset cache for this test (sync.Once cannot be copied, so we create a new one)
+	cachedOSVersion = ""
+	cacheOnce = sync.Once{}
+
+	// Create temporary file
+	tmpDir := t.TempDir()
+	mockFile := filepath.Join(tmpDir, "os-release")
+
+	content := "ID=" + id + "\nVERSION_ID=" + version + "\n"
+	if err := os.WriteFile(mockFile, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to create mock os-release: %v", err)
+	}
+
+	// Override package variable
+	osReleasePath = mockFile
+
+	// Return cleanup function
+	return func() {
+		osReleasePath = originalPath
+		// Reset cache again for subsequent tests
+		cachedOSVersion = ""
+		cacheOnce = sync.Once{}
+	}
+}
+
+func TestGetUserAgent(t *testing.T) {
+	// Setup mock RHEL environment for all tests
+	cleanup := setupMockOSRelease(t, "rhel", "9.3")
+	defer cleanup()
+
+	tests := []struct {
+		name        string
+		component   string
+		version     string
+		triggeredBy string
+		contains    []string
+	}{
+		{
+			name:        "full user agent with all fields",
+			component:   "rhc-collector",
+			version:     "1.0.0",
+			triggeredBy: "testing.collector",
+			contains: []string{
+				"rhc-collector/1.0.0",
+				"triggered-by: testing.collector",
+				"rhel/9.3",
+			},
+		},
+		{
+			name:        "user agent with empty triggered-by",
+			component:   "rhc-collector",
+			version:     "1.0.0",
+			triggeredBy: "",
+			contains: []string{
+				"rhc-collector/1.0.0",
+				"triggered-by: ",
+				"rhel/9.3",
+			},
+		},
+		{
+			name:        "rhc-server component",
+			component:   "rhc-server",
+			version:     "1.2.3",
+			triggeredBy: "sample.api.method",
+			contains: []string{
+				"rhc-server/1.2.3",
+				"triggered-by: sample.api.method",
+				"rhel/9.3",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userAgent := GetUserAgent(tt.component, tt.version, tt.triggeredBy)
+
+			if userAgent == "" {
+				t.Error("GetUserAgent() returned empty string")
+				return
+			}
+
+			for _, expected := range tt.contains {
+				if !strings.Contains(userAgent, expected) {
+					t.Errorf("GetUserAgent() = %q, want to contain %q", userAgent, expected)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Hi team, this PR adds the User-Agent header info when uploading to provide information about the origin.

This in one example of the expected User-Agent added info:
```console
rhc-collector/0.3.8 (triggered-by: Red Hat Lightspeed Advisor) rhel/10.1
```

## Testing:

To facilitate the manual test we can modify the following lane, to send the request to a local mocked server in order to inspect it:

```console
[vagrant@lv-rhel101 rhc]$ sed -i 's|https://cert.console.redhat.com|http://localhost:3000|' cmd/rhc-collector/main.go
```

Also we need to create a testing collector:
```console
[vagrant@lv-rhel101 rhc]$ mkdir -p /usr/lib/rhc/collectors
[vagrant@lv-rhel101 rhc]$ nano  /usr/lib/rhc/collectors/com.redhat.advisor.toml
[vagrant@lv-rhel101 rhc]$ cat /usr/lib/rhc/collectors/com.redhat.advisor.toml
[meta]
name = "Red Hat Lightspeed Advisor"
feature = "analytics"
type = "ingress"

[ingress]
user = "root"
group = "root"
content_type = "application/vnd.redhat.advisor.collection"
```

Then build the project:
```console
[vagrant@lv-rhel101 rhc]$ make build
...
```

In another terminal use the following python script to serve the requests and leave it running:

```python3
#!/usr/bin/env python3

from http.server import HTTPServer, BaseHTTPRequestHandler

class Handler(BaseHTTPRequestHandler):
    def do_POST(self):
        ua = self.headers.get("User-Agent", "")

        print("\n=== Incoming Request ===")
        print(f"User-Agent: {ua}")

if __name__ == "__main__":
    print("Mock server on http://localhost:3000")
    HTTPServer(("0.0.0.0", 3000), Handler).serve_forever()
```

```console
[vagrant@lv-rhel101 ~]$ python3 mock_ingress.py 
Mock server on http://localhost:3000
```

And in the previous terminal, execute the compiled `rhc-collector` binary:
```console
[vagrant@lv-rhel101 rhc]$ sudo ./rhc-collector com.redhat.advisor "insights-client --output-dir"
2026/04/13 15:05:26 INFO starting rhc-collector id=com.redhat.advisor
2026/04/13 15:05:26 INFO created temporary directory dir=/var/tmp/rhc/collector-1370553453
2026/04/13 15:05:26 INFO configuration of the collector config="{ID:com.redhat.advisor Name:Red Hat Lightspeed Advisor IsAnalyticsFeature:true User:root Group:root ContentType:application/vnd.redhat.advisor.collection}"
2026/04/13 15:05:39 INFO collector has ran successfully output="Starting to collect Insights data for lv-rhel101\nWriting RHSM facts to /etc/rhsm/facts/insights-client.facts ...\nCollected data copied to /var/tmp/rhc/collector-1370553453\n"
2026/04/13 15:05:40 INFO archive created path=/var/tmp/rhc/rhc-collector-20260413150539683.tar.xz
2026/04/13 15:05:40 INFO Uploading archive archive=/var/tmp/rhc/rhc-collector-20260413150539683.tar.xz url=http://localhost:3000
2026/04/13 15:05:40 INFO Successfully uploaded archive archive=/var/tmp/rhc/rhc-collector-20260413150539683.tar.xz
```

The server will show the following message:
```console
=== Incoming Request ===
User-Agent: rhc-collector/0.3.8 (triggered-by: Red Hat Lightspeed Advisor) rhel/10.1
```