### PR TITLE
fix: invoke WriteTimerCache during collector execution

### DIFF
--- a/cmd/rhc-collector/main.go
+++ b/cmd/rhc-collector/main.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/redhatinsights/rhc/internal/collector"
 	httpapi "github.com/redhatinsights/rhc/internal/http"
@@ -34,16 +35,17 @@ func main() {
 }
 
 func run(collectorId, command string) error {
+	config, err := getConfig(collectorId)
+	if err != nil {
+		return err
+	}
 	tmpDir, err := createTmpDir()
 	if err != nil {
 		return err
 	}
 	defer cleanup(tmpDir)
-	config, err := getConfig(collectorId)
-	if err != nil {
-		return err
-	}
-	if err = executeCollector(command, tmpDir); err != nil {
+
+	if err = executeCollector(collectorId, command, tmpDir); err != nil {
 		return err
 	}
 	archivePath, err := getArchivePath(tmpDir)
@@ -112,15 +114,44 @@ func getConfig(collectorId string) (collector.Config, error) {
 
 // executeCollector runs the specified collector command and stores output in tmpDir.
 // Returns an error if the command execution fails.
-func executeCollector(command, tmpDir string) error {
+func executeCollector(collectorId, command, tmpDir string) error {
 	// TODO: Run collector as specific user and group (defined in config of collector)
 	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("%s %q", command, tmpDir))
 	cmd.Dir = tmpDir
+
+	// Capture start/end time and execute the command
+	startTime := time.Now()
 	output, err := cmd.CombinedOutput()
+	endTime := time.Now()
+
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = 1
+		}
+	}
+
+	// Timer payload and writing to cache
+	timerPayload := collector.Timer{
+		ID:           collectorId,
+		LastStarted:  startTime,
+		LastFinished: endTime,
+		ExitCode:     exitCode,
+	}
+	cacheErr := collector.WriteTimerCache(collectorId, timerPayload)
+	if cacheErr != nil {
+		slog.Error("Failed to write timer cache", "error", cacheErr)
+	}
 	if err != nil {
 		slog.Error("failed to execute collector", "error", err, "output", string(output))
 		return fmt.Errorf("failed to execute collector: %w", err)
 	}
+	if cacheErr != nil {
+		return fmt.Errorf("failed to write timer cache: %w", cacheErr)
+	}
+
 	slog.Info("collector has ran successfully", "output", string(output))
 	return nil
 }

--- a/cmd/rhc-collector/rhc-collector_test.go
+++ b/cmd/rhc-collector/rhc-collector_test.go
@@ -105,10 +105,17 @@ func TestGetConfig(t *testing.T) {
 // TestExecuteCollector verifies that executeCollector runs shell commands in
 // the provided working directory.
 func TestExecuteCollector(t *testing.T) {
+	if err := os.MkdirAll(collector.TimerDir, 0755); err != nil {
+		t.Skipf("Cannot create timer cache directory %s: %v", collector.TimerDir, err)
+	}
+	t.Cleanup(func() {
+		_ = os.Remove(filepath.Join(collector.TimerDir, "test.collector.json"))
+	})
+
 	t.Run("successful command execution", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		command := "echo 'test output'"
-		err := executeCollector(command, tmpDir)
+		err := executeCollector("test.collector", command, tmpDir)
 		if err != nil {
 			t.Errorf("executeCollector() unexpected error: %v", err)
 		}
@@ -118,7 +125,7 @@ func TestExecuteCollector(t *testing.T) {
 		tmpDir := t.TempDir()
 		testFile := "test-output.txt"
 		command := fmt.Sprintf("echo 'test content' > %s", testFile)
-		err := executeCollector(command, tmpDir)
+		err := executeCollector("test.collector", command, tmpDir)
 		if err != nil {
 			t.Errorf("executeCollector() unexpected error: %v", err)
 		}
@@ -131,7 +138,7 @@ func TestExecuteCollector(t *testing.T) {
 	t.Run("failing command", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		command := "exit 1"
-		err := executeCollector(command, tmpDir)
+		err := executeCollector("test.collector", command, tmpDir)
 		if err == nil {
 			t.Error("executeCollector() expected error for failing command")
 		}
@@ -143,7 +150,7 @@ func TestExecuteCollector(t *testing.T) {
 	t.Run("nonexistent command", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		command := "nonexistentcommand123456"
-		err := executeCollector(command, tmpDir)
+		err := executeCollector("test.collector", command, tmpDir)
 		if err == nil {
 			t.Error("executeCollector() expected error for nonexistent command")
 		}
@@ -152,7 +159,7 @@ func TestExecuteCollector(t *testing.T) {
 	t.Run("command with special characters", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		command := "echo 'test with spaces and \"quotes\"'"
-		err := executeCollector(command, tmpDir)
+		err := executeCollector("test.collector", command, tmpDir)
 		if err != nil {
 			t.Errorf("executeCollector() unexpected error with special characters: %v", err)
 		}

--- a/integration-tests/test_collector_api.py
+++ b/integration-tests/test_collector_api.py
@@ -16,6 +16,9 @@ import textwrap
 from utils.varlink import run_varlinkctl
 from utils.systemctl import is_service_active
 
+RHC_COLLECTOR = "/usr/libexec/rhc/rhc-collector"
+TIMER_CACHE_DIR = "/var/cache/rhc/collectors"
+
 
 @pytest.fixture(scope="module")
 def rhc_server_socket():
@@ -240,6 +243,51 @@ def test_collector_info_with_timer_cache(
     # Verify last_run is present and matches
     assert "last_run" in info
     assert info["last_run"] == expected_last_run
+
+
+@pytest.mark.tier2
+def test_rhc_collector_writes_timer_cache(collector_config, rhc):
+    """
+    :id: b3644f21-1f2c-429b-b0eb-686749213a6a
+    :title: Verify rhc-collector writes timer cache after execution
+    :description:
+        Test that running rhc-collector creates a timer cache file with
+        execution timing information.
+    :tags: Tier 2
+    :steps:
+        1. Create test collector configuration
+        2. Run rhc-collector with a simple command
+        3. Verify timer cache file is created with expected fields
+    :expectedresults:
+        1. Test collector is created
+        2. rhc-collector runs the command
+        3. Cache file contains last_started and last_finished timestamps
+    """
+    collector_id = collector_config["id"]
+    cache_path = os.path.join(TIMER_CACHE_DIR, f"{collector_id}.json")
+
+    os.makedirs("/var/tmp/rhc", exist_ok=True)
+    os.makedirs(TIMER_CACHE_DIR, exist_ok=True)
+    if os.path.exists(cache_path):
+        os.remove(cache_path)
+
+    try:
+        subprocess.run(
+            [RHC_COLLECTOR, collector_id, "/bin/true"],
+            capture_output=True,
+            check=False,
+        )
+        assert os.path.exists(cache_path), "Timer cache file should be created"
+
+        with open(cache_path) as cache_file:
+            cache = json.load(cache_file)
+
+        assert "last_started" in cache
+        assert "last_finished" in cache
+        assert cache["last_finished"]["exit_code"] == 0
+    finally:
+        if os.path.exists(cache_path):
+            os.remove(cache_path)
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
This change updates `executeCollector` to:
- Capture the `startTime` and `endTime` around the command execution.
- Safely extract the process exit code via `exec.ExitError` type assertion.
- Call `collector.WriteTimerCache` to write the execution info to the filesystem
cache at `/var/cache/rhc/collectors/COLLECTOR-ID.json`.

The work is done for CCT-2537