### PR TITLE
fix: invoke WriteTimerCache during collector execution

### DIFF
--- a/cmd/rhc-collector/main.go
+++ b/cmd/rhc-collector/main.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/redhatinsights/rhc/internal/collector"
 	httpapi "github.com/redhatinsights/rhc/internal/http"
@@ -34,16 +35,17 @@ func main() {
 }
 
 func run(collectorId, command string) error {
+	config, err := getConfig(collectorId)
+	if err != nil {
+		return err
+	}
 	tmpDir, err := createTmpDir()
 	if err != nil {
 		return err
 	}
 	defer cleanup(tmpDir)
-	config, err := getConfig(collectorId)
-	if err != nil {
-		return err
-	}
-	if err = executeCollector(command, tmpDir); err != nil {
+
+	if err = executeCollector(collectorId, command, tmpDir); err != nil {
 		return err
 	}
 	archivePath, err := getArchivePath(tmpDir)
@@ -83,15 +85,43 @@ func getConfig(collectorId string) (collector.Config, error) {
 
 // executeCollector runs the specified collector command and stores output in tmpDir.
 // Returns an error if the command execution fails.
-func executeCollector(command, tmpDir string) error {
+func executeCollector(collectorId, command, tmpDir string) error {
 	// TODO: Run collector as specific user and group (defined in config of collector)
 	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("%s %q", command, tmpDir))
 	cmd.Dir = tmpDir
+
+	// Capture start/end time and execute the command
+	startTime := time.Now()
 	output, err := cmd.CombinedOutput()
+	endTime := time.Now()
+
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = 1
+		}
+	}
+
+	// Timer payload and writing to cache
+	timerPayload := collector.Timer{
+		ID:           collectorId,
+		LastStarted:  startTime,
+		LastFinished: endTime,
+		ExitCode:     exitCode,
+	}
+	if cacheErr := collector.WriteTimerCache(collectorId, timerPayload); cacheErr != nil {
+		slog.Error("Failed to write timer cache", "error", cacheErr)
+		return fmt.Errorf("failed to write timer cache: %w", cacheErr)
+	}
+
+	// original errors
 	if err != nil {
 		slog.Error("failed to execute collector", "error", err, "output", string(output))
 		return fmt.Errorf("failed to execute collector: %w", err)
 	}
+
 	slog.Info("collector has ran successfully", "output", string(output))
 	return nil
 }

--- a/cmd/rhc-collector/rhc-collector_test.go
+++ b/cmd/rhc-collector/rhc-collector_test.go
@@ -65,7 +65,7 @@ func TestExecuteCollector(t *testing.T) {
 	t.Run("successful command execution", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		command := "echo 'test output'"
-		err := executeCollector(command, tmpDir)
+		err := executeCollector("test.collector", command, tmpDir)
 		if err != nil {
 			t.Errorf("executeCollector() unexpected error: %v", err)
 		}
@@ -75,7 +75,7 @@ func TestExecuteCollector(t *testing.T) {
 		tmpDir := t.TempDir()
 		testFile := "test-output.txt"
 		command := fmt.Sprintf("echo 'test content' > %s", testFile)
-		err := executeCollector(command, tmpDir)
+		err := executeCollector("test.collector", command, tmpDir)
 		if err != nil {
 			t.Errorf("executeCollector() unexpected error: %v", err)
 		}
@@ -88,7 +88,7 @@ func TestExecuteCollector(t *testing.T) {
 	t.Run("failing command", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		command := "exit 1"
-		err := executeCollector(command, tmpDir)
+		err := executeCollector("test.collector", command, tmpDir)
 		if err == nil {
 			t.Error("executeCollector() expected error for failing command")
 		}
@@ -100,7 +100,7 @@ func TestExecuteCollector(t *testing.T) {
 	t.Run("nonexistent command", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		command := "nonexistentcommand123456"
-		err := executeCollector(command, tmpDir)
+		err := executeCollector("test.collector", command, tmpDir)
 		if err == nil {
 			t.Error("executeCollector() expected error for nonexistent command")
 		}
@@ -109,7 +109,7 @@ func TestExecuteCollector(t *testing.T) {
 	t.Run("command with special characters", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		command := "echo 'test with spaces and \"quotes\"'"
-		err := executeCollector(command, tmpDir)
+		err := executeCollector("test.collector", command, tmpDir)
 		if err != nil {
 			t.Errorf("executeCollector() unexpected error with special characters: %v", err)
 		}


### PR DESCRIPTION
This change updates `executeCollector` to:
- Capture the `startTime` and `endTime` around the command execution.
- Safely extract the process exit code via `exec.ExitError` type assertion.
- Call `collector.WriteTimerCache` to write the execution info to the filesystem cache at `/var/cache/rhc/collectors/COLLECTOR-ID.json`.

Thw work is done for CCT-2537