### PR TITLE
chore: The rhc-server.socket should not be enabled in fixture

### DIFF
--- a/integration-tests/test_collector_api.py
+++ b/integration-tests/test_collector_api.py
@@ -17,36 +17,6 @@ from utils.varlink import run_varlinkctl
 from utils.systemctl import is_service_active
 
 
-@pytest.fixture(scope="module")
-def rhc_server_socket():
-    """
-    Fixture to ensure rhc-server.socket is enabled and running before collector tests.
-    This is required for varlinkctl to communicate with the rhc-server.
-    """
-    socket_name = "rhc-server.socket"
-
-    # Check if socket is already active
-    was_active = is_service_active(socket_name)
-
-    if not was_active:
-        # Enable and start the socket
-        subprocess.run(
-            ["systemctl", "enable", "--now", socket_name],
-            check=True,
-            capture_output=True,
-        )
-
-    yield
-
-    # Cleanup: restore original state
-    if not was_active:
-        subprocess.run(
-            ["systemctl", "disable", "--now", socket_name],
-            check=False,
-            capture_output=True,
-        )
-
-
 # Ensure rhc_server_socket fixture is used for all tests in this module
 pytestmark = pytest.mark.usefixtures("rhc_server_socket")
 

--- a/integration-tests/test_socket_activated_service.py
+++ b/integration-tests/test_socket_activated_service.py
@@ -18,33 +18,6 @@ from utils.systemctl import (
 )
 
 
-@pytest.fixture(scope="module")
-def fd3_socket_setup():
-    """
-    Fixture to ensure rhc-server.socket is enabled for FD3 socket activation tests.
-    Stops the service if running to test auto-boot behavior.
-    """
-    socket_name = "rhc-server.socket"
-    service_name = "rhc-server.service"
-
-    socket_was_enabled = is_socket_enabled(socket_name)
-
-    if not socket_was_enabled:
-        enable_and_start_socket(socket_name)
-
-    if is_service_active(service_name):
-        stop_service(service_name)
-
-    yield {
-        "socket_name": socket_name,
-        "service_name": service_name,
-        "socket_was_enabled": socket_was_enabled,
-    }
-
-    if not socket_was_enabled:
-        disable_and_stop_socket(socket_name)
-
-
 @pytest.mark.tier1
 def test_fd3_socket_activation(fd3_socket_setup):
     """


### PR DESCRIPTION
* The rhc-server.socket is enabled, when the rhc rpm is installed. There is no need to have some fixtures for that. Such fixtures gave a fake feeling that software works as expected.