### PR TITLE
test: switch to token based auth for consoledot API requests.

### DIFF
--- a/integration-tests/test_connect.py
+++ b/integration-tests/test_connect.py
@@ -17,6 +17,7 @@ from utils import (
     rhcd_service_is_active,
     prepare_args_for_connect,
     check_rhcd_journalctl_logs,
+    get_access_token_client_credentials,
 )
 import re
 
@@ -150,12 +151,18 @@ def test_connect_with_content_template(external_candlepin, rhc, test_config, aut
         proxy_url = f"http://{proxy_host}:{proxy_port}"
         proxies = {"http": proxy_url, "https": proxy_url}
 
+    # Get template repositories by name using token based authentication
     template_name = test_config.get("rhc.template_name_el9")
+    sso_token_url = test_config.get("sso_token_url")
+    client_id = test_config.get("service_account.client_id")
+    client_secret = test_config.get("service_account.client_secret")
     template_repos = get_template_repos_by_name(
         template_name,
-        test_config.get("candlepin.username"),
-        test_config.get("candlepin.password"),
         test_config.get("rhc.template_url"),
+        sso_token_url,
+        client_id,
+        client_secret,
+        scope="openid api.iam.service_accounts",
         proxies=proxies,
     )
 
@@ -256,32 +263,53 @@ def get_enabled_repo_names():
 
 
 def get_template_repos_by_name(
-    template_name, username, password, template_url, proxies=None
+    template_name,
+    template_url,
+    token_url,
+    client_id,
+    client_secret,
+    *,
+    scope="openid api.iam.service_accounts",
+    proxies=None,
 ):
     """
     Fetch a content template by name from Red Hat Console and return
     the set of repository names in its snapshots.
 
+    Uses token based authentication for the content-sources API.
+
     Args:
         template_name: Name of the content template to find
-        username: Username for authentication
-        password: Password for authentication
-        template_url: Base URL for the templates API
+        template_url: Base URL for the templates API (e.g. …/api/content-sources/v1.0/)
+        token_url: OpenID token endpoint (``sso_token_url`` in settings)
+        client_id: Service account client id (``service_account.client_id``)
+        client_secret: Client secret (``service_account.client_secret``)
+        scope: openid api.iam.service_accounts,
         proxies: Optional dict of proxies, e.g. {"http": "...", "https": "..."}
     """
+    access_token = get_access_token_client_credentials(
+        token_url,
+        client_id,
+        client_secret,
+        scope=scope,
+        proxies=proxies,
+    )
+    api_headers = {
+        "accept": "application/json",
+        "Authorization": f"Bearer {access_token}",
+    }
+
     client = RestClient(base_url=template_url, verify=True, proxies=proxies)
 
     try:
         # Get all templates and find the one matching template_name
         response = client.get(
             "templates/",
-            auth=(username, password),
-            headers={"accept": "application/json"},
+            headers=api_headers,
         )
 
         templates_data = response.json()
 
-        # Handle the API response structure: {"data": [...]}
         if isinstance(templates_data, dict) and "data" in templates_data:
             templates = templates_data["data"]
         elif isinstance(templates_data, list):
@@ -297,8 +325,7 @@ def get_template_repos_by_name(
                 # Fetch template details by ID
                 detail_resp = client.get(
                     f"templates/{template_id}",
-                    auth=(username, password),
-                    headers={"accept": "application/json"},
+                    headers=api_headers,
                 )
                 template_details = detail_resp.json()
 

--- a/integration-tests/utils/__init__.py
+++ b/integration-tests/utils/__init__.py
@@ -1,3 +1,8 @@
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+
 import pytest
 import sh
 import time
@@ -112,3 +117,53 @@ def prepare_args_for_connect(
         args.extend(["--content-template", content_template])
 
     return args
+
+
+def get_access_token_client_credentials(
+    token_url,
+    client_id,
+    client_secret,
+    *,
+    scope="openid api.iam.service_accounts",
+    proxies=None,
+):
+    """
+    Obtain an access token for Consoledot content-sources API.
+
+    ``token_url`` is ``sso_token_url`` in settings; use with ``service_account.client_id``
+    and ``service_account.client_secret``.
+    """
+    body = urllib.parse.urlencode(
+        {
+            "grant_type": "client_credentials",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "scope": scope,
+        }
+    ).encode()
+
+    request = urllib.request.Request(
+        token_url,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    opener = urllib.request.build_opener()
+    if proxies:
+        opener = urllib.request.build_opener(urllib.request.ProxyHandler(proxies))
+    try:
+        with opener.open(request, timeout=120) as resp:
+            payload = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")[:800]
+        raise RuntimeError(
+            f"SSO token exchange failed (HTTP {e.code}): {detail}"
+        ) from e
+
+    access = payload.get("access_token")
+    if not access:
+        raise ValueError(
+            "token response contained no access_token; "
+            f"keys={list(payload.keys())}"
+        )
+    return access


### PR DESCRIPTION
-The Red Hat Console content-sources templates API no longer
 works with HTTP basic auth. The test_connect_with_content_template
 flow prefetches expected repository names from that API using basic auth.
 This work updates the integration harness to use token based auth(via service account).