### PR TITLE
 fix: change content availability status message

### DIFF
--- a/cmd/rhc/connect_cmd.go
+++ b/cmd/rhc/connect_cmd.go
@@ -103,12 +103,14 @@ func (connectResult *ConnectResult) TryRegisterRHSM(cmd *cli.Command, enableCont
 		ui.Printf("%s[%v] %s\n", ui.Indent.Small, ui.Icons.Ok, returnedMsg)
 		if enableContent {
 			connectResult.Features.Content.Successful = true
-			slog.Info("redhat.repo has been generated")
-			ui.Printf("%s[%v] Content ... Red Hat repository file generated\n", ui.Indent.Medium, ui.Icons.Ok)
+			infoMsg := "System has access to content"
+			slog.Info(infoMsg)
+			ui.Printf("%s[%v] Content ... %v\n", ui.Indent.Medium, ui.Icons.Ok, infoMsg)
 		} else {
 			connectResult.Features.Content.Successful = false
-			slog.Info("redhat.repo not generated (content feature disabled)")
-			ui.Printf("%s[%v] Content ... Red Hat repository file absent\n", ui.Indent.Medium, ui.Icons.Info)
+			infoMsg := "System has no access to content"
+			slog.Info(infoMsg)
+			ui.Printf("%s[ ] Content ... %v\n", ui.Indent.Medium, infoMsg)
 		}
 	}
 }

--- a/cmd/rhc/status_cmd.go
+++ b/cmd/rhc/status_cmd.go
@@ -84,20 +84,14 @@ func isContentEnabled(systemStatus *SystemStatus) error {
 
 	if contentEnabled == "1" && uuid != "" {
 		systemStatus.ContentEnabled = true
-		infoMsg := "Red Hat repository file generated"
+		infoMsg := "System has access to content"
 		slog.Info(infoMsg)
 		ui.Printf("%s[%v] Content ... %v\n", ui.Indent.Medium, ui.Icons.Ok, infoMsg)
 	} else {
 		systemStatus.ContentEnabled = false
-		if uuid != "" {
-			infoMsg := "Generating of Red Hat repository file disabled in rhsm.conf"
-			slog.Info(infoMsg)
-			ui.Printf("%s[ ] Content ... %v\n", ui.Indent.Medium, infoMsg)
-		} else {
-			infoMsg := "Red Hat repository file not generated"
-			slog.Info(infoMsg)
-			ui.Printf("%s[ ] Content ... %v\n", ui.Indent.Medium, infoMsg)
-		}
+		infoMsg := "System has no access to content"
+		slog.Info(infoMsg)
+		ui.Printf("%s[ ] Content ... %v\n", ui.Indent.Medium, infoMsg)
 	}
 	return nil
 }

