### PR TITLE
feat(collector): add minimal collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /rhc-server
 /rhc-collector
 /rhc.1.gz
+/data-collector
 /USAGE.md
 rhc.spec
 !/rhc.spec

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ build:
 	$(GO_BUILD) -o rhc ./cmd/rhc
 	$(GO_BUILD) -o rhc-server ./cmd/rhc-server
 	$(GO_BUILD) -o rhc-collector ./cmd/rhc-collector
+	$(GO_BUILD) -o data-collector ./cmd/data-collector
 
 .PHONY: archive
 archive:
@@ -31,4 +32,5 @@ clean:
 	rm -f rhc
 	rm -f rhc-server
 	rm -f rhc-collector
+	rm -f data-collector
 	rm -f rhc-*.tar*

--- a/cmd/data-collector/data_collector.go
+++ b/cmd/data-collector/data_collector.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/redhatinsights/rhc/internal/canonical_facts"
+)
+
+const (
+	providerID = "com.redhat.advisor"
+	reporter   = "rhc-data-collector"
+)
+
+// runDataCollection executes the complete data collection process.
+func runDataCollection(outputDir string) error {
+	// Collect canonical facts
+	facts, err := canonical_facts.GetCanonicalFacts()
+	if err != nil {
+		return err
+	}
+
+	// Create HBI ingress message
+	hbiMessage := createHBIMessage(facts)
+	if err := writeJSONFile(outputDir, "host.json", hbiMessage); err != nil {
+		return err
+	}
+
+	// Create canonical facts file for compatibility
+	if err := writeJSONFile(outputDir, "canonical_facts.json", facts); err != nil {
+		return err
+	}
+
+	// Create archive metadata
+	archiveMetadata := createArchiveMetadata(facts)
+	if err := writeJSONFile(outputDir, "archive_metadata.json", archiveMetadata); err != nil {
+		return err
+	}
+
+	slog.Debug("Generated files", "host", "host.json", "canonical_facts", "canonical_facts.json", "archive_metadata", "archive_metadata.json")
+	return nil
+}
+
+// createHBIMessage generates the HBI ingress message format.
+//
+// See: https://inscope.corp.redhat.com/docs/default/component/host-based-inventory.
+func createHBIMessage(facts *canonical_facts.CanonicalFacts) map[string]interface{} {
+	// Use machine_id as fallback when insights_id is missing
+	insightsID := facts.InsightsID
+	if insightsID == "" {
+		insightsID = facts.MachineID
+	}
+
+	// Extract org_id from RHSM certificate
+	orgID, err := extractOrgID("/etc/pki/consumer/cert.pem")
+	if err != nil {
+		slog.Debug("Failed to extract org_id from RHSM certificate", "error", err)
+		orgID = "unknown"
+	}
+
+	return map[string]interface{}{
+		"operation": "add_host",
+		"operation_args": map[string]interface{}{
+			"defer_to_reporter": reporter,
+		},
+		"platform_metadata": map[string]interface{}{
+			"request_id": reporter + "-" + facts.MachineID,
+		},
+		"data": map[string]interface{}{
+			"org_id":                  orgID,
+			"reporter":                reporter,
+			"provider_id":             providerID,
+			"provider_type":           "rhc",
+			"insights_id":             insightsID,
+			"machine_id":              facts.MachineID,
+			"bios_uuid":               facts.BIOSUUID,
+			"subscription_manager_id": facts.SubscriptionManagerID,
+			"ip_addresses":            facts.IPAddresses,
+			"mac_addresses":           facts.MACAddresses,
+			"fqdn":                    facts.FQDN,
+		},
+	}
+}
+
+// createArchiveMetadata generates the archive metadata.
+func createArchiveMetadata(facts *canonical_facts.CanonicalFacts) map[string]interface{} {
+	return map[string]interface{}{
+		"provider_id":     providerID,
+		"collection_type": "ingress",
+		"collector":       "data-collector",
+		"canonical_facts": facts,
+	}
+}
+
+// writeJSONFile writes data to a JSON file with pretty formatting.
+func writeJSONFile(outputDir, filename string, data interface{}) error {
+	filePath := filepath.Join(outputDir, filename)
+	file, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer func(file *os.File) {
+		if err := file.Close(); err != nil {
+			slog.Debug("failed to close file", "file", file.Name(), "error", err)
+			return
+		}
+	}(file)
+
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(data)
+}
+
+// extractOrgID reads the RHSM consumer certificate and extracts the org_id.
+func extractOrgID(filename string) (string, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return "", err
+	}
+
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return "", fmt.Errorf("failed to decode PEM data: %v", filename)
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", err
+	}
+
+	// Extract org ID from Organization field
+	if len(cert.Subject.Organization) > 0 {
+		return cert.Subject.Organization[0], nil
+	}
+
+	return "", fmt.Errorf("no organization found in certificate")
+}

