### PR TITLE
feat(collector): add minimal collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /rhc-server
 /rhc-collector
 /rhc.1.gz
+/com.redhat.minimal
 /USAGE.md
 rhc.spec
 !/rhc.spec

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ build:
 	$(GO_BUILD) -o rhc ./cmd/rhc
 	$(GO_BUILD) -o rhc-server ./cmd/rhc-server
 	$(GO_BUILD) -o rhc-collector ./cmd/rhc-collector
+	$(GO_BUILD) -o com.redhat.minimal ./cmd/minimal-collector
 
 .PHONY: archive
 archive:
@@ -43,6 +44,7 @@ clean:
 	rm -f rhc
 	rm -f rhc-server
 	rm -f rhc-collector
+	rm -f com.redhat.minimal
 	rm -f rhc-*.tar*
 	rm -rf vendor/
 	rm -rf x86_64/

--- a/cmd/minimal-collector/main.go
+++ b/cmd/minimal-collector/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/redhatinsights/rhc/pkg/exitcode"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		slog.Error("usage: com.redhat.minimal collect")
+		os.Exit(exitcode.Usage)
+	}
+
+	command := os.Args[1]
+	if command != "collect" {
+		slog.Error("unknown command", "command", command)
+		os.Exit(exitcode.Usage)
+	}
+
+	// Use current working directory as output directory (set by rhc-collector)
+	outputDir, err := os.Getwd()
+	if err != nil {
+		slog.Error("failed to get working directory", "error", err)
+		os.Exit(exitcode.Err)
+	}
+
+	if err := run(outputDir); err != nil {
+		slog.Error("minimal-collector failed", "error", err)
+		os.Exit(exitcode.Err)
+	}
+}
+
+func run(outputDir string) error {
+	slog.Info("starting minimal collector", "outputDir", outputDir)
+
+	dataDir, metaDataDir, err := createArchiveStructure(outputDir)
+	if err != nil {
+		return fmt.Errorf("failed to create archive structure: %w", err)
+	}
+	if err = writeVersionInfo(dataDir, metaDataDir); err != nil {
+		return fmt.Errorf("failed to write version info: %w", err)
+	}
+	if err = writeBranchInfo(dataDir, metaDataDir); err != nil {
+		return fmt.Errorf("failed to write branch info: %w", err)
+	}
+	if err = writeCanonicalFacts(dataDir, metaDataDir); err != nil {
+		return fmt.Errorf("failed to write canonical facts: %w", err)
+	}
+
+	slog.Info("minimal collector completed successfully")
+	return nil
+}

