### PR TITLE
fix(docs): Update docstrings

### DIFF
--- a/cmd/rhc-collector/rhc-collector_test.go
+++ b/cmd/rhc-collector/rhc-collector_test.go
@@ -45,6 +45,8 @@ func TestCreateTmpDir(t *testing.T) {
 	})
 }
 
+// TestGetConfig verifies that getConfig correctly validates the collector ID
+// before attempting to read from the filesystem.
 func TestGetConfig(t *testing.T) {
 	// Note: Can't test happy path without mocking filesystem or root permissions.
 	// This wrapper around collector.GetConfig() reads from /usr/lib/rhc/collectors/.
@@ -57,6 +59,8 @@ func TestGetConfig(t *testing.T) {
 	})
 }
 
+// TestExecuteCollector verifies that executeCollector runs shell commands in
+// the provided working directory.
 func TestExecuteCollector(t *testing.T) {
 	t.Run("successful command execution", func(t *testing.T) {
 		tmpDir := t.TempDir()
@@ -113,9 +117,7 @@ func TestExecuteCollector(t *testing.T) {
 }
 
 // TestGetArchive verifies that collector.GetArchive correctly creates a
-// .tar.xz archive from a given source directory. It covers three cases:
-// a directory containing files, an empty directory, and a nonexistent source
-// path (which must return an error).
+// .tar.xz archive from a given source directory.
 func TestGetArchive(t *testing.T) {
 	t.Run("directory with files", func(t *testing.T) {
 		srcDir := t.TempDir()
@@ -184,6 +186,7 @@ func getArchivePathFromTmpDir(t *testing.T) string {
 	return archivePath
 }
 
+// TestUploadArchive verifies the behavior of uploadArchive.
 func TestUploadArchive(t *testing.T) {
 	testConfig := collector.Config{
 		ID:          "test.collector",
@@ -191,6 +194,7 @@ func TestUploadArchive(t *testing.T) {
 		ContentType: "application/vnd.redhat.advisor.collection",
 	}
 
+	// FIXME What is this testing, without any asserts?
 	t.Run("upload with valid parameters", func(t *testing.T) {
 		archivePath := getArchivePathFromTmpDir(t)
 		err := uploadArchive(archivePath, testConfig)
@@ -219,6 +223,8 @@ func TestUploadArchive(t *testing.T) {
 	})
 }
 
+// TestCleanup verifies that the cleanup function removes a file or directory
+// when called.
 func TestCleanup(t *testing.T) {
 	t.Run("removes file successfully", func(t *testing.T) {
 		tmpFile, err := os.CreateTemp("", "test-cleanup-")

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -93,7 +93,8 @@ type timerDto struct {
 	LastFinished *finishedEventDto `json:"last_finished"`
 }
 
-// GetArchive generates an archive filename and creates a compressed archive from the specified directory.
+// GetArchive generates an archive filename, creates a compressed archive
+// from the sourceDir in the outputDir, and returns the path to the created archive.
 func GetArchive(sourceDir, outputDir string) (string, error) {
 	outputDir, err := ensureOutputDir(outputDir)
 	if err != nil {


### PR DESCRIPTION
GitHub doesn't like force-pushing to rebase if the force-pushed history contains unsigned commits. Opening as the last part of #461.