--- a/cmd/data-collector/main.go
+++ b/cmd/data-collector/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/redhatinsights/rhc/pkg/exitcode"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		slog.Error("usage: data-collector OUTPUT_DIRECTORY")
+		os.Exit(exitcode.Usage)
+	}
+	outputDir := os.Args[1]
+
+	if err := runDataCollection(outputDir); err != nil {
+		slog.Error("data collector failed", "error", err)
+		os.Exit(exitcode.Err)
+	}
+}

--- a/data/systemd/rhc-data-collector.service
+++ b/data/systemd/rhc-data-collector.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=rhc minimal data collector service
+Documentation=https://github.com/RedHatInsights/rhc
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/rhc/data-collector /tmp/rhc-data-collector
+StandardOutput=journal
+StandardError=journal
+UMask=0027
+User=root
+Group=root
+RuntimeMaxSec=300
+
+[Install]
+WantedBy=multi-user.target

--- a/data/systemd/rhc-data-collector.timer
+++ b/data/systemd/rhc-data-collector.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=rhc minimal data collector timer
+Documentation=https://github.com/RedHatInsights/rhc
+Requires=rhc-data-collector.service
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+RandomizedDelaySec=3600
+
+[Install]
+WantedBy=timers.target

--- a/rhc.spec
+++ b/rhc.spec
@@ -48,6 +48,7 @@ export GO_LDFLAGS="-X github.com/redhatinsights/rhc/pkg/version.Version=%{versio
 %gobuild -o %{gobuilddir}/bin/rhc %{goipath}/cmd/rhc
 %gobuild -o %{gobuilddir}/bin/rhc-server %{goipath}/cmd/rhc-server
 %gobuild -o %{gobuilddir}/bin/rhc-collector %{goipath}/cmd/rhc-collector
+%gobuild -o %{gobuilddir}/bin/data-collector %{goipath}/cmd/data-collector
 
 # Generate man page
 %{gobuilddir}/bin/rhc --generate-man-page > rhc.1
@@ -61,6 +62,7 @@ install -m 0755 -vp _build/bin/rhc      %{buildroot}%{_bindir}/
 install -m 0755 -vd                     %{buildroot}%{_libexecdir}/%{name}
 install -m 0755 -vp _build/bin/rhc-server %{buildroot}%{_libexecdir}/%{name}/
 install -m 0755 -vp _build/bin/rhc-collector %{buildroot}%{_libexecdir}/%{name}/
+install -m 0755 -vp _build/bin/data-collector %{buildroot}%{_libexecdir}/%{name}/
 # Bash completion
 install -m 0755 -vd                     %{buildroot}%{bash_completions_dir}/
 install -m 0644 -vp data/completion/rhc.bash  %{buildroot}%{bash_completions_dir}/%{name}
@@ -78,6 +80,7 @@ install -m 0644 -vp rhc.1               %{buildroot}%{_mandir}/man1/rhc.1
 # Systemd files
 install -m 0755 -vd                     %{buildroot}%{_unitdir}
 install -m 0644 -vp data/systemd/rhc-canonical-facts.*  %{buildroot}%{_unitdir}/