--- a/cmd/minimal-collector/minimal-collector.go
+++ b/cmd/minimal-collector/minimal-collector.go
@@ -1,0 +1,581 @@
+package main
+
+import (
+	"cmp"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/redhatinsights/rhc/internal/canonical_facts"
+	"github.com/redhatinsights/rhc/pkg/version"
+)
+
+// Satellite management constants. Both set to -1 to indicate "not managed by Satellite".
+// When puptoo processes branch_info, it checks: if remote_branch != -1, it sets
+// satellite_managed=true and satellite_id=remote_leaf.
+const (
+	remoteBranch = -1
+	remoteLeaf   = -1
+)
+
+// MetadataSpec represents metadata for a collected spec that is written to
+// the meta_data/ directory in insights archives. These metadata files are
+// required by insights-core's hydration process (serde.py) to load and parse
+// the archive data. The metadata format follows the structure created by
+// insights-client when it collects data using insights-core's spec framework.
+type MetadataSpec struct {
+	// Name is the fully qualified spec name in insights-core's namespace.
+	Name string `json:"name"`
+
+	// ExecTime is the execution time in seconds for collecting this spec.
+	// For minimal collector, use a placeholder value like 0.0001.
+	ExecTime float64 `json:"exec_time"`
+
+	// Errors is a list of error messages encountered during collection.
+	Errors []string `json:"errors"`
+
+	// Results contains the spec type and location information.
+	// Structure: {"type": "<provider_type>", "object": {"relative_path": "...", ...}}
+	// Provider types:
+	//   - insights.core.spec_factory.TextFileProvider (for file content)
+	//   - insights.core.spec_factory.CommandOutputProvider (for command output)
+	//   - insights.core.spec_factory.DatasourceProvider (for computed data)
+	// The "relative_path" field points to the actual data file in data/ directory.
+	Results any `json:"results"`
+
+	// SerTime is the serialization time in seconds for this spec's results.
+	// For minimal collector, use a placeholder value like 0.0001.
+	SerTime float64 `json:"ser_time"`
+}
+
+// SpecObject represents the "object" field within MetadataSpec.Results.
+// This structure describes how insights-core should locate and process the data file.
+type SpecObject struct {
+	// RelativePath is the path to the data file relative to the data/ directory.
+	RelativePath string `json:"relative_path"`
+
+	// SaveAs specifies an alternate path to save the file during collection.
+	// For minimal collector, always nil.
+	SaveAs any `json:"save_as"`
+
+	// RC is the command exit code (for CommandOutputProvider) or nil (for file-based providers).
+	// When a command is executed during collection, this stores the exit code.
+	// For minimal collector, always nil.
+	RC any `json:"rc"`
+
+	// Cmd is the original command string (for CommandOutputProvider only).
+	// For minimal collector, always nil.
+	Cmd any `json:"cmd"`
+
+	// Args are the command arguments (for CommandOutputProvider only).
+	// For minimal collector, always nil.
+	Args any `json:"args"`
+}
+
+// VersionInfo represents the version_info file content.
+type VersionInfo struct {
+	CoreVersion   string  `json:"core_version"`
+	ClientVersion *string `json:"client_version"`
+}
+
+// BranchInfo represents the branch_info file content.
+type BranchInfo struct {
+	RemoteBranch int `json:"remote_branch"`
+	RemoteLeaf   int `json:"remote_leaf"`
+}
+
+// createArchiveStructure creates an insights-core compatible archive structure.
+func createArchiveStructure(outputDir string) (string, string, error) {
+	dataDir := filepath.Join(outputDir, "data")
+	metaDataDir := filepath.Join(outputDir, "meta_data")
+
+	if err := os.MkdirAll(dataDir, 0700); err != nil {
+		return "", "", fmt.Errorf("failed to create data directory: %w", err)
+	}
+	if err := os.MkdirAll(metaDataDir, 0700); err != nil {
+		return "", "", fmt.Errorf("failed to create meta_data directory: %w", err)
+	}
+	// insights_archive.txt is an empty file used by insights-core to identify this as
+	// a SerializedArchiveContext. Its presence indicates this is an insights archive.
+	archiveMarker := filepath.Join(outputDir, "insights_archive.txt")
+	if err := os.WriteFile(archiveMarker, []byte{}, 0600); err != nil {
+		return "", "", fmt.Errorf("failed to write insights_archive.txt: %w", err)
+	}
+
+	return dataDir, metaDataDir, nil
+}
+
+// getOrgID retrieves the organization ID from the subscription-manager certificate.
+// The org_id is stored in the Organization field (O) of the certificate Subject.
+func getOrgID() (string, error) {
+	certPath := "/etc/pki/consumer/cert.pem"
+	data, err := os.ReadFile(certPath)
+	if err != nil {
+		slog.Error("failed to read consumer cert", "path", certPath, "error", err)
+		return "", fmt.Errorf("failed to read consumer cert: %w", err)
+	}
+
+	block, _ := pem.Decode(data)
+	if block == nil {
+		slog.Error("failed to decode PEM data from consumer cert", "path", certPath)
+		return "", fmt.Errorf("failed to decode PEM data from %s", certPath)
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		slog.Error("failed to parse certificate from consumer cert", "path", certPath, "error", err)
+		return "", fmt.Errorf("failed to parse certificate: %w", err)
+	}
+
+	if len(cert.Subject.Organization) == 0 {
+		slog.Error("failed to parse organization from consumer cert", "path", certPath)
+		return "", fmt.Errorf("failed to parse organization from %s", certPath)
+	}
+
+	orgID := cert.Subject.Organization[0]
+	slog.Debug("found org ID from certificate", "org_id", orgID)
+	return orgID, nil
+}
+
+// writeVersionInfo creates version_info file and metadata.
+//
+// The version_info file contains collector version information that Puptoo extracts
+// and includes in the system profile sent to HBI:
+//   - core_version → system_profile.insights_egg_version
+//   - client_version → system_profile.insights_client_version
+//
+// These fields help track which collector version generated the archive, useful for
+// debugging data collection issues and understanding feature availability across hosts.
+// For minimal collector, core_version is set to rhc's version and client_version is null
+// since there's no separate insights-client component.
+func writeVersionInfo(dataDir, metaDataDir string) error {
+	versionInfo := VersionInfo{
+		CoreVersion:   version.Version,
+		ClientVersion: nil,
+	}
+
+	versionData, err := json.Marshal(versionInfo)
+	if err != nil {
+		return fmt.Errorf("failed to marshal version_info: %w", err)
+	}
+
+	versionPath := filepath.Join(dataDir, "version_info")
+	if err = os.WriteFile(versionPath, versionData, 0600); err != nil {
+		return fmt.Errorf("failed to write version_info: %w", err)
+	}
+
+	// Write metadata
+	metadata := MetadataSpec{
+		Name:     "insights.specs.Specs.version_info",
+		ExecTime: 0.0001,
+		Errors:   []string{},
+		Results: map[string]any{
+			"type": "insights.core.spec_factory.DatasourceProvider",
+			"object": SpecObject{
+				RelativePath: "version_info",
+				SaveAs:       nil,
+				RC:           nil,
+				Cmd:          nil,
+				Args:         nil,
+			},
+		},
+		SerTime: 0.0001,
+	}
+
+	metaData, err := json.Marshal(metadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal version_info metadata: %w", err)
+	}
+
+	metaPath := filepath.Join(metaDataDir, "insights.specs.Specs.version_info.json")
+	if err := os.WriteFile(metaPath, metaData, 0600); err != nil {
+		return fmt.Errorf("failed to write version_info metadata: %w", err)
+	}
+
+	return nil
+}
+
+// writeBranchInfo creates branch_info file and metadata. Puptoo uses this to
+// determine Satellite management: if remote_branch != -1, sets satellite_managed=true
+// and satellite_id=remote_leaf. For minimal collector, both values are -1.
+func writeBranchInfo(dataDir, metaDataDir string) error {
+	branchInfo := BranchInfo{
+		RemoteBranch: remoteBranch,
+		RemoteLeaf:   remoteLeaf,
+	}
+
+	branchData, err := json.Marshal(branchInfo)
+	if err != nil {
+		return fmt.Errorf("failed to marshal branch_info: %w", err)
+	}
+
+	branchPath := filepath.Join(dataDir, "branch_info")
+	if err := os.WriteFile(branchPath, branchData, 0600); err != nil {
+		return fmt.Errorf("failed to write branch_info: %w", err)
+	}
+
+	// Write metadata
+	metadata := MetadataSpec{
+		Name:     "insights.specs.Specs.branch_info",
+		ExecTime: 0.0001,
+		Errors:   []string{},
+		Results: map[string]any{
+			"type": "insights.core.spec_factory.DatasourceProvider",
+			"object": SpecObject{
+				RelativePath: "branch_info",
+				SaveAs:       nil,
+				RC:           nil,
+				Cmd:          nil,
+				Args:         nil,
+			},
+		},
+		SerTime: 0.0001,
+	}
+
+	metaData, err := json.Marshal(metadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal branch_info metadata: %w", err)
+	}
+
+	metaPath := filepath.Join(metaDataDir, "insights.specs.Specs.branch_info.json")
+	if err := os.WriteFile(metaPath, metaData, 0600); err != nil {
+		return fmt.Errorf("failed to write branch_info metadata: %w", err)
+	}
+
+	return nil
+}
+
+// writeCanonicalFacts collects and writes canonical facts to the archive.
+func writeCanonicalFacts(dataDir, metaDataDir string) error {
+	facts, err := canonical_facts.GetCanonicalFacts()
+	if err != nil {
+		slog.Error("failed to get canonical facts", "error", err)
+		return fmt.Errorf("failed to get canonical facts: %w", err)
+	}
+
+	// Create subdirectories
+	etcDir := filepath.Join(dataDir, "etc", "insights-client")
+	commandsDir := filepath.Join(dataDir, "insights_commands")
+
+	for _, dir := range []string{etcDir, commandsDir} {
+		if err = os.MkdirAll(dir, 0700); err != nil {
+			slog.Error("failed to create directory", "path", dir, "error", err)
+			return fmt.Errorf("failed to create directory %s: %w", dir, err)
+		}
+	}
+
+	if facts.InsightsID != "" {
+		if err = writeInsightsID(etcDir, metaDataDir, facts.InsightsID); err != nil {
+			return err
+		}
+	}
+
+	if facts.SubscriptionManagerID != "" {
+		if err = writeSubscriptionManagerID(commandsDir, metaDataDir, facts.SubscriptionManagerID); err != nil {
+			return err
+		}
+	}
+
+	if len(facts.IPAddresses) > 0 {
+		if err = writeIPAddresses(commandsDir, metaDataDir, facts.IPAddresses); err != nil {
+			return err
+		}
+	}
+
+	if len(facts.MACAddresses) > 0 {
+		if err = writeMACAddresses(dataDir, metaDataDir); err != nil {
+			return err
+		}
+	}
+
+	if facts.BIOSUUID != "" {
+		if err = writeBIOSUUID(commandsDir, metaDataDir, facts.BIOSUUID); err != nil {
+			return err
+		}
+	}
+
+	if facts.FQDN != "" {
+		if err = writeFQDN(commandsDir, metaDataDir, facts.FQDN); err != nil {
+			return err
+		}
+	}
+
+	if facts.MachineID != "" {
+		if err = writeMachineID(filepath.Join(dataDir, "etc"), metaDataDir, facts.MachineID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// writeInsightsID writes the insights-client machine-id.
+func writeInsightsID(etcDir, metaDataDir, insightsID string) error {
+	path := filepath.Join(etcDir, "machine-id")
+	if err := os.WriteFile(path, []byte(insightsID), 0600); err != nil {
+		slog.Error("failed to write insights machine-id to file", "path", path, "error", err)
+		return fmt.Errorf("failed to write insights machine-id to %s: %w", path, err)
+	}
+
+	metadata := MetadataSpec{
+		Name:     "insights.specs.Specs.machine_id",
+		ExecTime: 0.0001,
+		Errors:   []string{},
+		Results: map[string]any{
+			"type": "insights.core.spec_factory.TextFileProvider",
+			"object": SpecObject{
+				RelativePath: "etc/insights-client/machine-id",
+				SaveAs:       nil,
+				RC:           nil,
+				Cmd:          nil,
+				Args:         nil,
+			},
+		},
+		SerTime: 0.0001,
+	}
+
+	return writeMetadata(metaDataDir, "insights.specs.Specs.machine_id.json", metadata)
+}
+
+// writeSubscriptionManagerID writes subscription-manager identity output.
+func writeSubscriptionManagerID(commandsDir, metaDataDir, subMgrID string) error {
+	orgID, err := getOrgID()
+	if err != nil {
+		slog.Error("failed to get org_id for subscription-manager output", "error", err)
+		return fmt.Errorf("failed to get org_id for subscription-manager output: %w", err)
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		slog.Warn("failed to get hostname for subscription-manager output", "error", err)
+		hostname = "unknown"
+	}
+
+	output := fmt.Sprintf("system identity: %s\nname: %s\norg name: %s\norg ID: %s\n",
+		subMgrID, hostname, orgID, orgID)
+
+	path := filepath.Join(commandsDir, "subscription-manager_identity")
+	if err := os.WriteFile(path, []byte(output), 0600); err != nil {
+		slog.Error("failed to write subscription-manager identity to file", "path", path, "error", err)
+		return fmt.Errorf("failed to write subscription-manager identity to %s: %w", path, err)
+	}
+
+	metadata := MetadataSpec{
+		Name:     "insights.specs.Specs.subscription_manager_id",
+		ExecTime: 0.0001,
+		Errors:   []string{},
+		Results: map[string]any{
+			"type": "insights.core.spec_factory.CommandOutputProvider",
+			"object": SpecObject{
+				RelativePath: "insights_commands/subscription-manager_identity",
+				SaveAs:       nil,
+				RC:           nil,
+				Cmd:          nil,
+				Args:         nil,
+			},
+		},
+		SerTime: 0.0001,
+	}
+
+	return writeMetadata(metaDataDir, "insights.specs.Specs.subscription_manager_id.json", metadata)
+}
+
+// writeIPAddresses writes hostname -I output.
+func writeIPAddresses(commandsDir, metaDataDir string, ipAddresses []string) error {
+	output := strings.Join(ipAddresses, " ") + "\n"
+
+	path := filepath.Join(commandsDir, "hostname_-I")
+	if err := os.WriteFile(path, []byte(output), 0600); err != nil {
+		slog.Error("failed to write IP addresses to file", "path", path, "error", err)
+		return fmt.Errorf("failed to write IP addresses to %s: %w", path, err)
+	}
+
+	metadata := MetadataSpec{
+		Name:     "insights.specs.Specs.ip_addresses",
+		ExecTime: 0.0001,
+		Errors:   []string{},
+		Results: map[string]any{
+			"type": "insights.core.spec_factory.CommandOutputProvider",
+			"object": SpecObject{
+				RelativePath: "insights_commands/hostname_-I",
+				SaveAs:       nil,
+				RC:           nil,
+				Cmd:          nil,
+				Args:         nil,
+			},
+		},
+		SerTime: 0.0001,
+	}
+
+	return writeMetadata(metaDataDir, "insights.specs.Specs.ip_addresses.json", metadata)
+}
+
+// writeMACAddresses writes MAC addresses data files and metadata.
+func writeMACAddresses(dataDir, metaDataDir string) error {
+	// Get network interfaces to match MAC addresses with interface names
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		slog.Error("failed to get network interfaces", "error", err)
+		return fmt.Errorf("failed to get network interfaces: %w", err)
+	}
+
+	// Sort interfaces by name for consistent ordering
+	slices.SortFunc(ifaces, func(a, b net.Interface) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	// Build results array with one entry per interface
+	results := make([]map[string]any, 0, len(ifaces))
+	for _, iface := range ifaces {
+		ifaceDir := filepath.Join(dataDir, "sys", "class", "net", iface.Name)
+		if err := os.MkdirAll(ifaceDir, 0700); err != nil {
+			slog.Error("failed to create interface directory", "path", ifaceDir, "error", err)
+			return fmt.Errorf("failed to create directory %s: %w", ifaceDir, err)
+		}
+
+		macPath := filepath.Join(ifaceDir, "address")
+		macAddr := iface.HardwareAddr.String()
+		if err := os.WriteFile(macPath, []byte(macAddr+"\n"), 0600); err != nil {
+			slog.Error("failed to write MAC address to file", "path", macPath, "error", err)
+			return fmt.Errorf("failed to write MAC address to %s: %w", macPath, err)
+		}
+
+		results = append(results, map[string]any{
+			"type": "insights.core.spec_factory.TextFileProvider",
+			"object": SpecObject{
+				RelativePath: fmt.Sprintf("sys/class/net/%s/address", iface.Name),
+				SaveAs:       nil,
+				RC:           nil,
+				Cmd:          nil,
+				Args:         nil,
+			},
+		})
+	}
+
+	metadata := MetadataSpec{
+		Name:     "insights.specs.Specs.mac_addresses",
+		ExecTime: 0.0001,
+		Errors:   []string{},
+		Results:  results,
+		SerTime:  0.0001,
+	}
+
+	return writeMetadata(metaDataDir, "insights.specs.Specs.mac_addresses.json", metadata)
+}
+
+// writeBIOSUUID writes minimal dmidecode output with UUID.
+func writeBIOSUUID(commandsDir, metaDataDir, biosUUID string) error {
+	// Create minimal dmidecode-style output containing just the UUID
+	output := fmt.Sprintf("# dmidecode 3.99.0\n"+
+		"Getting SMBIOS data from sysfs.\n"+
+		"\n"+
+		"Handle 0x0001, DMI type 1, 27 bytes\n"+
+		"System Information\n"+
+		"\tUUID: %s\n", biosUUID)
+
+	path := filepath.Join(commandsDir, "dmidecode")
+	if err := os.WriteFile(path, []byte(output), 0600); err != nil {
+		slog.Error("failed to write dmidecode to file", "path", path, "error", err)
+		return fmt.Errorf("failed to write dmidecode to %s: %w", path, err)
+	}
+
+	metadata := MetadataSpec{
+		Name:     "insights.specs.Specs.dmidecode",
+		ExecTime: 0.0001,
+		Errors:   []string{},
+		Results: map[string]any{
+			"type": "insights.core.spec_factory.CommandOutputProvider",
+			"object": SpecObject{
+				RelativePath: "insights_commands/dmidecode",
+				SaveAs:       nil,
+				RC:           nil,
+				Cmd:          nil,
+				Args:         nil,
+			},
+		},
+		SerTime: 0.0001,
+	}
+
+	return writeMetadata(metaDataDir, "insights.specs.Specs.dmidecode.json", metadata)
+}
+
+// writeFQDN writes hostname output.
+func writeFQDN(commandsDir, metaDataDir, fqdn string) error {
+	path := filepath.Join(commandsDir, "hostname_-f")
+	if err := os.WriteFile(path, []byte(fqdn+"\n"), 0600); err != nil {
+		slog.Error("failed to write FQDN to file", "path", path, "error", err)
+		return fmt.Errorf("failed to write FQDN to %s: %w", path, err)
+	}
+
+	metadata := MetadataSpec{
+		Name:     "insights.specs.Specs.hostname",
+		ExecTime: 0.0001,
+		Errors:   []string{},
+		Results: map[string]any{
+			"type": "insights.core.spec_factory.CommandOutputProvider",
+			"object": SpecObject{
+				RelativePath: "insights_commands/hostname_-f",
+				SaveAs:       nil,
+				RC:           nil,
+				Cmd:          nil,
+				Args:         nil,
+			},
+		},
+		SerTime: 0.0001,
+	}
+
+	return writeMetadata(metaDataDir, "insights.specs.Specs.hostname.json", metadata)
+}
+
+// writeMachineID writes system machine-id.
+func writeMachineID(etcDir, metaDataDir, machineID string) error {
+	path := filepath.Join(etcDir, "machine-id")
+	if err := os.WriteFile(path, []byte(machineID), 0600); err != nil {
+		slog.Error("failed to write machine-id to file", "path", path, "error", err)
+		return fmt.Errorf("failed to write machine-id to %s: %w", path, err)
+	}
+
+	metadata := MetadataSpec{
+		Name:     "insights.specs.Specs.etc_machine_id",
+		ExecTime: 0.0001,
+		Errors:   []string{},
+		Results: map[string]any{
+			"type": "insights.core.spec_factory.TextFileProvider",
+			"object": SpecObject{
+				RelativePath: "etc/machine-id",
+				SaveAs:       nil,
+				RC:           nil,
+				Cmd:          nil,
+				Args:         nil,
+			},
+		},
+		SerTime: 0.0001,
+	}
+
+	return writeMetadata(metaDataDir, "insights.specs.Specs.etc_machine_id.json", metadata)
+}
+
+// writeMetadata writes a metadata JSON file.
+func writeMetadata(metaDataDir, filename string, metadata MetadataSpec) error {
+	metaData, err := json.Marshal(metadata)
+	if err != nil {
+		slog.Error("failed to marshal metadata", "error", err)
+		return fmt.Errorf("failed to marshal metadata for %s: %w", filename, err)
+	}
+
+	metaPath := filepath.Join(metaDataDir, filename)
+	if err = os.WriteFile(metaPath, metaData, 0600); err != nil {
+		slog.Error("failed to write metadata to file", "filename", filename, "error", err)
+		return fmt.Errorf("failed to write metadata to %s: %w", filename, err)
+	}
+
+	slog.Debug("successfully written metadata to file", "metadata", metadata, "filename", filename)
+	return nil
+}

--- a/cmd/minimal-collector/minimal-collector_test.go
+++ b/cmd/minimal-collector/minimal-collector_test.go
@@ -1,0 +1,396 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCreateArchiveStructure(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	dataDir, metaDataDir, err := createArchiveStructure(tmpDir)
+	if err != nil {
+		t.Fatalf("createArchiveStructure failed: %v", err)
+	}
+
+	// Verify data directory exists
+	if _, err = os.Stat(dataDir); os.IsNotExist(err) {
+		t.Errorf("data directory not created: %s", dataDir)
+	}
+
+	// Verify meta_data directory exists
+	if _, err = os.Stat(metaDataDir); os.IsNotExist(err) {
+		t.Errorf("meta_data directory not created: %s", metaDataDir)
+	}
+
+	// Verify insights_archive.txt marker exists
+	markerPath := filepath.Join(tmpDir, "insights_archive.txt")
+	if _, err := os.Stat(markerPath); os.IsNotExist(err) {
+		t.Errorf("insights_archive.txt marker not created")
+	}
+
+	// Verify insights_archive.txt is empty
+	content, err := os.ReadFile(markerPath)
+	if err != nil {
+		t.Fatalf("failed to read insights_archive.txt: %v", err)
+	}
+	if len(content) != 0 {
+		t.Errorf("insights_archive.txt should be empty, got %d bytes", len(content))
+	}
+}
+
+func TestWriteMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	metadata := MetadataSpec{
+		Name:     "test.spec",
+		ExecTime: 0.0001,
+		Errors:   []string{},
+		Results: map[string]any{
+			"type": "test.type",
+			"object": SpecObject{
+				RelativePath: "test/path",
+				SaveAs:       nil,
+				RC:           nil,
+				Cmd:          nil,
+				Args:         nil,
+			},
+		},
+		SerTime: 0.0001,
+	}
+
+	err := writeMetadata(tmpDir, "test.spec.json", metadata)
+	if err != nil {
+		t.Fatalf("writeMetadata failed: %v", err)
+	}
+
+	// Verify file exists
+	metaPath := filepath.Join(tmpDir, "test.spec.json")
+	if _, err := os.Stat(metaPath); os.IsNotExist(err) {
+		t.Errorf("metadata file not created: %s", metaPath)
+	}
+
+	// Verify content can be parsed
+	content, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("failed to read metadata: %v", err)
+	}
+
+	var parsed MetadataSpec
+	if err := json.Unmarshal(content, &parsed); err != nil {
+		t.Fatalf("failed to parse metadata JSON: %v", err)
+	}
+
+	if parsed.Name != "test.spec" {
+		t.Errorf("expected name=test.spec, got %s", parsed.Name)
+	}
+}
+
+func TestObjectSerialization(t *testing.T) {
+	obj := SpecObject{
+		RelativePath: "etc/machine-id",
+		SaveAs:       false,
+		RC:           nil,
+		Cmd:          nil,
+		Args:         nil,
+	}
+
+	data, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("failed to marshal object: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal object: %v", err)
+	}
+
+	if parsed["relative_path"] != "etc/machine-id" {
+		t.Errorf("expected relative_path=etc/machine-id, got %v", parsed["relative_path"])
+	}
+
+	if parsed["save_as"] != false {
+		t.Errorf("expected save_as=false, got %v", parsed["save_as"])
+	}
+}
+
+func TestVersionInfoBranchInfo(t *testing.T) {
+	vi := VersionInfo{
+		CoreVersion:   "1.0.0",
+		ClientVersion: nil,
+	}
+
+	data, err := json.Marshal(vi)
+	if err != nil {
+		t.Fatalf("failed to marshal VersionInfo: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal VersionInfo: %v", err)
+	}
+
+	if parsed["core_version"] != "1.0.0" {
+		t.Errorf("expected core_version=1.0.0, got %v", parsed["core_version"])
+	}
+
+	bi := BranchInfo{
+		RemoteBranch: -1,
+		RemoteLeaf:   -1,
+	}
+
+	data, err = json.Marshal(bi)
+	if err != nil {
+		t.Fatalf("failed to marshal BranchInfo: %v", err)
+	}
+
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal BranchInfo: %v", err)
+	}
+
+	if parsed["remote_branch"].(float64) != -1 {
+		t.Errorf("expected remote_branch=-1, got %v", parsed["remote_branch"])
+	}
+}
+
+func TestWriteInsightsID(t *testing.T) {
+	tmpDir := t.TempDir()
+	etcDir := filepath.Join(tmpDir, "etc", "insights-client")
+	metaDataDir := filepath.Join(tmpDir, "meta_data")
+
+	if err := os.MkdirAll(etcDir, 0700); err != nil {
+		t.Fatalf("failed to create etc dir: %v", err)
+	}
+	if err := os.MkdirAll(metaDataDir, 0700); err != nil {
+		t.Fatalf("failed to create meta_data dir: %v", err)
+	}
+
+	testID := "test-insights-id-12345"
+	err := writeInsightsID(etcDir, metaDataDir, testID)
+	if err != nil {
+		t.Fatalf("writeInsightsID failed: %v", err)
+	}
+
+	// Verify data file
+	dataPath := filepath.Join(etcDir, "machine-id")
+	content, err := os.ReadFile(dataPath)
+	if err != nil {
+		t.Fatalf("failed to read machine-id: %v", err)
+	}
+
+	if string(content) != testID {
+		t.Errorf("expected content=%s, got %s", testID, string(content))
+	}
+
+	// Verify metadata file
+	metaPath := filepath.Join(metaDataDir, "insights.specs.Specs.machine_id.json")
+	if _, err := os.Stat(metaPath); os.IsNotExist(err) {
+		t.Errorf("metadata file not created")
+	}
+}
+
+func TestWriteIPAddresses(t *testing.T) {
+	tmpDir := t.TempDir()
+	commandsDir := filepath.Join(tmpDir, "insights_commands")
+	metaDataDir := filepath.Join(tmpDir, "meta_data")
+
+	if err := os.MkdirAll(commandsDir, 0700); err != nil {
+		t.Fatalf("failed to create commands dir: %v", err)
+	}
+	if err := os.MkdirAll(metaDataDir, 0700); err != nil {
+		t.Fatalf("failed to create meta_data dir: %v", err)
+	}
+
+	testIPs := []string{"192.168.1.1", "10.0.0.1"}
+	err := writeIPAddresses(commandsDir, metaDataDir, testIPs)
+	if err != nil {
+		t.Fatalf("writeIPAddresses failed: %v", err)
+	}
+
+	// Verify data file
+	dataPath := filepath.Join(commandsDir, "hostname_-I")
+	content, err := os.ReadFile(dataPath)
+	if err != nil {
+		t.Fatalf("failed to read hostname_-I: %v", err)
+	}
+
+	expected := "192.168.1.1 10.0.0.1\n"
+	if string(content) != expected {
+		t.Errorf("expected content=%q, got %q", expected, string(content))
+	}
+
+	// Verify metadata file
+	metaPath := filepath.Join(metaDataDir, "insights.specs.Specs.ip_addresses.json")
+	if _, err := os.Stat(metaPath); os.IsNotExist(err) {
+		t.Errorf("metadata file not created")
+	}
+}
+
+func TestWriteFQDN(t *testing.T) {
+	tmpDir := t.TempDir()
+	commandsDir := filepath.Join(tmpDir, "insights_commands")
+	metaDataDir := filepath.Join(tmpDir, "meta_data")
+
+	if err := os.MkdirAll(commandsDir, 0700); err != nil {
+		t.Fatalf("failed to create commands dir: %v", err)
+	}
+	if err := os.MkdirAll(metaDataDir, 0700); err != nil {
+		t.Fatalf("failed to create meta_data dir: %v", err)
+	}
+
+	testFQDN := "test.example.com"
+	err := writeFQDN(commandsDir, metaDataDir, testFQDN)
+	if err != nil {
+		t.Fatalf("writeFQDN failed: %v", err)
+	}
+
+	// Verify data file
+	dataPath := filepath.Join(commandsDir, "hostname_-f")
+	content, err := os.ReadFile(dataPath)
+	if err != nil {
+		t.Fatalf("failed to read hostname_-f: %v", err)
+	}
+
+	expected := "test.example.com\n"
+	if string(content) != expected {
+		t.Errorf("expected content=%q, got %q", expected, string(content))
+	}
+
+	// Verify metadata file
+	metaPath := filepath.Join(metaDataDir, "insights.specs.Specs.hostname.json")
+	if _, err := os.Stat(metaPath); os.IsNotExist(err) {
+		t.Errorf("metadata file not created")
+	}
+}
+
+func TestWriteMachineID(t *testing.T) {
+	tmpDir := t.TempDir()
+	etcDir := filepath.Join(tmpDir, "etc")
+	metaDataDir := filepath.Join(tmpDir, "meta_data")
+
+	if err := os.MkdirAll(etcDir, 0700); err != nil {
+		t.Fatalf("failed to create etc dir: %v", err)
+	}
+	if err := os.MkdirAll(metaDataDir, 0700); err != nil {
+		t.Fatalf("failed to create meta_data dir: %v", err)
+	}
+
+	testMachineID := "abc123-def456-ghi789"
+	err := writeMachineID(etcDir, metaDataDir, testMachineID)
+	if err != nil {
+		t.Fatalf("writeMachineID failed: %v", err)
+	}
+
+	// Verify data file
+	dataPath := filepath.Join(etcDir, "machine-id")
+	content, err := os.ReadFile(dataPath)
+	if err != nil {
+		t.Fatalf("failed to read machine-id: %v", err)
+	}
+
+	if string(content) != testMachineID {
+		t.Errorf("expected content=%s, got %s", testMachineID, string(content))
+	}
+
+	// Verify metadata file
+	metaPath := filepath.Join(metaDataDir, "insights.specs.Specs.etc_machine_id.json")
+	if _, err := os.Stat(metaPath); os.IsNotExist(err) {
+		t.Errorf("metadata file not created")
+	}
+}
+
+func TestWriteBIOSUUID(t *testing.T) {
+	tmpDir := t.TempDir()
+	commandsDir := filepath.Join(tmpDir, "insights_commands")
+	metaDataDir := filepath.Join(tmpDir, "meta_data")
+
+	if err := os.MkdirAll(commandsDir, 0700); err != nil {
+		t.Fatalf("failed to create commands dir: %v", err)
+	}
+	if err := os.MkdirAll(metaDataDir, 0700); err != nil {
+		t.Fatalf("failed to create meta_data dir: %v", err)
+	}
+
+	testUUID := "12345678-1234-1234-1234-123456789012"
+	err := writeBIOSUUID(commandsDir, metaDataDir, testUUID)
+	if err != nil {
+		t.Fatalf("writeBIOSUUID failed: %v", err)
+	}
+
+	// Verify data file contains UUID
+	dataPath := filepath.Join(commandsDir, "dmidecode")
+	content, err := os.ReadFile(dataPath)
+	if err != nil {
+		t.Fatalf("failed to read dmidecode: %v", err)
+	}
+
+	contentStr := string(content)
+	if !strings.Contains(contentStr, testUUID) {
+		t.Errorf("dmidecode output does not contain UUID %s", testUUID)
+	}
+
+	if !strings.Contains(contentStr, "# dmidecode") {
+		t.Errorf("dmidecode output missing header")
+	}
+
+	// Verify metadata file
+	metaPath := filepath.Join(metaDataDir, "insights.specs.Specs.dmidecode.json")
+	if _, err := os.Stat(metaPath); os.IsNotExist(err) {
+		t.Errorf("metadata file not created")
+	}
+}
+
+func TestWriteMACAddresses(t *testing.T) {
+	tmpDir := t.TempDir()
+	dataDir := filepath.Join(tmpDir, "data")
+	metaDataDir := filepath.Join(tmpDir, "meta_data")
+
+	if err := os.MkdirAll(dataDir, 0700); err != nil {
+		t.Fatalf("failed to create data dir: %v", err)
+	}
+	if err := os.MkdirAll(metaDataDir, 0700); err != nil {
+		t.Fatalf("failed to create meta_data dir: %v", err)
+	}
+
+	err := writeMACAddresses(dataDir, metaDataDir)
+	if err != nil {
+		t.Fatalf("writeMACAddresses failed: %v", err)
+	}
+
+	// Verify metadata file exists
+	metaPath := filepath.Join(metaDataDir, "insights.specs.Specs.mac_addresses.json")
+	content, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("failed to read mac_addresses metadata: %v", err)
+	}
+
+	// Parse and verify it's valid JSON with array results
+	var metadata MetadataSpec
+	if err := json.Unmarshal(content, &metadata); err != nil {
+		t.Fatalf("failed to parse metadata JSON: %v", err)
+	}
+
+	if metadata.Name != "insights.specs.Specs.mac_addresses" {
+		t.Errorf("expected name=insights.specs.Specs.mac_addresses, got %s", metadata.Name)
+	}
+
+	// Results should be an array
+	results, ok := metadata.Results.([]any)
+	if !ok {
+		t.Fatalf("expected Results to be array, got %T", metadata.Results)
+	}
+
+	// Should have at least one interface (loopback at minimum)
+	if len(results) == 0 {
+		t.Errorf("expected at least one interface, got 0")
+	}
+
+	// Verify data files were created
+	sysNetDir := filepath.Join(dataDir, "sys", "class", "net")
+	if _, err := os.Stat(sysNetDir); os.IsNotExist(err) {
+		t.Errorf("sys/class/net directory not created")
+	}
+}

