### PR TITLE
fix: show helpful error when rhc-server.socket is not available

### DIFF
--- a/cmd/rhc/collector_cmd.go
+++ b/cmd/rhc/collector_cmd.go
@@ -3,10 +3,13 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
+	"os"
 	"strings"
+	"syscall"
 
 	"github.com/emersion/go-varlink"
 
@@ -23,7 +26,12 @@ const rhcServerSocket = "/run/rhc/com.redhat.rhc"
 func newCollectorClient() (*collectorapi.Client, func(), error) {
 	conn, err := net.Dial("unix", rhcServerSocket)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to connect to rhc-server: %w", err)
+		slog.Error("failed to connect to rhc-server", "error", err)
+		var pathErr *os.PathError
+		if errors.As(err, &pathErr) && errors.Is(pathErr.Err, syscall.ENOENT) {
+			return nil, nil, fmt.Errorf("rhc-server.socket is not available. Try: systemctl restart rhc-server.socket")
+		}
+		return nil, nil, err
 	}
 	varlinkClient := varlink.NewClient(conn)
 	client := &collectorapi.Client{Client: varlinkClient}


### PR DESCRIPTION
* Card ID: CCT-2530

When rhc collector commands fail to connect to the Unix socket, provide clear instructions to restart the socket unit instead of a generic connection error.