+install -m 0644 -vp data/systemd/rhc-data-collector.*  %{buildroot}%{_unitdir}/
 install -m 0644 -vp data/systemd/rhc-server.service  %{buildroot}%{_unitdir}/
 install -m 0644 -vp data/systemd/rhc-server.socket   %{buildroot}%{_unitdir}/
 install -m 0755 -vd %{buildroot}%{_prefix}/lib/systemd/system-preset/
@@ -98,6 +101,7 @@ install -m 0644 -vp %{buildroot}%{_unitdir}/yggdrasil.service.d/rhcd.conf %{buil
 
 %post
 %systemd_post rhc-canonical-facts.timer
+%systemd_post rhc-data-collector.timer
 %systemd_post rhc-server.socket
 %if 0%{?with_rhcd_compat}
 # On package update, ensure yggdrasil (formerly rhcd) has its own configuration file
@@ -111,10 +115,12 @@ fi
 
 %preun
 %systemd_preun rhc-canonical-facts.timer
+%systemd_preun rhc-data-collector.timer
 %systemd_preun rhc-server.socket rhc-server.service
 
 %postun
 %systemd_postun_with_restart rhc-canonical-facts.timer
+%systemd_postun_with_restart rhc-data-collector.timer
 %systemd_postun_with_restart rhc-server.service
 
 %files -f %{go_vendor_license_filelist}
@@ -122,12 +128,14 @@ fi
 %{_bindir}/rhc
 %{_libexecdir}/%{name}/rhc-server
 %{_libexecdir}/%{name}/rhc-collector
+%{_libexecdir}/%{name}/data-collector
 # Bash completion
 %{bash_completions_dir}/%{name}
 # Man page
 %{_mandir}/man1/*
 # Systemd
 %{_unitdir}/rhc-canonical-facts.*
+%{_unitdir}/rhc-data-collector.*
 %{_unitdir}/rhc-server.service
 %{_unitdir}/rhc-server.socket
 %{_prefix}/lib/systemd/system-preset/50-rhc.preset


### PR DESCRIPTION
* Card ID: CCT-2393

Add minimal data collector that generates HBI ingress message format with canonical facts only (not full insights archive).

Features:
  - Collects canonical facts: insights_id, machine_id, bios_uuid, subscription_manager_id, ip_addresses, mac_addresses, fqdn
  - Generates HBI-compliant ingress message with provider_id and provider_type
  - Creates output files: host.json, canonical_facts.json, archive_metadata.json
  - Includes systemd service and timer units for scheduled collection
  - Adds RPM packaging support


---

Testing:
```
# cat /usr/lib/rhc/collectors/com.redhat.advisor.toml
[meta]
name = "Red Hat Lightspeed Advisor"
feature = "analytics"
type = "ingress"

[ingress]
user = "root"
group = "root"
content_type = "application/vnd.redhat.advisor.collection"
# mkdir -p /tmp/rhc/com.redhat.advisor
# /usr/libexec/rhc/data-collector /tmp/rhc/com.redhat.advisor
# /usr/libexec/rhc/rhc-collector com.redhat.advisor /usr/libexec/rhc/data-collector
2026/06/10 15:08:18 INFO starting rhc-collector id=com.redhat.advisor
2026/06/10 15:08:18 INFO created temporary directory dir=/var/tmp/rhc/collector-3075240992
2026/06/10 15:08:18 INFO configuration of the collector config="{ID:com.redhat.advisor Name:Red Hat Lightspeed Advisor IsAnalyticsFeature:true User:root Group:root ContentType:application/vnd.redhat.advisor.collection}"
2026/06/10 15:08:18 INFO collector has ran successfully output=""
2026/06/10 15:08:18 INFO archive created path=/var/tmp/rhc/rhc-collector-20260610150818796.tar.xz
2026/06/10 15:08:18 INFO Uploading archive archive=/var/tmp/rhc/rhc-collector-20260610150818796.tar.xz url=https://cert.console.redhat.com/api/ingress/v1/upload
2026/06/10 15:08:19 INFO Successfully uploaded archive archive=/var/tmp/rhc/rhc-collector-20260610150818796.tar.xz
#
```

^even though it says the archive was uploaded to Ingress, Inventory doesn't show it yet, and I don't know what type is needed to specify in the uploaded files