--- a/data/collectors/com.redhat.minimal.toml
+++ b/data/collectors/com.redhat.minimal.toml
@@ -1,0 +1,9 @@
+[meta]
+name = "Minimal Host Inventory Collector"
+feature = "analytics"
+type = "ingress"
+
+[ingress]
+user = "root"
+group = "root"
+content_type = "application/vnd.redhat.advisor.minimal"

--- a/data/systemd/rhc-collector-com.redhat.minimal.service
+++ b/data/systemd/rhc-collector-com.redhat.minimal.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Minimal Host Inventory data collector
+After=network.target
+Documentation=https://github.com/RedHatInsights/rhc
+
+# Only try to restart six times
+StartLimitIntervalSec=12h
+StartLimitBurst=6
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/rhc/rhc-collector run com.redhat.minimal
+
+Restart=on-failure
+RestartSec=1h
+
+[Install]
+WantedBy=multi-user.target

--- a/data/systemd/rhc-collector-com.redhat.minimal.timer
+++ b/data/systemd/rhc-collector-com.redhat.minimal.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Minimal Host Inventory data collector timer
+Documentation=https://github.com/RedHatInsights/rhc
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=4h
+
+# Run if the system was down
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/rhc.spec
+++ b/rhc.spec
@@ -77,6 +77,7 @@ export GO_LDFLAGS="-X github.com/redhatinsights/rhc/pkg/version.Version=%{versio
 %gobuild -o %{gobuilddir}/bin/rhc           %{goipath}/cmd/rhc
 %gobuild -o %{gobuilddir}/bin/rhc-server    %{goipath}/cmd/rhc-server
 %gobuild -o %{gobuilddir}/bin/rhc-collector %{goipath}/cmd/rhc-collector
