### PR TITLE
fix(rhc-server): use ErrNotExist for socket connection error

### DIFF
--- a/cmd/rhc/collector_cmd.go
+++ b/cmd/rhc/collector_cmd.go
@@ -27,8 +27,7 @@ func newCollectorClient() (*collectorapi.Client, func(), error) {
 	conn, err := net.Dial("unix", rhcServerSocket)
 	if err != nil {
 		slog.Error("failed to connect to rhc-server", "error", err)
-		var pathErr *os.PathError
-		if errors.As(err, &pathErr) && errors.Is(pathErr.Err, syscall.ENOENT) {
+		if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ECONNREFUSED) {
 			return nil, nil, fmt.Errorf("rhc-server.socket is not available. Try: systemctl restart rhc-server.socket")
 		}
 		return nil, nil, err


### PR DESCRIPTION
* Card ID: CCT-2530

Replace syscall.ENOENT checking with os.ErrNotExist to simplify socket connection error detection. Also add ECONNREFUSED socket error to the same actionable error message.

---
AI suggestion in https://github.com/RedHatInsights/rhc/pull/460#discussion_r3348047491 turned out to be not working properly:
```
# systemctl status rhc-server.socket
○ rhc-server.socket - rhc server socket
     Loaded: loaded (/usr/lib/systemd/system/rhc-server.socket; enabled; preset: enabled)
     Active: inactive (dead)
   Triggers: ● rhc-server.service
       Docs: https://github.com/RedHatInsights/rhc
     Listen: /run/rhc/com.redhat.rhc (Stream)

Jun 02 03:06:25 kvm-03-guest14.lab.eng.rdu2.dc.redhat.com systemd[1]: Listening on rhc-server.socket - rhc server socket.
Jun 04 02:56:58 kvm-03-guest14.lab.eng.rdu2.dc.redhat.com systemd[1]: rhc-server.socket: Deactivated successfully.
Jun 04 02:56:58 kvm-03-guest14.lab.eng.rdu2.dc.redhat.com systemd[1]: Closed rhc-server.socket - rhc server socket.
# rhc collector list
failed to connect to rhc-server: dial unix /run/rhc/com.redhat.rhc: connect: connection refused
#
```