### PR TITLE
feat(operations): add Feature enum and FeatureStatus operation

### DIFF
--- a/pkg/operations/feature.go
+++ b/pkg/operations/feature.go
@@ -1,0 +1,52 @@
+package operations
+
+import "fmt"
+
+// Feature represents a system feature that can be enabled or disabled.
+type Feature int
+
+const (
+	// Analytics represents Red Hat Lightspeed data collection.
+	Analytics Feature = iota
+	// Content represents Red Hat content management.
+	Content
+	// RemoteManagement represents Red Hat Lightspeed remote management.
+	RemoteManagement
+)
+
+// FeatureOperationOptions contains options for feature operations.
+// Currently holds only the Feature identifier, but can be extended
+// in the future to include additional operation-specific parameters.
+type FeatureOperationOptions struct {
+	Feature Feature
+}
+
+// String returns the string representation of the feature.
+// The returned string matches the feature ID used in commands and configuration.
+func (f Feature) String() string {
+	switch f {
+	case Analytics:
+		return "analytics"
+	case Content:
+		return "content"
+	case RemoteManagement:
+		return "remote-management"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(f))
+	}
+}
+
+// ParseFeature converts a string feature name to a Feature enum value.
+// Returns an error if the string does not match any known feature.
+func ParseFeature(s string) (Feature, error) {
+	switch s {
+	case "analytics":
+		return Analytics, nil
+	case "content":
+		return Content, nil
+	case "remote-management":
+		return RemoteManagement, nil
+	default:
+		return 0, fmt.Errorf("unknown feature: %s", s)
+	}
+}

--- a/pkg/operations/feature_status.go
+++ b/pkg/operations/feature_status.go
@@ -1,0 +1,37 @@
+package operations
+
+import (
+	"fmt"
+
+	"github.com/redhatinsights/rhc/internal/datacollection"
+	"github.com/redhatinsights/rhc/internal/remotemanagement"
+	"github.com/redhatinsights/rhc/internal/rhsm"
+)
+
+// FeatureStatusResult represents the result of checking a feature's status.
+type FeatureStatusResult struct {
+	Enabled bool
+	Err     error
+}
+
+// FeatureStatus checks the enabled status of a feature by calling the
+// appropriate internal/* infrastructure function based on the feature type.
+// This function provides the required layer boundary between cmd/ and internal/*
+// as cmd/ cannot import internal/* directly per ADR-011 layering rules.
+func FeatureStatus(opts FeatureOperationOptions) FeatureStatusResult {
+	var enabled bool
+	var err error
+
+	switch opts.Feature {
+	case Analytics:
+		enabled, err = datacollection.InsightsClientIsRegistered()
+	case Content:
+		enabled, err = rhsm.IsContentManagementEnabled()
+	case RemoteManagement:
+		enabled, err = remotemanagement.AssertYggdrasilServiceState("active")
+	default:
+		err = fmt.Errorf("unknown feature: %s", opts.Feature)
+	}
+
+	return FeatureStatusResult{Enabled: enabled, Err: err}
+}


### PR DESCRIPTION
## Description

This PR creates pkg/operations/ with typed Feature enum and FeatureStatus function implementing dependency injection via FeatureChecker interface.