### PR TITLE
fix: add rhc-collector related folders to spec file

### DIFF
--- a/rhc.spec
+++ b/rhc.spec
@@ -66,6 +66,9 @@ install -m 0755 -vd                     %{buildroot}%{bash_completions_dir}/
 install -m 0644 -vp data/completion/rhc.bash  %{buildroot}%{bash_completions_dir}/%{name}
 # Logs
 install -m 0755 -vd                     %{buildroot}%{_localstatedir}/log/%{name}/
+# Collector directories
+install -m 0755 -vd                     %{buildroot}%{_prefix}/lib/%{name}/collectors/
+install -m 0755 -vd                     %{buildroot}%{_libexecdir}/%{name}/collectors/
 # Logrotate
 install -m 0755 -vd                     %{buildroot}%{_sysconfdir}/logrotate.d/
 install -m 0644 -vp data/logrotate.d/rhc %{buildroot}%{_sysconfdir}/logrotate.d/rhc
@@ -130,6 +133,11 @@ fi
 %{_prefix}/lib/systemd/system-preset/50-rhc.preset
 # Configuration
 %{_sysconfdir}/%{name}/
+# Collector directories
+%dir %{_prefix}/lib/%{name}/collectors/
+%dir %{_libexecdir}/%{name}/collectors/
+# Logs
+%dir %{_localstatedir}/log/%{name}/
 # Logrotate
 %config(noreplace) %{_sysconfdir}/logrotate.d/rhc
 # Yggdrasil


### PR DESCRIPTION
* Card ID: CCT-2532

## Descripion

`/usr/lib/rhc/collectors` and `/usr/libexec/rhc/collectors` are folders owned by rhc-collector but not shipped in the rhc package. This commit adds them to the spec file so they are also included in the package.

Additionally, the `/var/log/rhc` folder is added in the %files section since it was being created but not added.

## Testing
Located in the repository in the PR branch, generate a package:
```console
[vagrant@lv-rhel101-go-lab rhc]$ git status
On branch macano/add-collector-directories-to-spec-file
Your branch is up to date with 'origin/macano/add-collector-directories-to-spec-file'.

nothing to commit, working tree clean

[vagrant@lv-rhel101-go-lab rhc]$ make rpm
...
```

Check for the presence of the added folders in the generated package:
```console
[vagrant@lv-rhel101-go-lab rhc]$ rpm -ql /home/vagrant/rpmbuild/RPMS/x86_64/rhc-0.3.9-1.el10.x86_64.rpm | grep -E '/var/log/rhc|/usr/lib/rhc/collectors|/usr/libexec/rhc/collectors'
/usr/lib/rhc/collectors
/usr/libexec/rhc/collectors
/var/log/rhc
``` 