+%gobuild -o %{gobuilddir}/bin/com.redhat.minimal %{goipath}/cmd/minimal-collector
 
 # Generate man page
 %{gobuilddir}/bin/rhc --generate-man-page > rhc.1
@@ -112,10 +113,14 @@ install -m 0755 -vd                     %{buildroot}%{_unitdir}
 install -m 0644 -vp data/systemd/rhc-canonical-facts.*  %{buildroot}%{_unitdir}/
 install -m 0644 -vp data/systemd/rhc-server.service  %{buildroot}%{_unitdir}/
 install -m 0644 -vp data/systemd/rhc-server.socket   %{buildroot}%{_unitdir}/
+install -m 0644 -vp data/systemd/rhc-collector-com.redhat.minimal.*  %{buildroot}%{_unitdir}/
 install -m 0755 -vd %{buildroot}%{_prefix}/lib/systemd/system-preset/
 install -m 0644 -vp data/systemd/presets/50-rhc.preset %{buildroot}%{_prefix}/lib/systemd/system-preset/
 # Configuration
 install -m 0755 -vd                     %{buildroot}%{_sysconfdir}/%{name}/
+# Minimal collector
+install -m 0755 -vp _build/bin/com.redhat.minimal %{buildroot}%{_libexecdir}/%{name}/collectors/com.redhat.minimal
+install -m 0644 -vp data/collectors/com.redhat.minimal.toml %{buildroot}%{_prefix}/lib/%{name}/collectors/
 
 %if 0%{?with_rhcd_compat}
 # Yggdrasil used to be called rhcd, and was part of rhc. For historical reasons, rhc
