### PR TITLE
refactor(version): centralize version handling in `pkg/version`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,15 @@
 .SHELLFLAGS := -e -c
 
 VERSION := $(shell rpmspec rhc.spec --query --queryformat '%{version}')
+LDFLAGS := -ldflags "-X github.com/redhatinsights/rhc/pkg/version.Version=$(VERSION)"
+GO_BUILD := go build $(LDFLAGS)
 
 # The 'build' target is not used during packaging; it is present for upstream development purposes.
 .PHONY: build
 build:
-	go build -ldflags "-X main.Version=$(VERSION)" -o rhc ./cmd/rhc
-	go build -ldflags "-X main.Version=${VERSION}" -o rhc-server ./cmd/rhc-server
-	go build -ldflags "-X main.Version=${VERSION}" -o rhc-collector ./cmd/rhc-collector
+	$(GO_BUILD) -o rhc ./cmd/rhc
+	$(GO_BUILD) -o rhc-server ./cmd/rhc-server
+	$(GO_BUILD) -o rhc-collector ./cmd/rhc-collector
 
 .PHONY: archive
 archive:

--- a/cmd/rhc-collector/main.go
+++ b/cmd/rhc-collector/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/redhatinsights/rhc/internal/collector"
 	httpapi "github.com/redhatinsights/rhc/internal/http"
+	"github.com/redhatinsights/rhc/pkg/version"
 )
 
 // FIXME: Make these configurable (use the values from "rhc configure")
@@ -16,11 +17,6 @@ const (
 	clientCertPath = "/etc/pki/consumer/cert.pem"
 	clientKeyPath  = "/etc/pki/consumer/key.pem"
 	rhcTmpDir      = "/var/tmp/rhc"
-)
-
-var (
-	// Version is set at build time.
-	Version = "dev"
 )
 
 func main() {
@@ -123,7 +119,7 @@ func uploadArchive(archivePath string, collectorConfig collector.Config) error {
 		ClientCertPath: clientCertPath,
 		ClientKeyPath:  clientKeyPath,
 	}
-	userAgent := httpapi.GetUserAgent("rhc-collector", Version, collectorConfig.ID)
+	userAgent := httpapi.GetUserAgent("rhc-collector", version.Version, collectorConfig.ID)
 	if err := collector.UploadArchive(archive, serviceConfig, userAgent); err != nil {
 		slog.Error("failed to upload archive", "error", err)
 		return fmt.Errorf("failed to upload archive: %w", err)

--- a/cmd/rhc-server/main.go
+++ b/cmd/rhc-server/main.go
@@ -15,6 +15,7 @@ import (
 	govarlink "github.com/emersion/go-varlink"
 
 	"github.com/redhatinsights/rhc/internal/util"
+	"github.com/redhatinsights/rhc/pkg/version"
 	"github.com/redhatinsights/rhc/varlink/collectorapi"
 	"github.com/redhatinsights/rhc/varlink/internalapi"
 )
@@ -51,7 +52,7 @@ func run() error {
 	registry := govarlink.NewRegistry(&govarlink.RegistryOptions{
 		Vendor:  "Red Hat",
 		Product: "rhc",
-		Version: Version,
+		Version: version.Version,
 		URL:     "https://github.com/redhatinsights/rhc",
 	})
 
@@ -74,7 +75,7 @@ func run() error {
 		}
 	}()
 
-	slog.Info("rhc-server starting", "version", Version)
+	slog.Info("rhc-server starting", "version", version.Version)
 	slog.Info("Listening on socket", "address", listener.Addr())
 
 	// Set up a graceful shutdown

--- a/cmd/rhc-server/rhc-server.go
+++ b/cmd/rhc-server/rhc-server.go
@@ -9,11 +9,6 @@ import (
 	"github.com/redhatinsights/rhc/varlink/internalapi"
 )
 
-var (
-	// Version is set at build time.
-	Version = "dev"
-)
-
 // Backend implements the internal API backend.
 type Backend struct{}
 

--- a/cmd/rhc/constants.go
+++ b/cmd/rhc/constants.go
@@ -28,17 +28,11 @@ const (
 )
 
 var (
-	// Version is the version as described by git.
-	Version string
-
 	// LogDir points to the log file directory
 	LogDir string
 )
 
 func init() {
-	if Version == "" {
-		Version = "dev"
-	}
 	if LogDir == "" {
 		LogDir = "/var/log/rhc/"
 	}

--- a/cmd/rhc/main.go
+++ b/cmd/rhc/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/redhatinsights/rhc/internal/conf"
 	"github.com/redhatinsights/rhc/internal/ui"
 	"github.com/redhatinsights/rhc/pkg/feature"
+	"github.com/redhatinsights/rhc/pkg/version"
 )
 
 const (
@@ -96,7 +97,7 @@ func beforeAction(c *cli.Context) error {
 
 	if !c.Bool("generate-man-page") && !c.Bool("generate-markdown") {
 		configureFileLogging(conf.Config.LogLevel)
-		slog.Info(c.App.Name+" started", "version", Version, "pid", os.Getpid())
+		slog.Info(c.App.Name+" started", "version", version.Version, "pid", os.Getpid())
 	}
 
 	// When environment variable NO_COLOR or --no-color CLI option is set, then do not display colors
@@ -133,7 +134,7 @@ func exitErrHandler(c *cli.Context, err error) {
 func main() {
 	app := cli.NewApp()
 	app.Name = "rhc"
-	app.Version = Version
+	app.Version = version.Version
 	app.Usage = "control the system's connection to Red Hat"
 	app.Description = "The " + app.Name + " command controls the system's connection to Red Hat.\n\n" +
 		"To connect the system using an activation key:\n" +

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ if get_option('vendor')
 endif
 
 goldflags = get_option('goldflags')
-goldflags += ' -X "main.Version=' + meson.project_version() + '"'
+goldflags += ' -X "github.com/redhatinsights/rhc/pkg/version.Version=' + meson.project_version() + '"'
 goldflags += ' -X "main.LogDir=/var/log/rhc/"'
 
 gobuildflags = get_option('gobuildflags')

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,5 @@
+package version
+
+// Version is the version string, set at build time via ldflags.
+// Example: go build -ldflags "-X github.com/redhatinsights/rhc/pkg/version.Version=1.2.3"
+var Version = "dev"

--- a/rhc.spec
+++ b/rhc.spec
@@ -43,7 +43,7 @@ to Red Hat Subscription Management and Red Hat Lightspeed.
 %go_vendor_license_buildrequires -c %{S:2}
 
 %build
-export GO_LDFLAGS="-X main.Version=%{version} -X main.ServiceName=yggdrasil"
+export GO_LDFLAGS="-X github.com/redhatinsights/rhc/pkg/version.Version=%{version} -X main.ServiceName=yggdrasil"
 %gobuild -o %{gobuilddir}/bin/rhc %{goipath}/cmd/rhc
 %gobuild -o %{gobuilddir}/bin/rhc-server %{goipath}/cmd/rhc-server
 %gobuild -o %{gobuilddir}/bin/rhc-collector %{goipath}/cmd/rhc-collector


### PR DESCRIPTION
* Card ID: CCT-2392

## Description

Hi team,

This Pr moves the version variable from cmd/rhc, cmd/rhc-server, and cmd/rhc-collector into a shared `pkg/version` package. This establishes the pkg/ business layer as part of the ADR-011 three-layer architecture transformation.