### PR TITLE
fix: Version for 'make build'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .ONESHELL:
 .SHELLFLAGS := -e -c
 
-VERSION := $(shell rpmspec rhc.spec --query --queryformat '%{version}')
+VERSION := $(shell rpmspec rhc.spec --query --srpm --queryformat '%{version}')
 LDFLAGS := -ldflags "-X github.com/redhatinsights/rhc/pkg/version.Version=$(VERSION)"
 GO_BUILD := go build $(LDFLAGS)
 


### PR DESCRIPTION
Without `--srpm` flag, rpmspec would read the value of VERSION from all binary packages, producing a string that repeats the version three times.

Generated-by: Claude Sonnet <noreply@anthropic.com>