### PR TITLE
fix(test): Do not declare variable without using it

### DIFF
--- a/integration-tests/test_connect.py
+++ b/integration-tests/test_connect.py
@@ -483,7 +483,7 @@ def test_connect_with_content_template(external_candlepin, rhc, test_config, aut
     )
 
     command = ["connect"] + command_args
-    result = rhc.run(*command)
+    rhc.run(*command)
 
     # Verify connection
     assert rhc.is_registered


### PR DESCRIPTION
Remove the unused local variable assignment while keeping the command execution intact.

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._