@@ -151,6 +156,7 @@ fi
 %post
 %systemd_post rhc-canonical-facts.timer
 %systemd_post rhc-server.socket
+%systemd_post rhc-collector-com.redhat.minimal.timer
 
 %if 0%{?with_rhcd_compat}
 # rhcd_t is the SELinux type used by the old rhcd daemon. Add it to the
@@ -169,10 +175,12 @@ fi
 %preun
 %systemd_preun rhc-canonical-facts.timer
 %systemd_preun rhc-server.socket rhc-server.service
+%systemd_preun rhc-collector-com.redhat.minimal.timer
 
 %postun
 %systemd_postun_with_restart rhc-canonical-facts.timer
 %systemd_postun_with_restart rhc-server.service
+%systemd_postun_with_restart rhc-collector-com.redhat.minimal.timer
 
 %if 0%{?with_rhcd_compat}
 # Remove rhcd_t from the SELinux permissive list on full package removal.
@@ -201,12 +209,16 @@ fi
 %{_unitdir}/rhc-canonical-facts.*
 %{_unitdir}/rhc-server.service
 %{_unitdir}/rhc-server.socket
+%{_unitdir}/rhc-collector-com.redhat.minimal.*
 %{_prefix}/lib/systemd/system-preset/50-rhc.preset
 # Configuration
 %{_sysconfdir}/%{name}/
 # Collector directories
 %dir %{_prefix}/lib/%{name}/collectors/
 %dir %{_libexecdir}/%{name}/collectors/
+# Minimal collector files
+%{_libexecdir}/%{name}/collectors/com.redhat.minimal
+%{_prefix}/lib/%{name}/collectors/com.redhat.minimal.toml
 # Logs
 %dir %{_localstatedir}/log/%{name}/
 # Logrotate


### PR DESCRIPTION
* Card ID: CCT-2393

Add minimal data collector that generates HBI ingress message format with canonical facts only (not full insights archive).

---
Testing:
1. Install rpm
2. Register to subscription-manager
3. Run `/usr/libexec/rhc/rhc-collector run com.redhat.minimal`
4. Login to console.redhat.com and find your system - it should have the data obtained by the collector (instead of by executing insights-client)

Note: The 4th step doesn't entirely work yet and I don't know why that happens. The archive is being correctly uploaded to Ingress, but the facts are not visible in console.redhat.com.