### PR TITLE
test: switch integration tests to use activation-key

### DIFF
--- a/integration-tests/test_connect.py
+++ b/integration-tests/test_connect.py
@@ -306,11 +306,11 @@ def test_connect_failure_does_not_print_success_message(
     :title: Verify 'rhc connect' does not print success message when credentials are invalid
     :description:
         Regression test for the bug where "Successfully connected to Red Hat!"
-        was printed even when connect failed (e.g. wrong username/password).
+        was printed even when connect failed (e.g. invalid activation key).
         Verifies that on failure the success message is absent and error output is present.
     :steps:
         1.  Ensure the system is disconnected from RHC.
-        2.  Run 'rhc connect' with invalid username and password (text output).
+        2.  Run 'rhc connect' with invalid activation key (text output).
         3.  Verify non-zero return code.
         4.  Verify "Successfully connected to Red Hat!" is not in stdout.
         5.  Verify RHSM error message is present in output.
@@ -319,15 +319,15 @@ def test_connect_failure_does_not_print_success_message(
         2.  Connect command runs and fails.
         3.  Return code is non-zero.
         4.  Success message is not printed.
-        5.  Error message indicates connection failure (e.g. Cannot connect to RHSM or Invalid username or password).
+        5.  Error message indicates connection failure (e.g. Cannot connect to RHSM or invalid activation key/org).
     """
     with contextlib.suppress(Exception):
         rhc.disconnect()
 
-    # Wrong username, valid password from config (same pattern as test_connect_wrong_parameters)
+    # Valid organization with invalid activation key (same pattern as test_connect_wrong_parameters)
     credentials = {
-        "username": "notarealuser",
-        "password": "candlepin.password",
+        "organization": "candlepin.org",
+        "activation-key": "xpto123",
     }
     command_args = prepare_args_for_connect(test_config, credentials=credentials)
     command = ["connect"] + command_args
@@ -337,9 +337,12 @@ def test_connect_failure_does_not_print_success_message(
     assert "Successfully connected to Red Hat!" not in result.stdout
 
     output = result.stdout + result.stderr
+    output_lower = output.lower()
     assert (
         "Cannot connect to Red Hat Subscription Management" in output
         or "Invalid username or password" in output
+        or "activation key" in output_lower
+        or "organization" in output_lower
     ), f"Expected RHSM error in output: {output!r}"
 
 

--- a/integration-tests/test_logging.py
+++ b/integration-tests/test_logging.py
@@ -415,12 +415,12 @@ def test_log_error_message_references_log_file(
     :title: Verify CLI output references log file path upon connect error
     :description:
         Verifies that when 'rhc connect' encounters an error (e.g. invalid
-        credentials), the CLI output includes a message directing the user
+        activation key), the CLI output includes a message directing the user
         to the log file for full details.
     :tags: Tier 1
     :steps:
         1. Ensure the system is disconnected.
-        2. Run 'rhc connect' with invalid credentials.
+        2. Run 'rhc connect' with invalid activation key credentials.
         3. Verify the command fails with non-zero return code.
         4. Verify CLI output contains "Please see /var/log/rhc/rhc.log for full details."
     :expectedresults:
@@ -433,8 +433,8 @@ def test_log_error_message_references_log_file(
         rhc.disconnect()
 
     credentials = {
-        "username": "non-existent-user",
-        "password": "candlepin.password",
+        "organization": "candlepin.org",
+        "activation-key": "xpto123",
     }
     command_args = prepare_args_for_connect(test_config, credentials=credentials)
     command = ["connect"] + command_args
@@ -557,13 +557,14 @@ def test_log_connect_error_logged(
     :id: 141aba4f-9898-4881-b0fd-2b978e6af9d6
     :title: Verify log file records errors when connect fails with invalid credentials
     :description:
-        Verifies that when 'rhc connect' fails due to invalid credentials,
+        Verifies that when 'rhc connect' fails due to invalid activation-key
+        credentials,
         the error is logged at ERROR level in the log file, providing
         details useful for troubleshooting.
     :tags: Tier 1
     :steps:
         1. Ensure the system is disconnected.
-        2. Run 'rhc connect' with invalid credentials.
+        2. Run 'rhc connect' with invalid activation-key credentials.
         3. Read new log entries.
         4. Verify log contains an ERROR level entry about the connection failure.
     :expectedresults:
@@ -576,8 +577,8 @@ def test_log_connect_error_logged(
         rhc.disconnect()
 
     credentials = {
-        "username": "non-existent-user",
-        "password": "candlepin.password",
+        "organization": "candlepin.org",
+        "activation-key": "xpto123",
     }
     command_args = prepare_args_for_connect(test_config, credentials=credentials)
     command = ["connect"] + command_args


### PR DESCRIPTION
*Card Id : CCT-2577

Basic auth is not supported on satellite, causing these integration tests to fail in satellite environments. Replacing those cases with activation-key authentication so the tests are satellite-compatible and expand effective coverage on satellite runs.