### PR TITLE
Add socket activation tests for Varlink API

### DIFF
--- a/integration-tests/test_collector_api.py
+++ b/integration-tests/test_collector_api.py
@@ -13,8 +13,11 @@ import os
 import time
 import textwrap
 
+from utils.varlink import run_varlinkctl
+from utils.systemctl import is_service_active
 
-@pytest.fixture(scope="module", autouse=True)
+
+@pytest.fixture(scope="module")
 def rhc_server_socket():
     """
     Fixture to ensure rhc-server.socket is enabled and running before collector tests.
@@ -23,13 +26,7 @@ def rhc_server_socket():
     socket_name = "rhc-server.socket"
 
     # Check if socket is already active
-    result = subprocess.run(
-        ["systemctl", "is-active", socket_name],
-        capture_output=True,
-        text=True,
-    )
-
-    was_active = result.returncode == 0
+    was_active = is_service_active(socket_name)
 
     if not was_active:
         # Enable and start the socket
@@ -50,28 +47,8 @@ def rhc_server_socket():
         )
 
 
-def run_varlinkctl(method, params=None, check=True):
-    """
-    Helper function to call varlinkctl and return parsed JSON response.
-
-    :param method: The varlink method to call (e.g., "com.redhat.rhc.collector.List")
-    :param params: Optional parameters as a dictionary
-    :param check: If True, raise exception on non-zero exit code (default: True)
-    :return: Parsed JSON response if check=True, otherwise CompletedProcess object
-    """
-    cmd = ["varlinkctl", "call", "unix:/run/rhc/com.redhat.rhc", method]
-
-    if params:
-        cmd.append(json.dumps(params))
-    else:
-        cmd.append("{}")
-
-    result = subprocess.run(cmd, capture_output=True, text=True, check=check)
-
-    if check:
-        return json.loads(result.stdout)
-    else:
-        return result
+# Ensure rhc_server_socket fixture is used for all tests in this module
+pytestmark = pytest.mark.usefixtures("rhc_server_socket")
 
 
 @pytest.fixture

--- a/integration-tests/test_socket_activated_service.py
+++ b/integration-tests/test_socket_activated_service.py
@@ -1,0 +1,87 @@
+"""
+:casecomponent: rhc
+:requirement: RHSS-XXXXX
+:subsystemteam: rhel-sst-csi-client-tools
+:caseautomation: Automated
+:upstream: Yes
+"""
+
+import pytest
+
+from utils.varlink import run_varlinkctl
+from utils.systemctl import (
+    is_service_active,
+    is_socket_enabled,
+    stop_service,
+    enable_and_start_socket,
+    disable_and_stop_socket,
+)
+
+
+@pytest.fixture(scope="module")
+def fd3_socket_setup():
+    """
+    Fixture to ensure rhc-server.socket is enabled for FD3 socket activation tests.
+    Stops the service if running to test auto-boot behavior.
+    """
+    socket_name = "rhc-server.socket"
+    service_name = "rhc-server.service"
+
+    socket_was_enabled = is_socket_enabled(socket_name)
+
+    if not socket_was_enabled:
+        enable_and_start_socket(socket_name)
+
+    if is_service_active(service_name):
+        stop_service(service_name)
+
+    yield {
+        "socket_name": socket_name,
+        "service_name": service_name,
+        "socket_was_enabled": socket_was_enabled,
+    }
+
+    if not socket_was_enabled:
+        disable_and_stop_socket(socket_name)
+
+
+@pytest.mark.tier1
+def test_fd3_socket_activation(fd3_socket_setup):
+    """
+    :id: d1e2f3a4-b5c6-7890-def1-23456789abcd
+    :title: Verify FD3 socket activation boots rhc-server on varlink call
+    :reference: https://redhat.atlassian.net/browse/CCT-1756
+    :description:
+        Test that when rhc-server.service is not running but rhc-server.socket
+        is enabled, making a varlink call triggers systemd socket activation,
+        automatically boots the service, and returns a correct response.
+    :tags: Tier 1
+    :steps:
+        1. Ensure rhc-server.service is stopped
+        2. Ensure rhc-server.socket is enabled
+        3. Verify service is not active before the call
+        4. Make a varlink call (com.redhat.rhc.collector.List)
+        5. Verify the service becomes active (auto-booted)
+        6. Verify the response is correct and well-formed
+    :expectedresults:
+        1. Service is stopped successfully
+        2. Socket is enabled
+        3. Service is not active before varlink call
+        4. Varlink call succeeds
+        5. Service becomes active after the call
+        6. Response contains the expected "collectors" field
+    """
+    service_name = fd3_socket_setup["service_name"]
+
+    assert not is_service_active(
+        service_name
+    ), f"Service {service_name} should not be active before FD3 call"
+
+    response = run_varlinkctl("com.redhat.rhc.collector.List")
+
+    assert "collectors" in response, "Response should contain 'collectors' field"
+    assert isinstance(response["collectors"], list), "'collectors' should be a list"
+
+    assert is_service_active(
+        service_name
+    ), f"Service {service_name} should be active after FD3 socket activation"

--- a/integration-tests/utils/systemctl.py
+++ b/integration-tests/utils/systemctl.py
@@ -1,0 +1,74 @@
+"""
+Systemctl-related utility functions for integration tests.
+
+This module provides helper functions for managing systemd services, sockets,
+and units using systemctl commands.
+"""
+
+import subprocess
+
+
+def is_service_active(service_name: str) -> bool:
+    """
+    Check if a systemd service is active.
+
+    :param service_name: Name of the systemd service
+    :return: True if the service is active, False otherwise
+    """
+    result = subprocess.run(
+        ["systemctl", "is-active", service_name],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def stop_service(service_name: str) -> None:
+    """
+    Stop a systemd service.
+
+    :param service_name: Name of the systemd service to stop
+    """
+    subprocess.run(
+        ["systemctl", "stop", service_name],
+        check=True,
+        capture_output=True,
+    )
+
+
+def is_socket_enabled(socket_name: str) -> bool:
+    """
+    Check if a systemd socket is enabled.
+
+    :param socket_name: Name of the systemd socket
+    :return: True if the socket is enabled, False otherwise
+    """
+    result = subprocess.run(
+        ["systemctl", "is-enabled", socket_name],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def enable_and_start_socket(socket_name: str) -> None:
+    """
+    Enable and start a systemd socket.
+
+    :param socket_name: Name of the systemd socket
+    """
+    subprocess.run(
+        ["systemctl", "enable", "--now", socket_name],
+        check=True,
+        capture_output=True,
+    )
+
+
+def disable_and_stop_socket(socket_name: str) -> None:
+    """
+    Disable and stop a systemd socket.
+
+    :param socket_name: Name of the systemd socket
+    """
+    subprocess.run(
+        ["systemctl", "disable", "--now", socket_name],
+        capture_output=True,
+    )

--- a/integration-tests/utils/varlink.py
+++ b/integration-tests/utils/varlink.py
@@ -1,0 +1,38 @@
+"""
+Varlink-related utility functions for integration tests.
+
+This module provides helper functions for interacting with varlink services
+using varlinkctl commands.
+"""
+
+import subprocess
+import json
+from typing import Optional, Union
+
+
+def run_varlinkctl(
+    method: str,
+    params: Optional[dict] = None,
+    check: bool = True
+) -> Union[dict, subprocess.CompletedProcess]:
+    """
+    Helper function to call varlinkctl and return a parsed JSON response.
+
+    :param method: The varlink method to call (e.g., "com.redhat.rhc.collector.List")
+    :param params: Optional parameters as a dictionary
+    :param check: If True, raise exception on non-zero exit code (default: True)
+    :return: Parsed JSON response if check=True, otherwise CompletedProcess object
+    """
+    cmd = ["varlinkctl", "call", "unix:/run/rhc/com.redhat.rhc", method]
+
+    if params:
+        cmd.append(json.dumps(params))
+    else:
+        cmd.append("{}")
+
+    result = subprocess.run(cmd, capture_output=True, text=True, check=check)
+
+    if check:
+        return json.loads(result.stdout)
+    else:
+        return result


### PR DESCRIPTION
* Card ID: CCT-1756

## Description

Hi team, this PR updates the `integration-tests/test_collector_api.py` to use the new reorganized utils for `systemctl` and `varlinkctl`, and also implements new tests to verify that an FD3 socket activation boots `rhc-server` on a `varlink` call.