### PR TITLE
fix(test): do not treat dependency skips as fatal errors

### DIFF
--- a/cmd/rhc/connect_cmd.go
+++ b/cmd/rhc/connect_cmd.go
@@ -64,10 +64,10 @@ func (connectResult *ConnectResult) errorMessages() map[string]string {
 	if connectResult.RHSMConnectError != "" {
 		errorMessages["rhsm"] = connectResult.RHSMConnectError
 	}
-	if connectResult.Features.Analytics.Error != "" {
+	if connectResult.Features.Analytics.Error != "" && !connectResult.Features.Analytics.Skipped {
 		errorMessages["insights"] = connectResult.Features.Analytics.Error
 	}
-	if connectResult.Features.RemoteManagement.Error != "" {
+	if connectResult.Features.RemoteManagement.Error != "" && !connectResult.Features.RemoteManagement.Skipped {
 		errorMessages["yggdrasil"] = connectResult.Features.RemoteManagement.Error
 	}
 	return errorMessages


### PR DESCRIPTION
When features are explicitly disabled with --disable-feature, dependent features are skipped but this should not cause the connect command to fail. This commit fixes the test_log_connect_with_disabled_feature test which expects connect to succeed when content is disabled.