### PR TITLE
feat(cli): rhc collector CLI

### DIFF
--- a/cmd/rhc/collector_cmd.go
+++ b/cmd/rhc/collector_cmd.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"strings"
+
+	"github.com/emersion/go-varlink"
+	"github.com/redhatinsights/rhc/internal/collector"
+	"github.com/redhatinsights/rhc/internal/ui"
+	"github.com/redhatinsights/rhc/varlink/collectorapi"
+	"github.com/urfave/cli/v2"
+)
+
+const rhcServerSocket = "/run/rhc/com.redhat.rhc"
+
+// newCollectorClient creates a varlink client for the collector API.
+func newCollectorClient() (*collectorapi.Client, func(), error) {
+	conn, err := net.Dial("unix", rhcServerSocket)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to connect to rhc-server: %w", err)
+	}
+	varlinkClient := varlink.NewClient(conn)
+	client := &collectorapi.Client{Client: varlinkClient}
+	cleanup := func() {
+		err = varlinkClient.Close()
+		if err != nil {
+			slog.Debug("failed to close varlink client", "error", err)
+			return
+		}
+	}
+	return client, cleanup, nil
+}
+
+// beforeCollectorInfoAction validates the collector info command arguments and configuration.
+func beforeCollectorInfoAction(ctx *cli.Context) error {
+	return validateCollectorCommand(ctx, true, true)
+}
+
+// collectorInfoAction retrieves and displays information for a specific collector.
+func collectorInfoAction(ctx *cli.Context) error {
+	logCommandStart(ctx)
+	client, cleanup, err := newCollectorClient()
+	if err != nil {
+		return cli.Exit(fmt.Sprintf("failed to connect to rhc-server: %v", err), ExitCodeErr)
+	}
+	defer cleanup()
+	response, err := client.Info(&collectorapi.InfoIn{Id: ctx.Args().First()})
+	if err != nil {
+		return cli.Exit(fmt.Sprintf("failed to get collector info: %v", err), ExitCodeErr)
+	}
+	ui.PrintCollectorInfo(&response.Info)
+	return nil
+}
+
+// beforeCollectorListAction validates the collector list command configuration.
+func beforeCollectorListAction(ctx *cli.Context) error {
+	return validateCollectorCommand(ctx, false, true)
+}
+
+// collectorListAction retrieves and displays a list of all available collectors.
+func collectorListAction(ctx *cli.Context) error {
+	logCommandStart(ctx)
+
+	client, cleanup, err := newCollectorClient()
+	if err != nil {
+		return cli.Exit(fmt.Sprintf("failed to connect to rhc-server: %v", err), ExitCodeErr)
+	}
+	defer cleanup()
+
+	response, err := client.List(&collectorapi.ListIn{})
+	if err != nil {
+		return cli.Exit(fmt.Sprintf("failed to list collectors: %v", err), ExitCodeErr)
+	}
+
+	if ui.IsOutputMachineReadable() {
+		if len(response.Collectors) == 0 {
+			fmt.Println("{}")
+			return nil
+		}
+		jsonData, err := json.Marshal(response.Collectors)
+		if err != nil {
+			return cli.Exit(fmt.Sprintf("failed to marshal collectors: %v", err), ExitCodeErr)
+		}
+		fmt.Println(string(jsonData))
+		return nil
+	}
+
+	var rows [][]string
+	for _, info := range response.Collectors {
+		rows = append(rows, []string{info.Id, info.Name})
+	}
+
+	headers := []string{"ID", "NAME"}
+	ui.PrintTable(headers, rows)
+	return nil
+}
+
+// beforeCollectorTimersAction validates the collector timers command configuration.
+func beforeCollectorTimersAction(ctx *cli.Context) error {
+	return validateCollectorCommand(ctx, false, true)
+}
+
+// collectorTimersAction retrieves and displays timer information for all collectors.
+func collectorTimersAction(ctx *cli.Context) error {
+	logCommandStart(ctx)
+
+	client, cleanup, err := newCollectorClient()
+	if err != nil {
+		return cli.Exit(fmt.Sprintf("failed to connect to rhc-server: %v", err), ExitCodeErr)
+	}
+	defer cleanup()
+
+	response, err := client.List(&collectorapi.ListIn{})
+	if err != nil {
+		return cli.Exit(fmt.Sprintf("failed to list collectors: %v", err), ExitCodeErr)
+	}
+
+	var infos []*collectorapi.CollectorInfo
+	for i := range response.Collectors {
+		infos = append(infos, &response.Collectors[i])
+	}
+
+	ui.PrintCollectorTimers(infos)
+	return nil
+}
+
+// beforeCollectorEnableAction validates the collector enable command arguments.
+func beforeCollectorEnableAction(ctx *cli.Context) error {
+	return validateCollectorCommand(ctx, true, false)
+}
+
+// collectorEnableAction enables a collector timer and optionally triggers immediate collection.
+func collectorEnableAction(ctx *cli.Context) error {
+	logCommandStart(ctx)
+	collectorId := ctx.Args().First()
+	nowFlag := ctx.Bool("now")
+	conn, timerName, err := collector.ValidateCollectorAndConnect(collectorId)
+	if err != nil {
+		return cli.Exit(fmt.Sprintf("%v", err), ExitCodeErr)
+	}
+	defer conn.Close()
+
+	err = conn.EnableUnit(timerName, true, false)
+	if err != nil {
+		if strings.Contains(fmt.Sprintf("%v", err), "does not exist") {
+			return cli.Exit(fmt.Sprintf("timer unit %s does not exist, collector systemd units need to be installed first", timerName), ExitCodeErr)
+		}
+		return cli.Exit(fmt.Sprintf("failed to enable timer %s: %v", timerName, err), ExitCodeErr)
+	}
+
+	if nowFlag {
+		serviceName := strings.Replace(timerName, ".timer", ".service", 1)
+		err = conn.StartUnit(serviceName, false)
+		if err != nil {
+			return cli.Exit(fmt.Sprintf("failed to start service %s: %v", serviceName, err), ExitCodeErr)
+		}
+		ui.Printf("Enabled timer %s and triggered immediate collection.\n", timerName)
+	} else {
+		ui.Printf("Enabled timer %s.\n", timerName)
+	}
+	return nil
+}
+
+// beforeCollectorDisableAction validates the collector disable command arguments.
+func beforeCollectorDisableAction(ctx *cli.Context) error {
+	return validateCollectorCommand(ctx, true, false)
+}
+
+// collectorDisableAction disables a collector timer and optionally stops immediate collection.
+func collectorDisableAction(ctx *cli.Context) error {
+	logCommandStart(ctx)
+	collectorId := ctx.Args().First()
+	nowFlag := ctx.Bool("now")
+	conn, timerName, err := collector.ValidateCollectorAndConnect(collectorId)
+	if err != nil {
+		return cli.Exit(fmt.Sprintf("%v", err), ExitCodeErr)
+	}
+	defer conn.Close()
+
+	if nowFlag {
+		serviceName := strings.Replace(timerName, ".timer", ".service", 1)
+		err = conn.StopUnit(serviceName, false)
+		if err != nil {
+			return cli.Exit(fmt.Sprintf("failed to stop service %s: %v", serviceName, err), ExitCodeErr)
+		}
+	}
+
+	err = conn.DisableUnit(timerName, true, false)
+	if err != nil {
+		if strings.Contains(fmt.Sprintf("%v", err), "does not exist") {
+			return cli.Exit(fmt.Sprintf("timer unit %s does not exist. Collector systemd units need to be installed first.", timerName), ExitCodeErr)
+		}
+		return cli.Exit(fmt.Sprintf("failed to disable timer %s: %v", timerName, err), ExitCodeErr)
+	}
+
+	if nowFlag {
+		ui.Printf("Disabled timer %s and stopped collection immediately.\n", timerName)
+	} else {
+		ui.Printf("Disabled timer %s.\n", timerName)
+	}
+	return nil
+}

