### PR TITLE
chore: Remove useless CLI option from unit file

### DIFF
--- a/data/systemd/rhc-server.service
+++ b/data/systemd/rhc-server.service
@@ -6,7 +6,7 @@ After=rhc-server.socket
 
 [Service]
 Type=simple
-ExecStart=/usr/libexec/rhc/rhc-server --varlink=unix:/run/rhc/com.redhat.rhc
+ExecStart=/usr/libexec/rhc/rhc-server
 StandardOutput=journal
 StandardError=journal
 ReadWritePaths=/run/rhc


### PR DESCRIPTION
* The rhc-server ignores all CLI options. It is useless to try to run rhc-server with some CLI options in systemd unit file