### PR TITLE
chore/fix/test: Added "make rpm" target and added another GitHub workflow for testing rpm build

### DIFF
--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -1,0 +1,68 @@
+name: rpmbuild.yml
+on:
+  pull_request:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  rpmbuild:
+    name: "rpmbuild"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "Fedora latest"
+            image: "registry.fedoraproject.org/fedora:latest"
+            slug: "fedora-latest"
+          - name: "Fedora Rawhide"
+            image: "registry.fedoraproject.org/fedora:rawhide"
+            slug: "fedora-rawhide"
+
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.image }}
+
+    steps:
+      - name: "Add COPR repository (Go Vendor Tools)"
+        run: |
+          dnf copr enable -y @go-sig/go-vendor-tools-dev
+
+      - name: "Install basic packages for 'dnf builddep'"
+        run: |
+          dnf --setopt install_weak_deps=False install -y \
+            git rpm-build go-vendor-tools go-rpm-macros
+
+      - name: "Checkout repository"
+        uses: actions/checkout@v6
+
+      - name: "Adding repository directory to the temporary git global config as a safe directory (again)"
+        run: |
+          git config --global --add safe.directory /__w/rhc/rhc
+
+      - name: "Install required packages"
+        run: |
+          dnf --setopt install_weak_deps=False builddep -y rhc.spec
+
+      - name: "Build srpm"
+        run: |
+          make srpm
+
+      - name: "Build rpm"
+        run: |
+          make rpm
+
+      - name: "Collect RPM artifacts"
+        run: |
+          mkdir -p rpms
+          cp ~/rpmbuild/RPMS/*/*.rpm rpms/
+
+      - name: "Upload RPM artifacts"
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-${{ matrix.slug }}
+          path: rpms/
+          retention-days: 30

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ archive:
 srpm: archive
 	rpmbuild --define "_sourcedir $$(pwd)" -bs rhc.spec
 
+.PHONY: rpm
+rpm: archive
+	rpmbuild --define "_sourcedir $$(pwd)" -bb rhc.spec
+
 # The 'clean' target removes build artifacts.
 .PHONY: clean
 clean:

--- a/data/systemd/presets/50-rhc.preset
+++ b/data/systemd/presets/50-rhc.preset
@@ -1,0 +1,1 @@
+enable rhc-server.socket

--- a/rhc.spec
+++ b/rhc.spec
@@ -19,6 +19,7 @@ Source2:        go-vendor-tools.toml
 
 BuildRequires:  go-vendor-tools
 BuildRequires:  systemd-rpm-macros
+BuildRequires:  askalono-cli
 %if 0%{?with_check}
 BuildRequires:  /usr/bin/dbus-launch
 %endif

--- a/rhc.spec
+++ b/rhc.spec
@@ -77,6 +77,8 @@ install -m 0755 -vd                     %{buildroot}%{_unitdir}
 install -m 0644 -vp data/systemd/rhc-canonical-facts.*  %{buildroot}%{_unitdir}/
 install -m 0644 -vp data/systemd/rhc-server.service  %{buildroot}%{_unitdir}/
 install -m 0644 -vp data/systemd/rhc-server.socket   %{buildroot}%{_unitdir}/
+install -m 0755 -vd %{buildroot}%{_prefix}/lib/systemd/system-preset/
+install -m 0644 -vp data/systemd/presets/50-rhc.preset %{buildroot}%{_prefix}/lib/systemd/system-preset/
 # Configuration
 install -m 0755 -vd                     %{buildroot}%{_sysconfdir}/%{name}/
 # Yggdrasil
@@ -125,6 +127,7 @@ fi
 %{_unitdir}/rhc-canonical-facts.*
 %{_unitdir}/rhc-server.service
 %{_unitdir}/rhc-server.socket
+%{_prefix}/lib/systemd/system-preset/50-rhc.preset
 # Configuration
 %{_sysconfdir}/%{name}/
 # Logrotate


### PR DESCRIPTION
* Allow to build rpm locally simply with "make rpm"
* Added simple workflow for quick testing of building rpm and srpm
* Added one missing build dependency (`askalono-cli`). The `askalono` is
  required in `go-vendor-tools.toml` configuration file.
* Fixed the issue wih `rhc-server.socket`. This socket has to be enabled, when `rhc` RPM is installed.