### PR TITLE
refactor: move exit codes to shared package

### DIFF
--- a/cmd/rhc-collector/constants.go
+++ b/cmd/rhc-collector/constants.go
@@ -1,6 +1,0 @@
-package main
-
-const (
-	ExitCodeErr         = 1  // generic error
-	ExitCodeUsage       = 64 // command line usage error
-)

--- a/cmd/rhc-collector/main.go
+++ b/cmd/rhc-collector/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/redhatinsights/rhc/internal/collector"
 	httpapi "github.com/redhatinsights/rhc/internal/http"
+	"github.com/redhatinsights/rhc/pkg/exitcode"
 	"github.com/redhatinsights/rhc/pkg/version"
 )
 
@@ -22,13 +23,13 @@ const (
 func main() {
 	if len(os.Args) <= 2 {
 		slog.Error("usage: rhc-collector COLLECTOR-ID COMMAND")
-		os.Exit(ExitCodeUsage)
+		os.Exit(exitcode.Usage)
 	}
 	collectorId, command := os.Args[1], os.Args[2]
 	slog.Info("starting rhc-collector", slog.String("id", collectorId))
 	if err := run(collectorId, command); err != nil {
 		slog.Error("rhc-collector exited with error", "error", err)
-		os.Exit(ExitCodeErr)
+		os.Exit(exitcode.Err)
 	}
 }
 

--- a/cmd/rhc-server/constants.go
+++ b/cmd/rhc-server/constants.go
@@ -1,5 +1,0 @@
-package main
-
-const (
-	ExitCodeErr         = 1  // generic error
-)

--- a/cmd/rhc-server/main.go
+++ b/cmd/rhc-server/main.go
@@ -15,6 +15,7 @@ import (
 	govarlink "github.com/emersion/go-varlink"
 
 	"github.com/redhatinsights/rhc/internal/util"
+	"github.com/redhatinsights/rhc/pkg/exitcode"
 	"github.com/redhatinsights/rhc/pkg/version"
 	"github.com/redhatinsights/rhc/varlink/collectorapi"
 	"github.com/redhatinsights/rhc/varlink/internalapi"
@@ -37,13 +38,13 @@ func main() {
 	cleanup, err := acquirePIDLock()
 	if err != nil {
 		slog.Error("Failed to acquire PID lock", "error", err)
-		os.Exit(ExitCodeErr)
+		os.Exit(exitcode.Err)
 	}
 	defer cleanup()
 
 	if err := run(); err != nil {
 		slog.Error("rhc-server error", "error", err)
-		os.Exit(ExitCodeErr)
+		os.Exit(exitcode.Err)
 	}
 }
 

--- a/cmd/rhc/canonical_facts_cmd.go
+++ b/cmd/rhc/canonical_facts_cmd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/redhatinsights/rhc/internal/canonical_facts"
+	"github.com/redhatinsights/rhc/pkg/exitcode"
 )
 
 // canonicalFactAction tries to gather canonical facts about system,
@@ -15,7 +16,7 @@ func canonicalFactAction(_ *cli.Context) error {
 	// NOTE: CLI context is not useful for anything
 	facts, err := canonical_facts.GetCanonicalFacts()
 	if err != nil {
-		return cli.Exit(fmt.Errorf("cannot generate canonical facts: %v", err), ExitCodeErr)
+		return cli.Exit(fmt.Errorf("cannot generate canonical facts: %v", err), exitcode.Err)
 	}
 	data, err := json.MarshalIndent(facts, "", "   ")
 	if err != nil {

--- a/cmd/rhc/collector_cmd.go
+++ b/cmd/rhc/collector_cmd.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/redhatinsights/rhc/internal/collector"
 	"github.com/redhatinsights/rhc/internal/ui"
+	"github.com/redhatinsights/rhc/pkg/exitcode"
 	"github.com/redhatinsights/rhc/varlink/collectorapi"
 )
 
@@ -45,12 +46,12 @@ func collectorInfoAction(ctx *cli.Context) error {
 	logCommandStart(ctx)
 	client, cleanup, err := newCollectorClient()
 	if err != nil {
-		return cli.Exit(fmt.Sprintf("failed to connect to rhc-server: %v", err), ExitCodeErr)
+		return cli.Exit(fmt.Sprintf("failed to connect to rhc-server: %v", err), exitcode.Unavailable)
 	}
 	defer cleanup()
 	response, err := client.Info(&collectorapi.InfoIn{Id: ctx.Args().First()})
 	if err != nil {
-		return cli.Exit(fmt.Sprintf("failed to get collector info: %v", err), ExitCodeErr)
+		return cli.Exit(fmt.Sprintf("failed to get collector info: %v", err), exitcode.Err)
 	}
 	ui.PrintCollectorInfo(&response.Info)
 	return nil
@@ -67,13 +68,13 @@ func collectorListAction(ctx *cli.Context) error {
 
 	client, cleanup, err := newCollectorClient()
 	if err != nil {
-		return cli.Exit(fmt.Sprintf("failed to connect to rhc-server: %v", err), ExitCodeErr)
+		return cli.Exit(fmt.Sprintf("failed to connect to rhc-server: %v", err), exitcode.Unavailable)
 	}
 	defer cleanup()
 
 	response, err := client.List(&collectorapi.ListIn{})
 	if err != nil {
-		return cli.Exit(fmt.Sprintf("failed to list collectors: %v", err), ExitCodeErr)
+		return cli.Exit(fmt.Sprintf("failed to list collectors: %v", err), exitcode.Err)
 	}
 
 	if ui.IsOutputMachineReadable() {
@@ -83,7 +84,7 @@ func collectorListAction(ctx *cli.Context) error {
 		}
 		jsonData, err := json.Marshal(response.Collectors)
 		if err != nil {
-			return cli.Exit(fmt.Sprintf("failed to marshal collectors: %v", err), ExitCodeErr)
+			return cli.Exit(fmt.Sprintf("failed to marshal collectors: %v", err), exitcode.Err)
 		}
 		fmt.Println(string(jsonData))
 		return nil
@@ -110,13 +111,13 @@ func collectorTimersAction(ctx *cli.Context) error {
 
 	client, cleanup, err := newCollectorClient()
 	if err != nil {
-		return cli.Exit(fmt.Sprintf("failed to connect to rhc-server: %v", err), ExitCodeErr)
+		return cli.Exit(fmt.Sprintf("failed to connect to rhc-server: %v", err), exitcode.Unavailable)
 	}
 	defer cleanup()
 
 	response, err := client.List(&collectorapi.ListIn{})
 	if err != nil {
-		return cli.Exit(fmt.Sprintf("failed to list collectors: %v", err), ExitCodeErr)
+		return cli.Exit(fmt.Sprintf("failed to list collectors: %v", err), exitcode.Err)
 	}
 
 	var infos []*collectorapi.CollectorInfo
@@ -140,23 +141,23 @@ func collectorEnableAction(ctx *cli.Context) error {
 	nowFlag := ctx.Bool("now")
 	conn, timerName, err := collector.ValidateCollectorAndConnect(collectorId)
 	if err != nil {
-		return cli.Exit(fmt.Sprintf("%v", err), ExitCodeErr)
+		return cli.Exit(fmt.Sprintf("%v", err), exitcode.Err)
 	}
 	defer conn.Close()
 
 	err = conn.EnableUnit(timerName, true, false)
 	if err != nil {
 		if strings.Contains(fmt.Sprintf("%v", err), "does not exist") {
-			return cli.Exit(fmt.Sprintf("timer unit %s does not exist, collector systemd units need to be installed first", timerName), ExitCodeErr)
+			return cli.Exit(fmt.Sprintf("timer unit %s does not exist, collector systemd units need to be installed first", timerName), exitcode.OSFile)
 		}
-		return cli.Exit(fmt.Sprintf("failed to enable timer %s: %v", timerName, err), ExitCodeErr)
+		return cli.Exit(fmt.Sprintf("failed to enable timer %s: %v", timerName, err), exitcode.OSFile)
 	}
 
 	if nowFlag {
 		serviceName := strings.Replace(timerName, ".timer", ".service", 1)
 		err = conn.StartUnit(serviceName, false)
 		if err != nil {
-			return cli.Exit(fmt.Sprintf("failed to start service %s: %v", serviceName, err), ExitCodeErr)
+			return cli.Exit(fmt.Sprintf("failed to start service %s: %v", serviceName, err), exitcode.OSFile)
 		}
 		ui.Printf("Enabled timer %s and triggered immediate collection.\n", timerName)
 	} else {
@@ -177,7 +178,7 @@ func collectorDisableAction(ctx *cli.Context) error {
 	nowFlag := ctx.Bool("now")
 	conn, timerName, err := collector.ValidateCollectorAndConnect(collectorId)
 	if err != nil {
-		return cli.Exit(fmt.Sprintf("%v", err), ExitCodeErr)
+		return cli.Exit(fmt.Sprintf("%v", err), exitcode.Err)
 	}
 	defer conn.Close()
 
@@ -185,16 +186,16 @@ func collectorDisableAction(ctx *cli.Context) error {
 		serviceName := strings.Replace(timerName, ".timer", ".service", 1)
 		err = conn.StopUnit(serviceName, false)
 		if err != nil {
-			return cli.Exit(fmt.Sprintf("failed to stop service %s: %v", serviceName, err), ExitCodeErr)
+			return cli.Exit(fmt.Sprintf("failed to stop service %s: %v", serviceName, err), exitcode.OSFile)
 		}
 	}
 
 	err = conn.DisableUnit(timerName, true, false)
 	if err != nil {
 		if strings.Contains(fmt.Sprintf("%v", err), "does not exist") {
-			return cli.Exit(fmt.Sprintf("timer unit %s does not exist. Collector systemd units need to be installed first.", timerName), ExitCodeErr)
+			return cli.Exit(fmt.Sprintf("timer unit %s does not exist. Collector systemd units need to be installed first.", timerName), exitcode.OSFile)
 		}
-		return cli.Exit(fmt.Sprintf("failed to disable timer %s: %v", timerName, err), ExitCodeErr)
+		return cli.Exit(fmt.Sprintf("failed to disable timer %s: %v", timerName, err), exitcode.OSFile)
 	}
 
 	if nowFlag {

--- a/cmd/rhc/configure_features_cmd.go
+++ b/cmd/rhc/configure_features_cmd.go
@@ -9,6 +9,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/redhatinsights/rhc/internal/rhsm"
+	"github.com/redhatinsights/rhc/pkg/exitcode"
 	"github.com/redhatinsights/rhc/pkg/feature"
 	"github.com/redhatinsights/rhc/pkg/feature/prefcache"
 )
@@ -57,7 +58,7 @@ func featuresStatusActionNotRegistered(_ *cli.Context) error {
 		icon := "enable"
 		enabled, err := cache.Get(f.ID())
 		if err != nil {
-			return cli.Exit(fmt.Sprintf("failed to get feature preference: %v", err), ExitCodeSoftware)
+			return cli.Exit(fmt.Sprintf("failed to get feature preference: %v", err), exitcode.Software)
 		}
 		if !enabled {
 			icon = "skip"
@@ -96,10 +97,10 @@ func beforeFeaturesEnableAction(ctx *cli.Context) error {
 	configureUI(ctx)
 
 	if ctx.Args().Len() != 1 {
-		return cli.Exit("this command requires a single FEATURE argument", ExitCodeUsage)
+		return cli.Exit("this command requires a single FEATURE argument", exitcode.Usage)
 	}
 	if _, err = feature.Get(ctx.Args().First()); err != nil {
-		return cli.Exit(err.Error(), ExitCodeDataErr)
+		return cli.Exit(err.Error(), exitcode.DataErr)
 	}
 	return nil
 }
@@ -109,7 +110,7 @@ func featuresEnableAction(ctx *cli.Context) error {
 	logCommandStart(ctx)
 	isRegistered, err := rhsm.IsRHSMRegistered()
 	if err != nil {
-		return cli.Exit(fmt.Sprintf("failed to check registration status: %v", err), ExitCodeSoftware)
+		return cli.Exit(fmt.Sprintf("failed to check registration status: %v", err), exitcode.Software)
 	}
 
 	requestedFeature := ctx.Args().First()
@@ -123,7 +124,7 @@ func featuresEnableAction(ctx *cli.Context) error {
 func featuresEnableActionNotRegistered(_ *cli.Context, targetName string) error {
 	cache, err := prefcache.LoadCache(ConnectFeaturesPrefsPath)
 	if err != nil {
-		return cli.Exit(fmt.Sprintf("failed to load feature preferences: %v", err), ExitCodeSoftware)
+		return cli.Exit(fmt.Sprintf("failed to load feature preferences: %v", err), exitcode.Software)
 	}
 
 	target := feature.MustGet(targetName)
@@ -132,12 +133,12 @@ func featuresEnableActionNotRegistered(_ *cli.Context, targetName string) error 
 	for _, requiredName := range target.Requires() {
 		enabled, err := cache.Get(requiredName)
 		if err != nil {
-			return cli.Exit(fmt.Sprintf("failed to get feature preference: %v", err), ExitCodeSoftware)
+			return cli.Exit(fmt.Sprintf("failed to get feature preference: %v", err), exitcode.Software)
 		}
 		if !enabled {
 			fmt.Printf("During registration, '%s' will be enabled (required by '%s').\n", requiredName, targetName)
 			if err = cache.Set(requiredName, true); err != nil {
-				return cli.Exit(fmt.Sprintf("failed to update preference: %v", err), ExitCodeSoftware)
+				return cli.Exit(fmt.Sprintf("failed to update preference: %v", err), exitcode.Software)
 			}
 			slog.Debug("enabling feature", "name", requiredName)
 		}
@@ -146,19 +147,19 @@ func featuresEnableActionNotRegistered(_ *cli.Context, targetName string) error 
 	{
 		enabled, err := cache.Get(targetName)
 		if err != nil {
-			return cli.Exit(fmt.Sprintf("failed to get feature preference: %v", err), ExitCodeSoftware)
+			return cli.Exit(fmt.Sprintf("failed to get feature preference: %v", err), exitcode.Software)
 		}
 		if !enabled {
 			fmt.Printf("During registration, '%s' will be enabled.\n", targetName)
 			if err = cache.Set(targetName, true); err != nil {
-				return cli.Exit(fmt.Sprintf("failed to update preference: %v", err), ExitCodeSoftware)
+				return cli.Exit(fmt.Sprintf("failed to update preference: %v", err), exitcode.Software)
 			}
 			slog.Debug("enabling feature", "name", targetName)
 		}
 	}
 
 	if err = cache.Save(); err != nil {
-		return cli.Exit(fmt.Sprintf("failed to save feature preferences: %v", err), ExitCodeSoftware)
+		return cli.Exit(fmt.Sprintf("failed to save feature preferences: %v", err), exitcode.Software)
 	}
 	return nil
 }
@@ -172,14 +173,14 @@ func featuresEnableActionRegistered(_ *cli.Context, targetName string) error {
 		required := feature.MustGet(requiredName)
 		requiredEnabled, err := required.IsEnabled()
 		if err != nil {
-			return cli.Exit(fmt.Sprintf("failed to check status of required feature '%s': %v", requiredName, err), ExitCodeSoftware)
+			return cli.Exit(fmt.Sprintf("failed to check status of required feature '%s': %v", requiredName, err), exitcode.Software)
 		}
 		if requiredEnabled {
 			slog.Debug("feature is already enabled", "feature", requiredName)
 			continue
 		}
 		if err = required.Enable(); err != nil {
-			return cli.Exit(fmt.Sprintf("failed to enable required feature '%s': %v", requiredName, err), ExitCodeSoftware)
+			return cli.Exit(fmt.Sprintf("failed to enable required feature '%s': %v", requiredName, err), exitcode.Software)
 		}
 		fmt.Printf("Feature '%s' enabled (required by '%s').\n", requiredName, targetName)
 	}
@@ -187,14 +188,14 @@ func featuresEnableActionRegistered(_ *cli.Context, targetName string) error {
 	{
 		featureEnabled, err := target.IsEnabled()
 		if err != nil {
-			return cli.Exit(fmt.Sprintf("failed to check status of target feature '%s': %v", targetName, err), ExitCodeSoftware)
+			return cli.Exit(fmt.Sprintf("failed to check status of target feature '%s': %v", targetName, err), exitcode.Software)
 		}
 		if featureEnabled {
 			slog.Debug("feature is already enabled", "feature", targetName)
 			return nil
 		}
 		if err = target.Enable(); err != nil {
-			return cli.Exit(fmt.Sprintf("failed to enable target feature '%s': %v", targetName, err), ExitCodeSoftware)
+			return cli.Exit(fmt.Sprintf("failed to enable target feature '%s': %v", targetName, err), exitcode.Software)
 		}
 		fmt.Printf("Feature '%s' enabled.\n", targetName)
 	}
@@ -211,10 +212,10 @@ func beforeFeaturesDisableAction(ctx *cli.Context) error {
 	configureUI(ctx)
 
 	if ctx.Args().Len() != 1 {
-		return cli.Exit("this command requires a single FEATURE argument", ExitCodeUsage)
+		return cli.Exit("this command requires a single FEATURE argument", exitcode.Usage)
 	}
 	if _, err = feature.Get(ctx.Args().First()); err != nil {
-		return cli.Exit(err.Error(), ExitCodeDataErr)
+		return cli.Exit(err.Error(), exitcode.DataErr)
 	}
 	return nil
 }
@@ -224,7 +225,7 @@ func featuresDisableAction(ctx *cli.Context) error {
 	logCommandStart(ctx)
 	isRegistered, err := rhsm.IsRHSMRegistered()
 	if err != nil {
-		return cli.Exit(fmt.Sprintf("failed to check registration status: %v", err), ExitCodeSoftware)
+		return cli.Exit(fmt.Sprintf("failed to check registration status: %v", err), exitcode.Software)
 	}
 
 	requestedFeature := ctx.Args().First()
@@ -238,7 +239,7 @@ func featuresDisableAction(ctx *cli.Context) error {
 func featuresDisableActionNotRegistered(_ *cli.Context, targetName string) error {
 	cache, err := prefcache.LoadCache(ConnectFeaturesPrefsPath)
 	if err != nil {
-		return cli.Exit(fmt.Sprintf("failed to load feature preferences: %v", err), ExitCodeSoftware)
+		return cli.Exit(fmt.Sprintf("failed to load feature preferences: %v", err), exitcode.Software)
 	}
 
 	target := feature.MustGet(targetName)
@@ -247,12 +248,12 @@ func featuresDisableActionNotRegistered(_ *cli.Context, targetName string) error
 	for _, dependentName := range target.RequiredBy() {
 		enabled, err := cache.Get(dependentName)
 		if err != nil {
-			return cli.Exit(fmt.Sprintf("failed to get feature preference: %v", err), ExitCodeSoftware)
+			return cli.Exit(fmt.Sprintf("failed to get feature preference: %v", err), exitcode.Software)
 		}
 		if enabled {
 			fmt.Printf("During registration, '%s' will not be enabled (depends on '%s').\n", dependentName, targetName)
 			if err = cache.Set(dependentName, false); err != nil {
-				return cli.Exit(fmt.Sprintf("failed to update preference: %v", err), ExitCodeSoftware)
+				return cli.Exit(fmt.Sprintf("failed to update preference: %v", err), exitcode.Software)
 			}
 			slog.Debug("disabling feature", "name", dependentName)
 		}
@@ -261,19 +262,19 @@ func featuresDisableActionNotRegistered(_ *cli.Context, targetName string) error
 	{
 		enabled, err := cache.Get(targetName)
 		if err != nil {
-			return cli.Exit(fmt.Sprintf("failed to get feature preference: %v", err), ExitCodeSoftware)
+			return cli.Exit(fmt.Sprintf("failed to get feature preference: %v", err), exitcode.Software)
 		}
 		if enabled {
 			fmt.Printf("During registration, '%s' will not be enabled.\n", targetName)
 			if err = cache.Set(targetName, false); err != nil {
-				return cli.Exit(fmt.Sprintf("failed to update preference: %v", err), ExitCodeSoftware)
+				return cli.Exit(fmt.Sprintf("failed to update preference: %v", err), exitcode.Software)
 			}
 			slog.Debug("disabling feature", "name", targetName)
 		}
 	}
 
 	if err = cache.Save(); err != nil {
-		return cli.Exit(fmt.Sprintf("failed to save feature preferences: %v", err), ExitCodeSoftware)
+		return cli.Exit(fmt.Sprintf("failed to save feature preferences: %v", err), exitcode.Software)
 	}
 	return nil
 }
@@ -287,14 +288,14 @@ func featuresDisableActionRegistered(_ *cli.Context, targetName string) error {
 		dependent := feature.MustGet(dependentName)
 		dependentEnabled, err := dependent.IsEnabled()
 		if err != nil {
-			return cli.Exit(fmt.Sprintf("failed to check status of dependent feature '%s': %v", dependentName, err), ExitCodeSoftware)
+			return cli.Exit(fmt.Sprintf("failed to check status of dependent feature '%s': %v", dependentName, err), exitcode.Software)
 		}
 		if !dependentEnabled {
 			slog.Debug("feature is already disabled", "feature", dependentName)
 			continue
 		}
 		if err = dependent.Disable(); err != nil {
-			return cli.Exit(fmt.Sprintf("failed to disable dependent feature '%s': %v", dependentName, err), ExitCodeSoftware)
+			return cli.Exit(fmt.Sprintf("failed to disable dependent feature '%s': %v", dependentName, err), exitcode.Software)
 		}
 		fmt.Printf("Feature '%s' disabled (depends on '%s').\n", dependentName, targetName)
 	}
@@ -302,14 +303,14 @@ func featuresDisableActionRegistered(_ *cli.Context, targetName string) error {
 	{
 		featureEnabled, err := target.IsEnabled()
 		if err != nil {
-			return cli.Exit(fmt.Sprintf("failed to check status of target feature '%s': %v", targetName, err), ExitCodeSoftware)
+			return cli.Exit(fmt.Sprintf("failed to check status of target feature '%s': %v", targetName, err), exitcode.Software)
 		}
 		if !featureEnabled {
 			slog.Debug("feature is already disabled", "feature", targetName)
 			return nil
 		}
 		if err = target.Disable(); err != nil {
-			return cli.Exit(fmt.Sprintf("failed to disable target feature '%s': %v", targetName, err), ExitCodeSoftware)
+			return cli.Exit(fmt.Sprintf("failed to disable target feature '%s': %v", targetName, err), exitcode.Software)
 		}
 		fmt.Printf("Feature '%s' disabled.\n", targetName)
 	}

--- a/cmd/rhc/connect_cmd.go
+++ b/cmd/rhc/connect_cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/redhatinsights/rhc/internal/remotemanagement"
 	"github.com/redhatinsights/rhc/internal/rhsm"
 	"github.com/redhatinsights/rhc/internal/ui"
+	"github.com/redhatinsights/rhc/pkg/exitcode"
 	"github.com/redhatinsights/rhc/pkg/feature"
 	"github.com/redhatinsights/rhc/pkg/feature/prefcache"
 )
@@ -224,7 +225,7 @@ func beforeConnectAction(ctx *cli.Context) error {
 		ctx.StringSlice("disable-feature"),
 	)
 	if err != nil {
-		return cli.Exit(err.Error(), ExitCodeUsage)
+		return cli.Exit(err.Error(), exitcode.Usage)
 	}
 
 	// Do not continue if the host is already registered
@@ -233,12 +234,12 @@ func beforeConnectAction(ctx *cli.Context) error {
 	if err != nil {
 		return cli.Exit(
 			fmt.Sprintf("unable to get consumer UUID: %s", err),
-			ExitCodeSoftware,
+			exitcode.Software,
 		)
 	}
 	if uuid != "" {
 		slog.Info("Consumer UUID is set, system is already connected")
-		return cli.Exit("this system is already connected", ExitCodeUsage)
+		return cli.Exit("this system is already connected", exitcode.Usage)
 	}
 
 	username := ctx.String("username")
@@ -251,7 +252,7 @@ func beforeConnectAction(ctx *cli.Context) error {
 		if username != "" {
 			exitErr := cli.Exit(
 				"--username and --activation-key can not be used together",
-				ExitCodeUsage,
+				exitcode.Usage,
 			)
 			return exitErr
 
@@ -259,7 +260,7 @@ func beforeConnectAction(ctx *cli.Context) error {
 		if password != "" {
 			exitErr := cli.Exit(
 				"--password and --activation-key can not be used together",
-				ExitCodeUsage,
+				exitcode.Usage,
 			)
 			return exitErr
 
@@ -267,7 +268,7 @@ func beforeConnectAction(ctx *cli.Context) error {
 		if organization == "" {
 			exitErr := cli.Exit(
 				"--organization is required, when --activation-key is used",
-				ExitCodeUsage,
+				exitcode.Usage,
 			)
 			return exitErr
 		}
@@ -279,7 +280,7 @@ func beforeConnectAction(ctx *cli.Context) error {
 		if (username == "" || password == "") && (len(activationKeys) == 0 || organization == "") {
 			exitErr := cli.Exit(
 				"--username/--password or --organization/--activation-key are required when a machine-readable format is used",
-				ExitCodeUsage,
+				exitcode.Usage,
 			)
 			return exitErr
 		}
@@ -292,16 +293,16 @@ func beforeConnectAction(ctx *cli.Context) error {
 	if len(ctx.StringSlice("enable-feature")) > 0 || len(ctx.StringSlice("disable-feature")) > 0 {
 		cache, err = prefcache.NewDefaultCache(ConnectFeaturesPrefsPath)
 		if err != nil {
-			return cli.Exit(fmt.Sprintf("failed to create default cache: %v", err), ExitCodeSoftware)
+			return cli.Exit(fmt.Sprintf("failed to create default cache: %v", err), exitcode.Software)
 		}
 		for _, f := range ctx.StringSlice("enable-feature") {
 			if err = cache.Set(f, true); err != nil {
-				return cli.Exit(err.Error(), ExitCodeDataErr)
+				return cli.Exit(err.Error(), exitcode.DataErr)
 			}
 		}
 		for _, f := range ctx.StringSlice("disable-feature") {
 			if err = cache.Set(f, false); err != nil {
-				return cli.Exit(err.Error(), ExitCodeDataErr)
+				return cli.Exit(err.Error(), exitcode.DataErr)
 			}
 		}
 		ui.Printf("Notice: ignoring preferences set via 'rhc configure features'.\n")
@@ -310,7 +311,7 @@ func beforeConnectAction(ctx *cli.Context) error {
 		// No flags provided, load cache from file (or defaults if file doesn't exist)
 		cache, err = prefcache.LoadCache(ConnectFeaturesPrefsPath)
 		if err != nil {
-			return cli.Exit(fmt.Sprintf("failed to load preferences: %v", err), ExitCodeSoftware)
+			return cli.Exit(fmt.Sprintf("failed to load preferences: %v", err), exitcode.Software)
 		}
 	}
 	ctx.App.Metadata[ctxConnectCache] = cache
@@ -318,15 +319,15 @@ func beforeConnectAction(ctx *cli.Context) error {
 	// Error out if we're trying to set content templates without having enabling content
 	contentEnabled, err := cache.Get("content")
 	if err != nil {
-		return cli.Exit(fmt.Sprintf("failed to get content preference: %v", err), ExitCodeSoftware)
+		return cli.Exit(fmt.Sprintf("failed to get content preference: %v", err), exitcode.Software)
 	}
 	if !contentEnabled && len(contentTemplates) > 0 {
-		return cli.Exit("content feature is disabled, cannot use --content-template", ExitCodeUsage)
+		return cli.Exit("content feature is disabled, cannot use --content-template", exitcode.Usage)
 	}
 
 	err = checkForUnknownArgs(ctx)
 	if err != nil {
-		return cli.Exit(err.Error(), ExitCodeUsage)
+		return cli.Exit(err.Error(), exitcode.Usage)
 	}
 
 	return nil
@@ -357,9 +358,9 @@ func connectAction(ctx *cli.Context) error {
 		if ui.IsOutputMachineReadable() {
 			connectResult.UID = uid
 			connectResult.UIDError = errMsg
-			return cli.Exit(connectResult, ExitCodeErr)
+			return cli.Exit(connectResult, exitcode.NoPerm)
 		}
-		return cli.Exit(fmt.Errorf("%s", errMsg), ExitCodeErr)
+		return cli.Exit(fmt.Errorf("%s", errMsg), exitcode.NoPerm)
 	}
 
 	// Gather hostname
@@ -368,9 +369,9 @@ func connectAction(ctx *cli.Context) error {
 		slog.Error(fmt.Sprintf("Error retrieving system hostname: %v", err))
 		if ui.IsOutputMachineReadable() {
 			connectResult.HostnameError = err.Error()
-			return cli.Exit(connectResult, ExitCodeErr)
+			return cli.Exit(connectResult, exitcode.Err)
 		}
-		return cli.Exit(err, ExitCodeErr)
+		return cli.Exit(err, exitcode.Err)
 	}
 	connectResult.Hostname = hostname
 
@@ -378,21 +379,21 @@ func connectAction(ctx *cli.Context) error {
 	var toEnableList []string
 	contentEnabled, err := cache.Get("content")
 	if err != nil {
-		return cli.Exit(fmt.Sprintf("failed to get content preference: %v", err), ExitCodeSoftware)
+		return cli.Exit(fmt.Sprintf("failed to get content preference: %v", err), exitcode.Software)
 	}
 	if contentEnabled {
 		toEnableList = append(toEnableList, "content")
 	}
 	analyticsEnabled, err := cache.Get("analytics")
 	if err != nil {
-		return cli.Exit(fmt.Sprintf("failed to get analytics preference: %v", err), ExitCodeSoftware)
+		return cli.Exit(fmt.Sprintf("failed to get analytics preference: %v", err), exitcode.Software)
 	}
 	if analyticsEnabled {
 		toEnableList = append(toEnableList, "analytics")
 	}
 	remoteManagementEnabled, err := cache.Get("remote-management")
 	if err != nil {
-		return cli.Exit(fmt.Sprintf("failed to get remote-management preference: %v", err), ExitCodeSoftware)
+		return cli.Exit(fmt.Sprintf("failed to get remote-management preference: %v", err), exitcode.Software)
 	}
 	if remoteManagementEnabled {
 		toEnableList = append(toEnableList, "remote management")
@@ -411,7 +412,7 @@ func connectAction(ctx *cli.Context) error {
 		start = time.Now()
 		contentRequested, err := cache.Get("content")
 		if err != nil {
-			return cli.Exit(fmt.Sprintf("failed to get content preference: %v", err), ExitCodeSoftware)
+			return cli.Exit(fmt.Sprintf("failed to get content preference: %v", err), exitcode.Software)
 		}
 		connectResult.TryRegisterRHSM(
 			ctx,
@@ -423,7 +424,7 @@ func connectAction(ctx *cli.Context) error {
 	// Enable data collection
 	analyticsRequested, err := cache.Get("analytics")
 	if err != nil {
-		return cli.Exit(fmt.Sprintf("failed to get analytics preference: %v", err), ExitCodeSoftware)
+		return cli.Exit(fmt.Sprintf("failed to get analytics preference: %v", err), exitcode.Software)
 	}
 	if analyticsRequested {
 		start = time.Now()
@@ -436,7 +437,7 @@ func connectAction(ctx *cli.Context) error {
 	// Enable remote management
 	remoteManagementRequested, err := cache.Get("remote-management")
 	if err != nil {
-		return cli.Exit(fmt.Sprintf("failed to get remote-management preference: %v", err), ExitCodeSoftware)
+		return cli.Exit(fmt.Sprintf("failed to get remote-management preference: %v", err), exitcode.Software)
 	}
 	if remoteManagementRequested {
 		if !connectResult.Features.Content.Successful {

--- a/cmd/rhc/constants.go
+++ b/cmd/rhc/constants.go
@@ -1,24 +1,6 @@
 package main
 
 const (
-	ExitCodeOK          = 0  // successful termination
-	ExitCodeErr         = 1  // generic error
-	ExitCodeUsage       = 64 // command line usage error
-	ExitCodeDataErr     = 65 // data format error
-	ExitCodeNoInput     = 66 // cannot open input
-	ExitCodeNoUser      = 67 // addressee unknown
-	ExitCodeNoHost      = 68 // host name unknown
-	ExitCodeUnavailable = 69 // service unavailable
-	ExitCodeSoftware    = 70 // internal software error
-	ExitCodeOSErr       = 71 // system error (e.g., can't fork)
-	ExitCodeOSFile      = 72 // critical OS file missing
-	ExitCodeCantCreat   = 73 // can't create (user) output file
-	ExitCodeIOErr       = 74 // input/output error
-	ExitCodeTempFail    = 75 // temp failure; user is invited to retry
-	ExitCodeProtocol    = 76 // remote error in protocol
-	ExitCodeNoPerm      = 77 // permission denied
-	ExitCodeConfig      = 78 // configuration error
-
 	// ConnectFeaturesPrefsPath is the path to the feature preferences cache file
 	ConnectFeaturesPrefsPath = "/var/lib/rhc/rhc-connect-features-prefs.json"
 

--- a/cmd/rhc/disconnect_cmd.go
+++ b/cmd/rhc/disconnect_cmd.go
@@ -7,12 +7,13 @@ import (
 	"os"
 	"time"
 
-	"github.com/redhatinsights/rhc/internal/rhsm"
 	"github.com/urfave/cli/v2"
 
 	"github.com/redhatinsights/rhc/internal/datacollection"
 	"github.com/redhatinsights/rhc/internal/remotemanagement"
+	"github.com/redhatinsights/rhc/internal/rhsm"
 	"github.com/redhatinsights/rhc/internal/ui"
+	"github.com/redhatinsights/rhc/pkg/exitcode"
 )
 
 // DisconnectResult is structure holding information about result of
@@ -192,9 +193,9 @@ func disconnectAction(ctx *cli.Context) error {
 		if ui.IsOutputMachineReadable() {
 			disconnectResult.UID = uid
 			disconnectResult.UIDError = errMsg
-			return cli.Exit(disconnectResult, ExitCodeErr)
+			return cli.Exit(disconnectResult, exitcode.NoPerm)
 		} else {
-			return cli.Exit(fmt.Errorf("%s", errMsg), ExitCodeErr)
+			return cli.Exit(fmt.Errorf("%s", errMsg), exitcode.NoPerm)
 		}
 	}
 
@@ -204,9 +205,9 @@ func disconnectAction(ctx *cli.Context) error {
 		slog.Error("error retrieving system hostname", "err", err)
 		if ui.IsOutputMachineReadable() {
 			disconnectResult.HostnameError = err.Error()
-			return cli.Exit(disconnectResult, ExitCodeErr)
+			return cli.Exit(disconnectResult, exitcode.Err)
 		} else {
-			return cli.Exit(err, ExitCodeErr)
+			return cli.Exit(err, exitcode.Err)
 		}
 	}
 

--- a/cmd/rhc/interactive.go
+++ b/cmd/rhc/interactive.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/redhatinsights/rhc/internal/conf"
 	"github.com/redhatinsights/rhc/internal/ui"
+	"github.com/redhatinsights/rhc/pkg/exitcode"
 )
 
 // showTimeDuration shows a table with the duration of each sub-action
@@ -47,5 +48,5 @@ func showErrorMessages(action string, errorMessages map[string]string) error {
 		fmt.Printf("Please see %s for full details.\n", logFile.Name())
 	}
 
-	return cli.Exit("", ExitCodeErr)
+	return cli.Exit("", exitcode.Err)
 }

--- a/cmd/rhc/main.go
+++ b/cmd/rhc/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/redhatinsights/rhc/internal/conf"
 	"github.com/redhatinsights/rhc/internal/ui"
+	"github.com/redhatinsights/rhc/pkg/exitcode"
 	"github.com/redhatinsights/rhc/pkg/feature"
 	"github.com/redhatinsights/rhc/pkg/version"
 )
@@ -35,7 +36,7 @@ func mainAction(c *cli.Context) error {
 	}
 	data, err := generationFunc()
 	if err != nil {
-		return cli.Exit(err, ExitCodeErr)
+		return cli.Exit(err, exitcode.Err)
 	}
 	fmt.Println(data)
 	return nil
@@ -154,7 +155,7 @@ func main() {
 	defaultConfigFilePath, err := ConfigPath()
 	if err != nil {
 		slog.Error(err.Error())
-		os.Exit(ExitCodeErr)
+		os.Exit(exitcode.Err)
 	}
 
 	app.Flags = []cli.Flag{

--- a/cmd/rhc/status_cmd.go
+++ b/cmd/rhc/status_cmd.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/godbus/dbus/v5"
-	"github.com/redhatinsights/rhc/internal/rhsm"
 	"github.com/urfave/cli/v2"
 
 	"github.com/briandowns/spinner"
@@ -18,7 +17,9 @@ import (
 
 	"github.com/redhatinsights/rhc/internal/datacollection"
 	"github.com/redhatinsights/rhc/internal/localization"
+	"github.com/redhatinsights/rhc/internal/rhsm"
 	"github.com/redhatinsights/rhc/internal/ui"
+	"github.com/redhatinsights/rhc/pkg/exitcode"
 )
 
 // rhsmStatus tries to print status provided by RHSM D-Bus API. If we provide
@@ -273,11 +274,11 @@ func statusAction(ctx *cli.Context) (err error) {
 			if err != nil {
 				err = cli.Exit(
 					fmt.Errorf("unable to print status as %s document: %s", format, err.Error()),
-					ExitCodeErr)
+					exitcode.IOErr)
 			}
-			// When any of status is not correct, then return ExitCodeErr exit code
+			// When any of status is not correct, then return exitcode.Err exit code
 			if systemStatus.returnCode != 0 {
-				err = cli.Exit("", ExitCodeErr)
+				err = cli.Exit("", exitcode.Err)
 			}
 		}(&systemStatus)
 	}
@@ -287,7 +288,7 @@ func statusAction(ctx *cli.Context) (err error) {
 		if ui.IsOutputMachineReadable() {
 			systemStatus.HostnameError = err.Error()
 		} else {
-			return cli.Exit(err, ExitCodeErr)
+			return cli.Exit(err, exitcode.Err)
 		}
 	}
 
@@ -344,9 +345,9 @@ func statusAction(ctx *cli.Context) (err error) {
 	ui.Printf("\nManage your connected systems: https://red.ht/connector\n")
 
 	// At the end check if all statuses are correct.
-	// If not, return ExitCodeErr exit code without any message.
+	// If not, return exitcode.Err exit code without any message.
 	if systemStatus.returnCode != 0 {
-		return cli.Exit("", ExitCodeErr)
+		return cli.Exit("", exitcode.Err)
 	}
 
 	return nil

--- a/cmd/rhc/util.go
+++ b/cmd/rhc/util.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sys/unix"
+
+	"github.com/redhatinsights/rhc/pkg/exitcode"
 )
 
 // isTerminal returns true if the file descriptor is terminal.
@@ -88,7 +90,7 @@ func checkFormatFlag(ctx *cli.Context) error {
 			format,
 			`"json"`,
 		)
-		return cli.Exit(err, ExitCodeDataErr)
+		return cli.Exit(err, exitcode.DataErr)
 	}
 }
 
@@ -122,7 +124,7 @@ func validateCollectorCommand(ctx *cli.Context, requiresCollectorID, requiresFor
 	}
 	if requiresCollectorID && ctx.Args().Len() == 0 {
 		commandName := getFullCommandName(ctx)
-		return cli.Exit(fmt.Sprintf("%s requires a collector ID", commandName), ExitCodeUsage)
+		return cli.Exit(fmt.Sprintf("%s requires a collector ID", commandName), exitcode.Usage)
 	}
 	configureUI(ctx)
 	return nil

--- a/internal/rhsm/rhsm.go
+++ b/internal/rhsm/rhsm.go
@@ -18,13 +18,11 @@ import (
 
 	"github.com/redhatinsights/rhc/internal/localization"
 	"github.com/redhatinsights/rhc/internal/ui"
+	"github.com/redhatinsights/rhc/pkg/exitcode"
 )
 
 const (
 	EnvTypeContentTemplate = "content-template"
-
-	// Exit codes
-	ExitCodeErr = 1 // generic error
 )
 
 func GetConsumerUUID() (string, error) {
@@ -366,7 +364,7 @@ func UnpackDBusError(err error) error {
 func RegisterRHSM(ctx *cli.Context, enableContent bool) (string, error) {
 	uuid, err := GetConsumerUUID()
 	if err != nil {
-		return "unable to get consumer UUID", cli.Exit(err, ExitCodeErr)
+		return "unable to get consumer UUID", cli.Exit(err, exitcode.Err)
 	}
 	var successMsg string
 
@@ -389,7 +387,7 @@ func RegisterRHSM(ctx *cli.Context, enableContent bool) (string, error) {
 				fmt.Print("Password: ")
 				data, err := term.ReadPassword(int(os.Stdin.Fd()))
 				if err != nil {
-					return "unable to read password", cli.Exit(err, ExitCodeErr)
+					return "unable to read password", cli.Exit(err, exitcode.IOErr)
 				}
 				password = string(data)
 				fmt.Printf("\n\n")
@@ -425,7 +423,7 @@ func RegisterRHSM(ctx *cli.Context, enableContent bool) (string, error) {
 				   the organization. */
 				if len(orgs) > 0 {
 					if ui.IsOutputMachineReadable() {
-						return "unable to register system to RHSM", cli.Exit("no organization specified", ExitCodeErr)
+						return "unable to register system to RHSM", cli.Exit("no organization specified", exitcode.Err)
 					}
 					// Stop spinner to be able to display message and ask for organization
 					if ui.IsOutputRich() {
@@ -460,7 +458,7 @@ func RegisterRHSM(ctx *cli.Context, enableContent bool) (string, error) {
 			}
 		}
 		if err != nil {
-			return "unable to register system to RHSM", cli.Exit(err, ExitCodeErr)
+			return "unable to register system to RHSM", cli.Exit(err, exitcode.Err)
 		}
 		successMsg = "Connected to Red Hat Subscription Management"
 	} else {

--- a/pkg/exitcode/exitcode.go
+++ b/pkg/exitcode/exitcode.go
@@ -1,0 +1,26 @@
+// Package exitcode defines exit codes for rhc CLI tools.
+//
+// These codes follow the sysexits.h convention from BSD systems,
+// providing standardized exit codes for command-line programs.
+// See: https://man.openbsd.org/sysexits.3
+package exitcode
+
+const (
+	OK          = 0  // successful termination
+	Err         = 1  // generic error
+	Usage       = 64 // command line usage error
+	DataErr     = 65 // data format error
+	NoInput     = 66 // cannot open input
+	NoUser      = 67 // addressee unknown
+	NoHost      = 68 // host name unknown
+	Unavailable = 69 // service unavailable
+	Software    = 70 // internal software error
+	OSErr       = 71 // system error (e.g., can't fork)
+	OSFile      = 72 // critical OS file missing
+	CantCreat   = 73 // can't create (user) output file
+	IOErr       = 74 // input/output error
+	TempFail    = 75 // temp failure; user is invited to retry
+	Protocol    = 76 // remote error in protocol
+	NoPerm      = 77 // permission denied
+	Config      = 78 // configuration error
+)


### PR DESCRIPTION
* Card ID: CCT-2422

Moved exit code constants out of cmd packages into pkg/exitcode so the values can be reused in the whole project.