### PR TITLE
fix: Start rhc-server.socket, when rhc package is installed

### DIFF
--- a/rhc.spec
+++ b/rhc.spec
@@ -96,6 +96,9 @@ install -m 0644 -vp %{buildroot}%{_unitdir}/yggdrasil.service.d/rhcd.conf %{buil
 %post
 %systemd_post rhc-canonical-facts.timer
 %systemd_post rhc-server.socket
+if [ "$1" -eq 1 ] ; then
+    systemctl start rhc-server.socket >/dev/null 2>&1 || :
+fi
 %if 0%{?with_rhcd_compat}
 # On package update, ensure yggdrasil (formerly rhcd) has its own configuration file
 if [ $1 -eq 2 ] && [ ! -f /etc/yggdrasil/config.toml ]; then


### PR DESCRIPTION
* Not sure about it, because it break some policy
  * The service should not be started, when rpm is installed as part of installation script, but we will only instruct systemd to start to listen on one another socket.
* The `rhc-server.socket` has to be "started" to be able to call varlink API using given `/run/rhc/com.redhat.rhc` socket. The enabling the systemd `rhc-server.socket` is not enough despite the socket file `/run/rhc/com.redhat.rhc` is created by systemd. It seems that there is no macro for this.