### PR TITLE
ci: use the latest version of woke

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,4 +54,5 @@ jobs:
       - name: Run woke
         uses: get-woke/woke-action@v0
         with:
+          version: "latest"
           fail-on-error: true


### PR DESCRIPTION
CI pipeline for woke job was complaining that it could not find the correct version (`get-woke/woke crit unable to find '' - use 'latest'`). This commit pinpoints it to the latest version.