### PR TITLE
fix(collector): Improve warning message invalid collector config

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -334,15 +334,15 @@ func newConfig(id string, dto *configDto) (Config, error) {
 		return Config{}, fmt.Errorf("invalid config: ingress.content_type is required")
 	}
 
-	// Emit warning if meta.feature is present but not 'analytics'
+	// Emit debug log message if meta.feature is present but not 'analytics'
 	if dto.Meta.Feature != nil && *dto.Meta.Feature != "analytics" {
-		slog.Warn("Unexpected meta.feature value", "actual", *dto.Meta.Feature, "expected", "analytics")
+		slog.Debug("Unsupported collector config feature value ignored", "feature", *dto.Meta.Feature, "supported", "analytics")
 	}
 
 	return Config{
 		ID:                 id,
 		Name:               dto.Meta.Name,
-		IsAnalyticsFeature: dto.Meta.Feature == nil || *dto.Meta.Feature == "analytics",
+		IsAnalyticsFeature: dto.Meta.Feature != nil && *dto.Meta.Feature == "analytics",
 		User:               user,
 		Group:              group,
 		ContentType:        dto.Ingress.ContentType,

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -112,7 +112,7 @@ func TestNewConfig(t *testing.T) {
 			want: Config{
 				ID:                 "test.nil.feature",
 				Name:               "Test nil feature",
-				IsAnalyticsFeature: true,
+				IsAnalyticsFeature: false,
 				User:               "root",
 				Group:              "root",
 				ContentType:        "application/vnd.redhat.advisor.collection",


### PR DESCRIPTION
* Card ID: CCT-2239

Improves the warning message when unsupported collector configuration feature values are provided.

- Update warning level log message to debug level and made message clearer when an unsupported collector configuration feature value is used