### PR TITLE
fix: create /var/tmp/rhc if missing

### DIFF
--- a/cmd/rhc-collector/main.go
+++ b/cmd/rhc-collector/main.go
@@ -57,9 +57,38 @@ func run(collectorId, command string) error {
 	return nil
 }
 
-// createTmpDir creates a temporary directory for collector output in rhcTmpDir.
-// Returns the directory path or an error if creation fails.
+// createTmpDir ensures rhcTmpDir exists with root-only permissions (0700)
+// and creates a collector-specific temporary directory inside it. If the
+// parent directory exists with different permissions, they are reset to
+// 0700. Returns the temporary directory path or an error if any step fails.
 func createTmpDir() (string, error) {
+	// Ensure the parent directory exists
+	if err := os.MkdirAll(rhcTmpDir, 0700); err != nil {
+		slog.Error("failed to create rhc temporary directory", "error", err)
+		return "", fmt.Errorf("failed to create rhc temporary directory: %w", err)
+	}
+
+	// Verify permissions and fix if necessary 
+	info, err := os.Stat(rhcTmpDir)
+	if err != nil {
+		slog.Error("failed to stat rhc temporary directory", "error", err)
+		return "", fmt.Errorf("failed to stat rhc temporary directory: %w", err)
+	}
+
+	if perms := info.Mode().Perm(); perms != 0700 {
+		slog.Warn(
+			"rhc temporary directory has incorrect permissions, resetting",
+			"path", rhcTmpDir,
+			"current_permissions", fmt.Sprintf("%#o", perms),
+			"expected_permissions", "0700",
+		)
+
+		if err := os.Chmod(rhcTmpDir, 0700); err != nil {
+			slog.Error("failed to reset permissions on rhc temporary directory", "error", err)
+			return "", fmt.Errorf("failed to reset permissions on rhc temporary directory: %w", err)
+		}
+	}
+
 	tmpDir, err := os.MkdirTemp(rhcTmpDir, "collector-")
 	if err != nil {
 		slog.Error("failed to create a temporary directory", "error", err)

--- a/cmd/rhc-collector/rhc-collector_test.go
+++ b/cmd/rhc-collector/rhc-collector_test.go
@@ -34,6 +34,14 @@ func TestCreateTmpDir(t *testing.T) {
 		if !strings.HasPrefix(tmpDir, rhcTmpDir) {
 			t.Errorf("createTmpDir() = %q, want prefix '%q'", tmpDir, rhcTmpDir)
 		}
+		parentInfo, err := os.Stat(rhcTmpDir)
+		if err != nil {
+			t.Errorf("parent directory does not exist: %v", err)
+			return
+		}
+		if perms := parentInfo.Mode().Perm(); perms != 0700 {
+			t.Errorf("parent directory permissions = %o, want %o", perms, os.FileMode(0700))
+		}
 		info, err := os.Stat(tmpDir)
 		if err != nil {
 			t.Errorf("created directory does not exist: %v", err)
@@ -43,6 +51,41 @@ func TestCreateTmpDir(t *testing.T) {
 			t.Error("created path is not a directory")
 		}
 	})
+}
+
+func TestCreateTmpDirCreatesMissingParent(t *testing.T) {
+	if err := os.RemoveAll(rhcTmpDir); err != nil {
+		t.Fatalf("failed to remove existing rhcTmpDir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(rhcTmpDir); err != nil {
+			t.Logf("Failed to clean up rhcTmpDir: %v", err)
+		}
+	})
+
+	tmpDir, err := createTmpDir()
+	if err != nil {
+		t.Fatalf("createTmpDir() unexpected error: %v", err)
+	}
+
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Logf("Failed to clean up temp dir: %v", err)
+		}
+	}()
+
+	info, err := os.Stat(rhcTmpDir)
+	if err != nil {
+		t.Fatalf("parent directory was not created: %v", err)
+	}
+
+	if !info.IsDir() {
+		t.Fatal("rhcTmpDir is not a directory")
+	}
+
+	if perms := info.Mode().Perm(); perms != 0700 {
+		t.Errorf("permissions = %o, want %o", perms, os.FileMode(0700))
+	}
 }
 
 // TestGetConfig verifies that getConfig correctly validates the collector ID


### PR DESCRIPTION
* Card Id: CCT-2534

Create /var/tmp/rhc with root-only permissions before creating the collector-specific temporary directory. This prevents rhc-collector from failing when the parent directory does not already exist.