--- a/cmd/rhc/main.go
+++ b/cmd/rhc/main.go
@@ -321,6 +321,81 @@ func main() {
 			Before:      beforeStatusAction,
 			Action:      statusAction,
 		},
+		{
+			Name:      "collector",
+			Usage:     "Collect data for analysis",
+			UsageText: fmt.Sprintf("%v collector COMMAND [command options]", app.Name),
+			Subcommands: []*cli.Command{
+				{
+					Name: "info",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:    "format",
+							Usage:   "prints collector information in machine-readable format (supported formats: \"json\")",
+							Aliases: []string{"f"},
+						},
+					},
+					Usage:     "Display collector information",
+					UsageText: fmt.Sprintf("%v collector info COLLECTOR", app.Name),
+					Before:    beforeCollectorInfoAction,
+					Action:    collectorInfoAction,
+				},
+				{
+					Name: "list",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:    "format",
+							Usage:   "prints list of collectors in machine-readable format (supported formats: \"json\")",
+							Aliases: []string{"f"},
+						},
+					},
+					Usage:     "List available collectors",
+					UsageText: fmt.Sprintf("%v collector list", app.Name),
+					Before:    beforeCollectorListAction,
+					Action:    collectorListAction,
+				},
+				{
+					Name: "timers",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:    "format",
+							Usage:   "prints list of collector timers in machine-readable format (supported formats: \"json\")",
+							Aliases: []string{"f"},
+						},
+					},
+					Usage:     "List collector timers",
+					UsageText: fmt.Sprintf("%v collector timers", app.Name),
+					Before:    beforeCollectorTimersAction,
+					Action:    collectorTimersAction,
+				},
+				{
+					Name: "enable",
+					Flags: []cli.Flag{
+						&cli.BoolFlag{
+							Name:  "now",
+							Usage: "enable collector and trigger immediate collection",
+						},
+					},
+					Usage:     "Enable timer-based collection",
+					UsageText: fmt.Sprintf("%v collector enable COLLECTOR", app.Name),
+					Before:    beforeCollectorEnableAction,
+					Action:    collectorEnableAction,
+				},
+				{
+					Name: "disable",
+					Flags: []cli.Flag{
+						&cli.BoolFlag{
+							Name:  "now",
+							Usage: "disable collector and stop the collection immediately",
+						},
+					},
+					Usage:     "Disable timer-based collection",
+					UsageText: fmt.Sprintf("%v collector disable COLLECTOR", app.Name),
+					Before:    beforeCollectorDisableAction,
+					Action:    collectorDisableAction,
+				},
+			},
+		},
 	}
 	app.EnableBashCompletion = true
 	app.BashComplete = BashComplete

