### PR TITLE
fix(rhc-collector): execute collector binary instead of shell command

### DIFF
--- a/cmd/rhc-collector/main.go
+++ b/cmd/rhc-collector/main.go
@@ -23,10 +23,10 @@ const (
 
 func main() {
 	if len(os.Args) <= 2 {
-		slog.Error("usage: rhc-collector COLLECTOR-ID COMMAND")
+		slog.Error("usage: rhc-collector COMMAND COLLECTOR-ID")
 		os.Exit(exitcode.Usage)
 	}
-	collectorId, command := os.Args[1], os.Args[2]
+	command, collectorId := os.Args[1], os.Args[2]
 	slog.Info("starting rhc-collector", slog.String("id", collectorId))
 	if err := run(collectorId, command); err != nil {
 		slog.Error("rhc-collector exited with error", "error", err)
@@ -35,17 +35,29 @@ func main() {
 }
 
 func run(collectorId, command string) error {
+	collectorId, err := collector.ValidateID(collectorId)
+	if err != nil {
+		slog.Error("invalid collector ID", "error", err)
+		return fmt.Errorf("invalid collector ID: %w", err)
+	}
+
+	if command != "run" {
+		slog.Error("invalid command", "command", command)
+		return fmt.Errorf("invalid command %q: must be 'run'", command)
+	}
+
 	config, err := getConfig(collectorId)
 	if err != nil {
 		return err
 	}
+
 	tmpDir, err := createTmpDir()
 	if err != nil {
 		return err
 	}
 	defer cleanup(tmpDir)
 
-	if err = executeCollector(collectorId, command, tmpDir); err != nil {
+	if err = executeCollector(collectorId, tmpDir); err != nil {
 		return err
 	}
 	archivePath, err := getArchivePath(tmpDir)
@@ -70,7 +82,7 @@ func createTmpDir() (string, error) {
 		return "", fmt.Errorf("failed to create rhc temporary directory: %w", err)
 	}
 
-	// Verify permissions and fix if necessary 
+	// Verify permissions and fix if necessary
 	info, err := os.Stat(rhcTmpDir)
 	if err != nil {
 		slog.Error("failed to stat rhc temporary directory", "error", err)
@@ -112,11 +124,14 @@ func getConfig(collectorId string) (collector.Config, error) {
 	return config, nil
 }
 
-// executeCollector runs the specified collector command and stores output in tmpDir.
+// executeCollector runs the specified collector binary with the collect argument and and stores output in tmpDir.
 // Returns an error if the command execution fails.
-func executeCollector(collectorId, command, tmpDir string) error {
+func executeCollector(collectorId, tmpDir string) error {
+	// Construct path to the collector binary
+	collectorPath := fmt.Sprintf("/usr/libexec/rhc/collectors/%s", collectorId)
+
 	// TODO: Run collector as specific user and group (defined in config of collector)
-	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("%s %q", command, tmpDir))
+	cmd := exec.Command(collectorPath, "collect", tmpDir)
 	cmd.Dir = tmpDir
 
 	// Capture start/end time and execute the command

--- a/cmd/rhc-collector/rhc-collector_test.go
+++ b/cmd/rhc-collector/rhc-collector_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -102,66 +101,27 @@ func TestGetConfig(t *testing.T) {
 	})
 }
 
-// TestExecuteCollector verifies that executeCollector runs shell commands in
-// the provided working directory.
+// TestExecuteCollector verifies that executeCollector runs the collector binary
+// with the correct arguments.
 func TestExecuteCollector(t *testing.T) {
-	if err := os.MkdirAll(collector.TimerDir, 0755); err != nil {
-		t.Skipf("Cannot create timer cache directory %s: %v", collector.TimerDir, err)
-	}
-	t.Cleanup(func() {
-		_ = os.Remove(filepath.Join(collector.TimerDir, "test.collector.json"))
-	})
-
-	t.Run("successful command execution", func(t *testing.T) {
+	t.Run("nonexistent collector binary", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		command := "echo 'test output'"
-		err := executeCollector("test.collector", command, tmpDir)
-		if err != nil {
-			t.Errorf("executeCollector() unexpected error: %v", err)
-		}
-	})
-
-	t.Run("command that creates files", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		testFile := "test-output.txt"
-		command := fmt.Sprintf("echo 'test content' > %s", testFile)
-		err := executeCollector("test.collector", command, tmpDir)
-		if err != nil {
-			t.Errorf("executeCollector() unexpected error: %v", err)
-		}
-		createdFile := filepath.Join(tmpDir, testFile)
-		if _, err := os.Stat(createdFile); os.IsNotExist(err) {
-			t.Errorf("executeCollector() did not create expected file: %s", createdFile)
-		}
-	})
-
-	t.Run("failing command", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		command := "exit 1"
-		err := executeCollector("test.collector", command, tmpDir)
+		collectorId := "com.redhat.nonexistent"
+		err := executeCollector(collectorId, tmpDir)
 		if err == nil {
-			t.Error("executeCollector() expected error for failing command")
+			t.Error("executeCollector() expected error for nonexistent collector binary")
 		}
 		if !strings.Contains(err.Error(), "failed to execute collector") {
 			t.Errorf("executeCollector() error = %v, want error containing 'failed to execute collector'", err)
 		}
 	})
 
-	t.Run("nonexistent command", func(t *testing.T) {
+	t.Run("collector binary with invalid ID characters", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		command := "nonexistentcommand123456"
-		err := executeCollector("test.collector", command, tmpDir)
+		collectorId := "../../../etc/passwd"
+		err := executeCollector(collectorId, tmpDir)
 		if err == nil {
-			t.Error("executeCollector() expected error for nonexistent command")
-		}
-	})
-
-	t.Run("command with special characters", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		command := "echo 'test with spaces and \"quotes\"'"
-		err := executeCollector("test.collector", command, tmpDir)
-		if err != nil {
-			t.Errorf("executeCollector() unexpected error with special characters: %v", err)
+			t.Error("executeCollector() expected error for path traversal attempt")
 		}
 	})
 }

--- a/integration-tests/test_collector_api.py
+++ b/integration-tests/test_collector_api.py
@@ -57,11 +57,13 @@ pytestmark = pytest.mark.usefixtures("rhc_server_socket")
 @pytest.fixture
 def collector_config():
     """
-    Fixture to create a test collector configuration.
+    Fixture to create a test collector configuration and binary.
     """
-    collector_dir = "/usr/lib/rhc/collectors"
+    collector_config_dir = "/usr/lib/rhc/collectors"
+    collector_bin_dir = "/usr/libexec/rhc/collectors"
     collector_id = "test.integration.collector"
-    collector_config_path = os.path.join(collector_dir, f"{collector_id}.toml")
+    collector_config_path = os.path.join(collector_config_dir, f"{collector_id}.toml")
+    collector_bin_path = os.path.join(collector_bin_dir, collector_id)
 
     config_content = textwrap.dedent("""
         [meta]
@@ -75,20 +77,42 @@ def collector_config():
         content_type = "application/vnd.redhat.test.collection"
     """).strip()
 
+    # Create a simple collector binary that accepts "collect" subcommand
+    collector_script = textwrap.dedent("""
+        #!/bin/bash
+        if [ "$1" = "collect" ] && [ -n "$2" ]; then
+            # Create a simple test file in the provided directory
+            echo "test data" > "$2/test-output.txt"
+            exit 0
+        else
+            echo "Usage: $0 collect <directory>"
+            exit 1
+        fi
+    """).strip()
+
     # Create the collector config
-    os.makedirs(collector_dir, exist_ok=True)
+    os.makedirs(collector_config_dir, exist_ok=True)
     with open(collector_config_path, "w") as f:
         f.write(config_content)
+
+    # Create the collector binary
+    os.makedirs(collector_bin_dir, exist_ok=True)
+    with open(collector_bin_path, "w") as f:
+        f.write(collector_script)
+    os.chmod(collector_bin_path, 0o755)
 
     yield {
         "id": collector_id,
         "name": "Test Integration Collector",
         "config_path": collector_config_path,
+        "bin_path": collector_bin_path,
     }
 
     # Cleanup
     if os.path.exists(collector_config_path):
         os.remove(collector_config_path)
+    if os.path.exists(collector_bin_path):
+        os.remove(collector_bin_path)
 
 
 @pytest.fixture
@@ -273,7 +297,7 @@ def test_rhc_collector_writes_timer_cache(collector_config, rhc):
 
     try:
         subprocess.run(
-            [RHC_COLLECTOR, collector_id, "/bin/true"],
+            [RHC_COLLECTOR, "run", collector_id],
             capture_output=True,
             check=False,
         )


### PR DESCRIPTION
## Description 

* Card ID: CCT-2535

When rhc-collector was triggered to start data collection, it passed the command argument to /bin/sh instead of executing the actual collector binary.

Changes:
- Swap argument order to COMMAND COLLECTOR-ID (was COLLECTOR-ID COMMAND)
- Validate command is "run" before proceeding
- Execute /usr/libexec/rhc/collectors/{COLLECTOR-ID} with "collect" subcommand
- Pass tmpDir as argument to the collector binary
- Update executeCollector signature to accept collectorId instead of command
- Simplify tests to focus on binary execution validation


Assisted-by: Claude Code