### PR TITLE
chore(cmd): Refactor internal/rhsm

### DIFF
--- a/cmd/rhc/configure_features_cmd.go
+++ b/cmd/rhc/configure_features_cmd.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 
-	"github.com/redhatinsights/rhc/internal/rhsm"
+	"github.com/redhatinsights/rhc/internal/subman"
 	"github.com/redhatinsights/rhc/internal/ui"
 	"github.com/redhatinsights/rhc/pkg/exitcode"
 	"github.com/redhatinsights/rhc/pkg/feature"
@@ -64,7 +64,7 @@ func beforeFeaturesStatusAction(ctx context.Context, cmd *cli.Command) (context.
 // featuresStatusAction displays the current status or preferences of all features.
 func featuresStatusAction(ctx context.Context, cmd *cli.Command) error {
 	logCommandStart(cmd)
-	isRegistered, err := rhsm.IsRHSMRegistered()
+	isRegistered, err := subman.IsRegistered()
 	if err != nil {
 		return err
 	}
@@ -192,7 +192,7 @@ func beforeFeaturesEnableAction(ctx context.Context, cmd *cli.Command) (context.
 // featuresEnableAction enables one or more features.
 func featuresEnableAction(ctx context.Context, cmd *cli.Command) error {
 	logCommandStart(cmd)
-	isRegistered, err := rhsm.IsRHSMRegistered()
+	isRegistered, err := subman.IsRegistered()
 	if err != nil {
 		return cli.Exit(fmt.Sprintf("failed to check registration status: %v", err), exitcode.Software)
 	}
@@ -316,7 +316,7 @@ func beforeFeaturesDisableAction(ctx context.Context, cmd *cli.Command) (context
 // featuresDisableAction disables one or more features.
 func featuresDisableAction(ctx context.Context, cmd *cli.Command) error {
 	logCommandStart(cmd)
-	isRegistered, err := rhsm.IsRHSMRegistered()
+	isRegistered, err := subman.IsRegistered()
 	if err != nil {
 		return cli.Exit(fmt.Sprintf("failed to check registration status: %v", err), exitcode.Software)
 	}

--- a/cmd/rhc/connect_cmd.go
+++ b/cmd/rhc/connect_cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/redhatinsights/rhc/internal/datacollection"
 	"github.com/redhatinsights/rhc/internal/remotemanagement"
 	"github.com/redhatinsights/rhc/internal/rhsm"
+	"github.com/redhatinsights/rhc/internal/subman"
 	"github.com/redhatinsights/rhc/internal/ui"
 	"github.com/redhatinsights/rhc/pkg/exitcode"
 	"github.com/redhatinsights/rhc/pkg/feature"
@@ -233,7 +234,7 @@ func beforeConnectAction(ctx context.Context, cmd *cli.Command) (context.Context
 
 	// Do not continue if the host is already registered
 	slog.Info("Checking system connection status")
-	uuid, err := rhsm.GetConsumerUUID()
+	uuid, err := subman.GetConsumerUUID()
 	if err != nil {
 		return ctx, cli.Exit(
 			fmt.Sprintf("unable to get consumer UUID: %s", err),

--- a/cmd/rhc/disconnect_cmd.go
+++ b/cmd/rhc/disconnect_cmd.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/redhatinsights/rhc/internal/datacollection"
 	"github.com/redhatinsights/rhc/internal/remotemanagement"
-	"github.com/redhatinsights/rhc/internal/rhsm"
+	"github.com/redhatinsights/rhc/internal/subman"
 	"github.com/redhatinsights/rhc/internal/ui"
 	"github.com/redhatinsights/rhc/pkg/exitcode"
 )
@@ -135,7 +135,7 @@ func (disconnectResult *DisconnectResult) TryUnregisterInsightsClient() error {
 func (disconnectResult *DisconnectResult) TryUnregisterRHSM() error {
 	slog.Info("Unregistering system from Red Hat Subscription Management")
 
-	isRegistered, err := rhsm.IsRHSMRegistered()
+	isRegistered, err := subman.IsRegistered()
 	if err != nil {
 		return err
 	}
@@ -147,7 +147,7 @@ func (disconnectResult *DisconnectResult) TryUnregisterRHSM() error {
 		return nil
 	}
 	err = ui.Spinner(
-		rhsm.Unregister,
+		subman.Unregister,
 		ui.Indent.Small,
 		"Disconnecting from Red Hat Subscription Management...",
 	)

--- a/cmd/rhc/status_cmd.go
+++ b/cmd/rhc/status_cmd.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/redhatinsights/rhc/internal/datacollection"
 	"github.com/redhatinsights/rhc/internal/localization"
-	"github.com/redhatinsights/rhc/internal/rhsm"
+	"github.com/redhatinsights/rhc/internal/subman"
 	"github.com/redhatinsights/rhc/internal/ui"
 	"github.com/redhatinsights/rhc/pkg/exitcode"
 )
@@ -28,7 +28,7 @@ import (
 func rhsmStatus(systemStatus *SystemStatus) error {
 	slog.Info("Checking status of Red Hat Subscription Management")
 
-	uuid, err := rhsm.GetConsumerUUID()
+	uuid, err := subman.GetConsumerUUID()
 	if err != nil {
 		systemStatus.returnCode += 1
 		systemStatus.RHSMError = err.Error()
@@ -72,10 +72,10 @@ func isContentEnabled(systemStatus *SystemStatus) error {
 		locale).Store(&contentEnabled); err != nil {
 		systemStatus.returnCode += 1
 		systemStatus.ContentError = err.Error()
-		return rhsm.UnpackDBusError(err)
+		return subman.UnpackDBusError(err)
 	}
 
-	uuid, err := rhsm.GetConsumerUUID()
+	uuid, err := subman.GetConsumerUUID()
 	if err != nil {
 		systemStatus.returnCode += 1
 		systemStatus.ContentError = err.Error()

--- a/internal/rhsm/rhsm.go
+++ b/internal/rhsm/rhsm.go
@@ -296,39 +296,6 @@ func registerActivationKey(orgID string, activationKeys []string, environments [
 	return nil
 }
 
-func Unregister() error {
-	conn, err := dbus.SystemBus()
-	if err != nil {
-		return err
-	}
-	// godbus implements SystemBus as a singleton, do not call conn.Close()
-
-	uuid, err := GetConsumerUUID()
-	if err != nil {
-		return err
-	}
-	if uuid == "" {
-		return fmt.Errorf("warning: the system is already unregistered")
-	}
-
-	locale := localization.GetLocale()
-
-	slog.Debug("Calling method com.redhat.RHSM1.Unregister.Unregister")
-	err = conn.Object(
-		"com.redhat.RHSM1",
-		"/com/redhat/RHSM1/Unregister").Call(
-		"com.redhat.RHSM1.Unregister.Unregister",
-		dbus.Flags(0),
-		map[string]string{},
-		locale).Err
-
-	if err != nil {
-		return UnpackDBusError(err)
-	}
-
-	return nil
-}
-
 // DBusError is used for parsing JSON document returned by D-Bus methods.
 type DBusError struct {
 	Exception string `json:"exception"`
@@ -465,19 +432,4 @@ func RegisterRHSM(cmd *cli.Command, enableContent bool) (string, error) {
 		successMsg = "This system is already connected to Red Hat Subscription Management"
 	}
 	return successMsg, nil
-}
-
-// IsRHSMRegistered returns true, when system is registered
-func IsRHSMRegistered() (bool, error) {
-	slog.Debug("Checking if system is registered to Red Hat Subscription Management")
-	uuid, err := GetConsumerUUID()
-	if err != nil {
-		return false, err
-	}
-	if uuid != "" {
-		slog.Debug("Consumer UUID is set, system is registered")
-		return true, nil
-	}
-	slog.Debug("Consumer UUID is not set, system is not registered")
-	return false, nil
 }

--- a/internal/subman/content.go
+++ b/internal/subman/content.go
@@ -1,0 +1,65 @@
+package subman
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/godbus/dbus/v5"
+
+	"github.com/redhatinsights/rhc/internal/localization"
+)
+
+// IsContentManagementEnabled returns true if content management is enabled for the system in rhsm.conf
+func IsContentManagementEnabled() (bool, error) {
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		return false, fmt.Errorf("cannot connect to system D-Bus: %w", err)
+	}
+	// godbus implements SystemBus as a singleton, do not call conn.Close()
+
+	locale := localization.GetLocale()
+	config := conn.Object("com.redhat.RHSM1", "/com/redhat/RHSM1/Config")
+
+	var contentEnabled string
+	err = config.Call(
+		"com.redhat.RHSM1.Config.Get",
+		dbus.Flags(0),
+		"rhsm.manage_repos",
+		locale).Store(&contentEnabled)
+	if err != nil {
+		slog.Debug("Failed to get rhsm.manage_repos config", "error", err)
+		return false, UnpackDBusError(err)
+	}
+
+	return contentEnabled == "1", nil
+}
+
+// SetContentManagement tries to enable or disable content management for the system in rhsm.conf
+func SetContentManagement(enabled bool) error {
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		return fmt.Errorf("cannot connect to system D-Bus: %w", err)
+	}
+	// godbus implements SystemBus as a singleton, do not call conn.Close()
+
+	locale := localization.GetLocale()
+	config := conn.Object("com.redhat.RHSM1", "/com/redhat/RHSM1/Config")
+	enabledStr := "1"
+	if !enabled {
+		enabledStr = "0"
+	}
+
+	err = config.Call(
+		"com.redhat.RHSM1.Config.Set",
+		dbus.Flags(0),
+		"rhsm.manage_repos",
+		enabledStr,
+		locale,
+	).Err
+	if err != nil {
+		slog.Debug("Failed to set rhsm.manage_repos config", "error", err)
+		return UnpackDBusError(err)
+	}
+
+	return nil
+}

--- a/internal/subman/errors.go
+++ b/internal/subman/errors.go
@@ -1,0 +1,44 @@
+package subman
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/godbus/dbus/v5"
+)
+
+// DBusError is used for parsing JSON document returned by D-Bus methods.
+type DBusError struct {
+	Exception string `json:"exception"`
+	Severity  string `json:"severity"`
+	Message   string `json:"message"`
+}
+
+// Error returns textual representation of DBusError. This implements all necessary
+// methods for the error interface. Thus, DBusError can be handled as a regular error.
+func (dbusError DBusError) Error() string {
+	return fmt.Sprintf("%v: %v", dbusError.Severity, dbusError.Message)
+}
+
+// UnpackDBusError tries to unpack a JSON document (part of the error) into the structure DBusError.
+// When it is not possible to parse an error into structure, then a corresponding or original error
+// is returned. When it is possible to parse error into structure, then DBusError is returned
+func UnpackDBusError(err error) error {
+	var e dbus.Error
+	ok := errors.As(err, &e)
+	if !ok {
+		return err
+	}
+	if e.Name != "com.redhat.RHSM1.Error" {
+		return err
+	}
+
+	var dbusError DBusError
+	if jsonErr := json.Unmarshal([]byte(e.Error()), &dbusError); jsonErr != nil {
+		slog.Debug("Failed to unmarshal D-Bus error body", "error", jsonErr)
+		return err
+	}
+	return dbusError
+}

--- a/internal/subman/identity.go
+++ b/internal/subman/identity.go
@@ -1,0 +1,85 @@
+package subman
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/godbus/dbus/v5"
+
+	"github.com/redhatinsights/rhc/internal/localization"
+)
+
+// GetConsumerUUID returns the consumer UUID from RHSM D-Bus API.
+// An empty string means the system is not registered.
+func GetConsumerUUID() (string, error) {
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		return "", err
+	}
+	// godbus implements SystemBus as a singleton, do not call conn.Close()
+
+	locale := localization.GetLocale()
+
+	var uuid string
+	err = conn.Object(
+		"com.redhat.RHSM1",
+		"/com/redhat/RHSM1/Consumer").Call(
+		"com.redhat.RHSM1.Consumer.GetUuid",
+		dbus.Flags(0),
+		locale).Store(&uuid)
+	if err != nil {
+		return "", UnpackDBusError(err)
+	}
+
+	return uuid, nil
+}
+
+// IsRegistered returns true when the system is registered with RHSM.
+func IsRegistered() (bool, error) {
+	slog.Debug("Checking if system is registered to Red Hat Subscription Management")
+
+	uuid, err := GetConsumerUUID()
+	if err != nil {
+		return false, err
+	}
+	if uuid != "" {
+		slog.Debug("Consumer UUID is set, system is registered")
+		return true, nil
+	}
+
+	slog.Debug("Consumer UUID is not set, system is not registered")
+	return false, nil
+}
+
+// Unregister removes the system registration from RHSM.
+func Unregister() error {
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		return err
+	}
+	// godbus implements SystemBus as a singleton, do not call conn.Close()
+
+	uuid, err := GetConsumerUUID()
+	if err != nil {
+		return err
+	}
+	if uuid == "" {
+		return fmt.Errorf("warning: the system is already unregistered")
+	}
+
+	locale := localization.GetLocale()
+
+	slog.Debug("Calling method com.redhat.RHSM1.Unregister.Unregister")
+	err = conn.Object(
+		"com.redhat.RHSM1",
+		"/com/redhat/RHSM1/Unregister").Call(
+		"com.redhat.RHSM1.Unregister.Unregister",
+		dbus.Flags(0),
+		map[string]string{},
+		locale).Err
+	if err != nil {
+		return UnpackDBusError(err)
+	}
+
+	return nil
+}

--- a/pkg/feature/content.go
+++ b/pkg/feature/content.go
@@ -1,7 +1,7 @@
 package feature
 
 import (
-	"github.com/redhatinsights/rhc/internal/rhsm"
+	"github.com/redhatinsights/rhc/internal/subman"
 )
 
 // Content implements IFeature.
@@ -24,13 +24,13 @@ func (c Content) RequiredBy() []string {
 }
 
 func (c Content) Enable() error {
-	return rhsm.SetContentManagement(true)
+	return subman.SetContentManagement(true)
 }
 
 func (c Content) Disable() error {
-	return rhsm.SetContentManagement(false)
+	return subman.SetContentManagement(false)
 }
 
 func (c Content) IsEnabled() (bool, error) {
-	return rhsm.IsContentManagementEnabled()
+	return subman.IsContentManagementEnabled()
 }

--- a/pkg/operations/feature_status.go
+++ b/pkg/operations/feature_status.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/redhatinsights/rhc/internal/datacollection"
 	"github.com/redhatinsights/rhc/internal/remotemanagement"
-	"github.com/redhatinsights/rhc/internal/rhsm"
+	"github.com/redhatinsights/rhc/internal/subman"
 )
 
 // FeatureStatusResult represents the result of checking a feature's status.
@@ -26,7 +26,7 @@ func FeatureStatus(opts FeatureOperationOptions) FeatureStatusResult {
 	case Analytics:
 		enabled, err = datacollection.InsightsClientIsRegistered()
 	case Content:
-		enabled, err = rhsm.IsContentManagementEnabled()
+		enabled, err = subman.IsContentManagementEnabled()
 	case RemoteManagement:
 		enabled, err = remotemanagement.AssertYggdrasilServiceState("active")
 	default:


### PR DESCRIPTION
* Card ID: CCT-2400

In preparation to clean up presentation responsibilities from internal/rhsm package, move content and identity responsibilities (and the D-Bus API of subscription-manager) into a new separate package.

In a follow-up patch, the registration methods will be moved to the new package as well, but as they mix user input and business logic, smaller diff will be easier to review. That means the code will contain some duplication between rhsm and subman packages for a short time.

Generated-by: Claude Sonnet <noreply@anthropic.com>