--- a/cmd/rhc/util.go
+++ b/cmd/rhc/util.go
@@ -112,3 +112,18 @@ func logCommandStart(ctx *cli.Context) {
 	fullCommandName := getFullCommandName(ctx)
 	slog.Info(fmt.Sprintf("Command '%s' started", fullCommandName))
 }
+
+// validateCollectorCommand performs common validation for collector commands.
+func validateCollectorCommand(ctx *cli.Context, requiresCollectorID, requiresFormat bool) error {
+	if requiresFormat {
+		if err := checkFormatFlag(ctx); err != nil {
+			return err
+		}
+	}
+	if requiresCollectorID && ctx.Args().Len() == 0 {
+		commandName := getFullCommandName(ctx)
+		return cli.Exit(fmt.Sprintf("%s requires a collector ID", commandName), ExitCodeUsage)
+	}
+	configureUI(ctx)
+	return nil
+}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/redhatinsights/rhc/internal/systemd"
 )
 
 // ConfigDir is the default directory path where collector configuration files are stored.
@@ -345,4 +347,27 @@ func newConfig(id string, dto *configDto) (Config, error) {
 		Group:              group,
 		ContentType:        dto.Ingress.ContentType,
 	}, nil
+}
+
+// ValidateCollectorAndConnect validates that the collector exists and systemd is available,
+// then establishes a systemd connection for timer operations.
+// Returns the systemd connection, timer unit name, and any validation errors.
+func ValidateCollectorAndConnect(collectorID string) (*systemd.Conn, string, error) {
+	if !systemd.IsSystemdAvailable() {
+		return nil, "", fmt.Errorf("automatic execution requires systemd, which is not present in your environment")
+	}
+
+	_, err := GetConfig(collectorID)
+	if err != nil {
+		return nil, "", fmt.Errorf("collector %s not found", collectorID)
+	}
+
+	ctxSystemd := context.Background()
+	conn, err := systemd.NewConnectionContext(ctxSystemd, systemd.ConnectionTypeSystem)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to connect to systemd: %w", err)
+	}
+
+	timerName := fmt.Sprintf("rhc-collector-%s.timer", collectorID)
+	return conn, timerName, nil
 }

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -173,3 +173,15 @@ func (c *Conn) waitForState(unit string, wantState string, timeout time.Duration
 		}
 	}
 }
+
+// IsSystemdAvailable checks if systemd is available in the current environment.
+// It returns false in containers or environments where systemd is not running.
+func IsSystemdAvailable() bool {
+	conn, err := NewConnectionContext(context.Background(), ConnectionTypeSystem)
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+	_, err = conn.GetUnitState("systemd.service")
+	return err == nil
+}