--- a/integration-tests/test_logging.py
+++ b/integration-tests/test_logging.py
@@ -692,7 +692,7 @@ def test_log_connect_with_disabled_feature(
     :description:
         Verifies that when 'rhc connect' is run with --disable-feature content,
         the log file contains messages indicating the content feature was
-        disabled and the repository file was not generated.
+        disabled and the system has no access to content.
     :tags: Tier 1
     :steps:
         1. Ensure the system is disconnected.
@@ -703,8 +703,8 @@ def test_log_connect_with_disabled_feature(
         1. The system is disconnected.
         2. 'rhc connect' executes.
         3. New log entries are captured.
-        4. Log contains a message indicating that the content feature is
-           disabled and that redhat.repo was not generated.
+        4. Log contains a message indicating that the system has no access
+           to content.
     """
     with contextlib.suppress(Exception):
         rhc.disconnect()
@@ -715,8 +715,8 @@ def test_log_connect_with_disabled_feature(
     rhc.run(*command)
 
     content = log_monitor.get_new_content()
-    assert "redhat.repo not generated" in content or "content feature disabled" in content, (
-        "Log should indicate the content feature was disabled"
+    assert "System has no access to content" in content, (
+        "Log should indicate the system has no access to content"
     )
 
 

--- a/integration-tests/test_status.py
+++ b/integration-tests/test_status.py
@@ -35,7 +35,7 @@ def test_status_connected(external_candlepin, rhc, test_config):
         3.  The 'rhc status' command executes successfully.
         4.  The exit code is 0.
         5.  The output contains "Connected to Red Hat Subscription Management",
-            "Connected to Red Hat Lightspeed (formerly Insights)", "Red Hat repository file generated",
+            "Connected to Red Hat Lightspeed (formerly Insights)", "System has access to content",
             and "The yggdrasil service is active".
     """
 
@@ -47,7 +47,7 @@ def test_status_connected(external_candlepin, rhc, test_config):
     status_result = rhc.run("status", check=False)
     assert status_result.returncode == 0
     assert "Connected to Red Hat Subscription Management" in status_result.stdout
-    assert "Red Hat repository file generated" in status_result.stdout
+    assert "System has access to content" in status_result.stdout
     assert "Connected to Red Hat Lightspeed (formerly Insights)" in status_result.stdout
     assert "The yggdrasil service is active" in status_result.stdout
 
@@ -164,7 +164,7 @@ def test_status_disconnected(rhc):
         2.  The command executes.
         3.  The exit code is not 0.
         4.  The status command output contains "Not connected to Red Hat Subscription Management",
-            "Red Hat repository file not generated", "Not connected to Red Hat Lightspeed (formerly Insights)",
+            "System has no access to content", "Not connected to Red Hat Lightspeed (formerly Insights)",
             and a message indicating that the yggdrasil service is inactive.
     """
 
@@ -173,7 +173,7 @@ def test_status_disconnected(rhc):
     status_result = rhc.run("status", check=False)
     assert status_result.returncode != 0
     assert "Not connected to Red Hat Subscription Management" in status_result.stdout
-    assert "Red Hat repository file not generated" in status_result.stdout
+    assert "System has no access to content" in status_result.stdout
     assert "Not connected to Red Hat Lightspeed (formerly Insights)" in status_result.stdout
     assert "The yggdrasil service is inactive" in status_result.stdout
 
@@ -385,7 +385,7 @@ def test_status_connected_yggdrasil_masked(external_candlepin, rhc, test_config)
         3.  The command executes and fails.
         4.  The exit code is not 0.
         5.  The output contains "Connected to Red Hat Subscription Management",
-            "Connected to Red Hat Lightspeed (formerly Insights)", "Red Hat repository file generated",
+            "Connected to Red Hat Lightspeed (formerly Insights)", "System has access to content",
             "Unit yggdrasil.service is masked"
         6.  The 'yggdrasil.service' is unmasked.
     """
@@ -404,7 +404,7 @@ def test_status_connected_yggdrasil_masked(external_candlepin, rhc, test_config)
     assert status_result.returncode != 0
     # RHSM
     assert "Connected to Red Hat Subscription Management" in status_result.stdout
-    assert "Red Hat repository file generated" in status_result.stdout
+    assert "System has access to content" in status_result.stdout
     # Insights
     assert "Connected to Red Hat Lightspeed (formerly Insights)" in status_result.stdout
     # yggdrasil


### PR DESCRIPTION
* Card ID: CCT-2436
## Description

The content availability is now reported directly, instead of the presence of the repository file presence, since it does not really determine if the content is available.

## Testing

Generate a package with this branch and install it. 

Connect the system:
```console
[vagrant@lv-rhel101-go-lab rhc]$ sudo rhc connect
Connecting lv-rhel101-go-lab to Red Hat. Enabled features: content, analytics, remote management.
This might take some time.

Username:
Password: 

 [✓] Connected to Red Hat Subscription Management
  [✓] Content ... System has access to content
  [✓] Analytics ... Connected to Red Hat Lightspeed (formerly Insights)
  [✓] Remote Management ... Activated the yggdrasil service

Successfully connected to Red Hat!

Manage your connected systems: https://red.ht/connector

```

Check status:
```console
[vagrant@lv-rhel101-go-lab rhc]$ sudo rhc status
Connection status for lv-rhel101-go-lab:

 [✓] Connected to Red Hat Subscription Management
  [✓] Content ... System has access to content
  [✓] Analytics ... Connected to Red Hat Lightspeed (formerly Insights)
  [✓] Remote Management ... The yggdrasil service is active

Manage your connected systems: https://red.ht/connector
```

Disable content and check status again:
```console
[vagrant@lv-rhel101-go-lab rhc]$ sudo rhc configure features disable content
Feature 'remote-management' disabled (depends on 'content').
Feature 'content' disabled.
[vagrant@lv-rhel101-go-lab rhc]$ sudo rhc status
Connection status for lv-rhel101-go-lab:

 [✓] Connected to Red Hat Subscription Management
  [ ] Content ... System has no access to content
  [✓] Analytics ... Connected to Red Hat Lightspeed (formerly Insights)
  [ ] Remote Management ... The yggdrasil service is inactive but loaded

Manage your connected systems: https://red.ht/connector
```

The status now shows the content accessibility instead of the presence of the repo file, since it does not really determine if the system has or hasn't actual access to content.