### PR TITLE
feat(feature): Add feature management system

### DIFF
--- a/pkg/feature/analytics.go
+++ b/pkg/feature/analytics.go
@@ -1,0 +1,36 @@
+package feature
+
+import (
+	"github.com/redhatinsights/rhc/internal/datacollection"
+)
+
+// Analytics implements IFeature.
+type Analytics struct{}
+
+func (a Analytics) ID() string {
+	return "analytics"
+}
+
+func (a Analytics) Description() string {
+	return "Red Hat Lightspeed data collection"
+}
+
+func (a Analytics) Requires() []string {
+	return []string{}
+}
+
+func (a Analytics) RequiredBy() []string {
+	return []string{"remote-management"}
+}
+
+func (a Analytics) Enable() error {
+	return datacollection.RegisterInsightsClient()
+}
+
+func (a Analytics) Disable() error {
+	return datacollection.UnregisterInsightsClient()
+}
+
+func (a Analytics) IsEnabled() (bool, error) {
+	return datacollection.InsightsClientIsRegistered()
+}

--- a/pkg/feature/content.go
+++ b/pkg/feature/content.go
@@ -1,0 +1,36 @@
+package feature
+
+import (
+	"github.com/redhatinsights/rhc/internal/rhsm"
+)
+
+// Content implements IFeature.
+type Content struct{}
+
+func (c Content) ID() string {
+	return "content"
+}
+
+func (c Content) Description() string {
+	return "Red Hat content management"
+}
+
+func (c Content) Requires() []string {
+	return []string{}
+}
+
+func (c Content) RequiredBy() []string {
+	return []string{}
+}
+
+func (c Content) Enable() error {
+	return rhsm.SetContentManagement(true)
+}
+
+func (c Content) Disable() error {
+	return rhsm.SetContentManagement(false)
+}
+
+func (c Content) IsEnabled() (bool, error) {
+	return rhsm.IsContentManagementEnabled()
+}

--- a/pkg/feature/doc.go
+++ b/pkg/feature/doc.go
@@ -1,0 +1,33 @@
+/*
+Package feature provides a unified interface for managing feature levels.
+
+# System and feature lifecycle
+
+  - Before registration: Use the prefcache subpackage. No system changes are
+    applied yet.
+  - During and after registration: Features are enabled and disabled
+    immediately by altering the system configuration.
+
+Features declare dependencies on other features. Dependencies are enforced:
+  - before a feature is enabled, all required features will be enabled,
+  - before a feature is disabled, all dependent features will be disabled.
+
+# Package usage
+
+Every feature must implement the IFeature interface. Several feature levels
+are available:
+  - content: Red Hat content management
+  - analytics: Red Hat Lightspeed data collection
+  - remote-management: Red Hat Lightspeed remote management
+
+Feature objects can be retrieved using Get() or MustGet():
+
+	feature, err := feature.Get("analytics")
+	if err != nil {
+		// handle error
+	}
+	if err := feature.Enable(); err != nil {
+		// handle error
+	}
+*/
+package feature

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -1,0 +1,49 @@
+package feature
+
+import (
+	"fmt"
+)
+
+type IFeature interface {
+	ID() string
+	Description() string
+	// Requires returns a list of all feature IDs the feature depends on
+	Requires() []string
+	// RequiredBy returns a list of all feature IDs that require this feature
+	RequiredBy() []string
+
+	// Enable enables a feature. Acts as a no-op if it is already enabled.
+	Enable() error
+	// Disable disables a feature. Acts as a no-op if it is already disabled.
+	Disable() error
+	// IsEnabled returns true if the feature is enabled, false otherwise.
+	// Returns an error if the feature misbehaves.
+	IsEnabled() (bool, error)
+}
+
+var registered = []IFeature{
+	Content{},
+	Analytics{},
+	RemoteManagement{},
+}
+
+func All() []IFeature {
+	return registered
+}
+
+func Get(id string) (IFeature, error) {
+	for _, f := range registered {
+		if f.ID() == id {
+			return f, nil
+		}
+	}
+	return nil, fmt.Errorf("feature %q not found", id)
+}
+
+func MustGet(id string) IFeature {
+	f, err := Get(id)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}

--- a/pkg/feature/remotemanagement.go
+++ b/pkg/feature/remotemanagement.go
@@ -1,0 +1,36 @@
+package feature
+
+import (
+	"github.com/redhatinsights/rhc/internal/remotemanagement"
+)
+
+// RemoteManagement implements IFeature.
+type RemoteManagement struct{}
+
+func (r RemoteManagement) ID() string {
+	return "remote-management"
+}
+
+func (r RemoteManagement) Description() string {
+	return "Red Hat Lightspeed remote management"
+}
+
+func (r RemoteManagement) Requires() []string {
+	return []string{"analytics"}
+}
+
+func (r RemoteManagement) RequiredBy() []string {
+	return []string{}
+}
+
+func (r RemoteManagement) Enable() error {
+	return remotemanagement.ActivateServices()
+}
+
+func (r RemoteManagement) Disable() error {
+	return remotemanagement.DeactivateServices()
+}
+
+func (r RemoteManagement) IsEnabled() (bool, error) {
+	return remotemanagement.AssertYggdrasilServiceState("active")
+}


### PR DESCRIPTION
* Card ID: CCT-2169

Add a new 'pkg/feature' package providing unified interface for managing feature levels. Features may declare dependencies and can be enabled and disabled programatically.

Since the number of features is expected to stay quite small, I have reached a conclusion that an implementation of a DAG or otherwise "smart" resolution of what depends on what would only make things complicated.

The number of features might grow in the future, but they will stay sortable and without cycles; hardcoding their dependencies feels like the simplest way to keep it small and maintainable.
