### PR TITLE
fix(test): URL-encode proxy username and password 

### DIFF
--- a/integration-tests/utils/__init__.py
+++ b/integration-tests/utils/__init__.py
@@ -109,7 +109,9 @@ def configure_proxy_rhsm(subman, test_config, auth_proxy=False):
             proxy_user = test_config.get("auth_proxy.username")
             proxy_pass = test_config.get("auth_proxy.password")
             proxy_port = str(test_config.get("auth_proxy.port"))
-            proxy_url = f"http://{proxy_user}:{proxy_pass}@{proxy_host}:{proxy_port}"
+            proxy_user_enc = urllib.parse.quote(str(proxy_user), safe="")
+            proxy_pass_enc = urllib.parse.quote(str(proxy_pass), safe="")
+            proxy_url = f"http://{proxy_user_enc}:{proxy_pass_enc}@{proxy_host}:{proxy_port}"
         else:
             proxy_host = test_config.get("noauth_proxy.host")
             proxy_port = str(test_config.get("noauth_proxy.port"))

--- a/integration-tests/utils/__init__.py
+++ b/integration-tests/utils/__init__.py
@@ -13,7 +13,7 @@ def yggdrasil_service_is_active():
     :return: True if yggdrasil in active state else False
     """
     try:
-        stdout = sh.systemctl(f"is-active yggdrasil".split()).strip()
+        stdout = sh.systemctl("is-active yggdrasil".split()).strip()
         return stdout == "active"
     except sh.ErrorReturnCode_3:
         return False


### PR DESCRIPTION
fix(test): URL-encode proxy username and password 

If the username or a password contained special characters, they would break the URL.

---

fix(test): Drop 'f' prefix from a string