--- a/internal/systemd/systemd_test.go
+++ b/internal/systemd/systemd_test.go
@@ -269,3 +269,34 @@ func TestUnitOperationsNonExistent(t *testing.T) {
 		}
 	})
 }
+
+func TestIsSystemdAvailable(t *testing.T) {
+	tests := []struct {
+		name        string
+		expectTrue  bool
+		description string
+	}{
+		{
+			name:        "systemd_availability",
+			expectTrue:  true,
+			description: "Should detect systemd availability correctly",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, has := os.LookupEnv("DBUS_SESSION_BUS_ADDRESS"); !has {
+				t.Skip("DBUS_SESSION_BUS_ADDRESS undefined - cannot test systemd availability")
+			}
+
+			// The actual result depends on the test environment
+			// In CI or containers, systemd might not be available
+			// In local development with systemd, it should be available
+			result := IsSystemdAvailable()
+			t.Logf("IsSystemdAvailable() returned: %v", result)
+			if result != true && result != false {
+				t.Error("IsSystemdAvailable() should return a boolean value")
+			}
+		})
+	}
+}

--- a/internal/systemd/systemd_timer.go
+++ b/internal/systemd/systemd_timer.go
@@ -64,7 +64,7 @@ func getSystemdTimerRaw(timer string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "systemctl", "list-timers", timer, "--output=json")
+	cmd := exec.CommandContext(ctx, "systemctl", "list-timers", timer, "--all", "--output=json")
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/ui/collector.go
+++ b/internal/ui/collector.go
@@ -1,0 +1,166 @@
+package ui
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/redhatinsights/rhc/varlink/collectorapi"
+)
+
+const timeFormat = "Mon 2006-01-02 15:04 MST"
+
+// formatRelativeTime converts a duration into a human-readable relative time string.
+func formatRelativeTime(d time.Duration) string {
+	if d < 0 {
+		d = -d
+	}
+
+	hours := int(d.Hours())
+	minutes := int(d.Minutes()) % 60
+	if hours > 24 {
+		days := hours / 24
+		if hours%24 > 0 {
+			return fmt.Sprintf("%dd %dh", days, hours%24)
+		}
+		return fmt.Sprintf("%dd", days)
+	}
+	if hours > 0 {
+		if minutes > 0 {
+			return fmt.Sprintf("%dh %dm", hours, minutes)
+		}
+		return fmt.Sprintf("%dh", hours)
+	}
+	if minutes > 0 {
+		return fmt.Sprintf("%dm", minutes)
+	}
+
+	seconds := int(d.Seconds())
+	return fmt.Sprintf("%ds", seconds)
+}
+
+// PrintTable prints data in a table format using tabwriter.
+// headers are the column headers, rows contain the data for each row.
+func PrintTable(headers []string, rows [][]string) {
+	if len(rows) == 0 {
+		fmt.Println("No data collectors available.")
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer func(w *tabwriter.Writer) {
+		err := w.Flush()
+		if err != nil {
+			slog.Debug("Unable to flush tabwriter", "error", err)
+			return
+		}
+	}(w)
+
+	for i, header := range headers {
+		if i == len(headers)-1 {
+			_, _ = fmt.Fprint(w, header)
+		} else {
+			_, _ = fmt.Fprint(w, header+"\t")
+		}
+	}
+	_, _ = fmt.Fprintln(w)
+
+	for _, row := range rows {
+		for i, cell := range row {
+			if i == len(row)-1 {
+				_, _ = fmt.Fprint(w, cell)
+			} else {
+				_, _ = fmt.Fprint(w, cell+"\t")
+			}
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+}
+
+// printMachineReadable marshals data to JSON and prints it to stdout.
+func printMachineReadable(data interface{}) {
+	if slice, ok := data.([]*collectorapi.CollectorInfo); ok && len(slice) == 0 {
+		fmt.Println("{}")
+		return
+	}
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		slog.Error("Failed to marshal data to JSON", "error", err)
+		return
+	}
+	fmt.Println(string(jsonData))
+}
+
+// PrintCollectorInfo formats CollectorInfo for output.
+// For human-readable output, it prints formatted text.
+// For machine-readable output, it returns JSON.
+func PrintCollectorInfo(info *collectorapi.CollectorInfo) {
+	if IsOutputMachineReadable() {
+		printMachineReadable(info)
+		return
+	}
+
+	fmt.Printf("Name:      %s\n", info.Name)
+	feature := "-"
+	if info.Feature != nil {
+		feature = *info.Feature
+	}
+	fmt.Printf("Feature:   %s\n\n", feature)
+
+	if info.LastRun != nil {
+		lastRunTime := time.Unix(int64(*info.LastRun), 0)
+		relativeTime := formatRelativeTime(time.Since(lastRunTime))
+		fmt.Printf("Last run:  %s (%s ago)\n", lastRunTime.Format(timeFormat), relativeTime)
+	} else {
+		fmt.Printf("Last run:  -\n")
+	}
+	if info.NextRun != nil {
+		nextRunTime := time.Unix(int64(*info.NextRun), 0)
+		relativeTime := formatRelativeTime(time.Until(nextRunTime))
+		fmt.Printf("Next run:  %s (%s)\n\n", nextRunTime.Format(timeFormat), relativeTime)
+	} else {
+		fmt.Printf("Next run:  -\n\n")
+	}
+
+	fmt.Printf("Config:   %s\n", info.ConfigPath)
+	fmt.Printf("Service:  %s\n", info.ServiceName)
+	fmt.Printf("Timer:    %s\n", info.TimerName)
+}
+
+// PrintCollectorTimers formats multiple CollectorInfo structs into a table showing timing information.
+// For machine-readable output, it returns JSON array.
+// For human-readable output, it prints a table.
+func PrintCollectorTimers(infos []*collectorapi.CollectorInfo) {
+	if IsOutputMachineReadable() {
+		printMachineReadable(infos)
+		return
+	}
+
+	if len(infos) == 0 {
+		fmt.Println("No data collectors available.")
+		return
+	}
+	headers := []string{"ID", "LAST", "NEXT"}
+	var rows [][]string
+	for _, info := range infos {
+		lastRun := "-"
+		if info.LastRun != nil {
+			lastRunTime := time.Unix(int64(*info.LastRun), 0)
+			lastRun = formatRelativeTime(time.Since(lastRunTime))
+		}
+		nextRun := "-"
+		if info.NextRun != nil {
+			nextRunTime := time.Unix(int64(*info.NextRun), 0)
+			nextRun = formatRelativeTime(time.Until(nextRunTime))
+		}
+		rows = append(rows, []string{info.Id, lastRun, nextRun})
+	}
+
+	PrintTable(headers, rows)
+	if len(infos) != 0 {
+		fmt.Println("\nHint: Run 'rhc collector info COLLECTOR' to show more details.")
+	}
+}


### PR DESCRIPTION
* Card ID: CCT-1845

Add comprehensive collector CLI interface with commands:
- rhc collector info <ID> - Display collector information
- rhc collector list - List available collectors
- rhc collector timers - List collector timers
- rhc collector enable [--now] <ID> - Enable timer-based collection
- rhc collector disable [--now] <ID> - Disable timer-based collection

An example of how to test this PR:
```
# systemctl enable rhc-server.socket rhc-server.service
# systemctl start rhc-server.socket rhc-server.service
# mkdir -p /usr/lib/rhc/collectors/
# cat /usr/lib/rhc/collectors/com.redhat.advisor.toml
[meta]
name = "Red Hat Lightspeed Advisor"
feature = "analytics"
type = "ingress"

[ingress]
user = "root"
group = "root"
content_type = "application/vnd.redhat.advisor.collection"
# mkdir -p /var/cache/rhc/collectors/
# cat /var/cache/rhc/collectors/com.redhat.advisor.json
{
  "last_started": {"timestamp": 1777461050},
  "last_finished": {"timestamp": 1777461150, "exit_code": 0}
}

# rhc collector
NAME:
   rhc collector - Collect data for analysis

USAGE:
   rhc collector COMMAND [command options]

COMMANDS:
   info     Display collector information
   list     List available collectors
   timers   List collector timers
   enable   Enable timer-based collection
   disable  Disable timer-based collection
   help, h  Shows a list of commands or help for one command

OPTIONS:
   --help, -h  show help
# rhc collector list
ID                  NAME
com.redhat.advisor  Red Hat Lightspeed Advisor
# rhc collector info com.redhat.advisor
Name:      Red Hat Lightspeed Advisor
Feature:   analytics

Last run:  Wed 2026-04-29 07:12 EDT (2h 48m ago)
Next run:  -

Config:   /usr/lib/rhc/collectors/com.redhat.advisor.toml
Service:  rhc-collector-com.redhat.advisor.service
Timer:    rhc-collector-com.redhat.advisor.timer
# rhc collector timers
ID                  LAST    NEXT
com.redhat.advisor  2h 48m  -

Hint: Run 'rhc collector info COLLECTOR' to show more details.
```