### PR TITLE
[0.2] fix(ci): Rebase GitHub Actions workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,16 +1,16 @@
 name: Go
 
 on:
-  push:
   pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   build:
     name: "Build"
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: ["1.18", "1.19", "1.20"]
     steps:
       - name: Updating ...
         run: sudo apt-get -qq update
@@ -20,13 +20,13 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go }}
+          go-version: "stable"
 
       - name: Go build (source)
-        run: make
+        run: go build ./...
 
       - name: Go build (tests)
-        run: make tests
+        run: go test ./...
 
       - name: Go vet
-        run: make vet
+        run: go vet ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,11 @@
 name: Lint
 
-on: pull_request
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   lint-commits:
@@ -19,8 +24,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - run: go mod download
+
       - name: Run commitsar
         uses: aevea/commitsar@v1.0.3
+
   lint-code:
     name: Lint code
     runs-on: ubuntu-latest
@@ -28,18 +35,21 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.19"
+          go-version: "stable"
       - name: Check out code
         uses: actions/checkout@v6
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9.2.0
         with:
           version: "latest"
           args: "--verbose"
+
       - name: Install shellcheck
         run: sudo apt install shellcheck
       - name: Check shell bash scripts
         run: shellcheck ./rhc.bash
+
   lint-language:
     name: Lint language
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Constrain workflow permissions
- Use latest Go version for linting
- Instead of multiple hardcoded Go versions, use "stable"