### PR TITLE
chore(subman): Refactor system registration

### DIFF
--- a/cmd/rhc/connect_cmd.go
+++ b/cmd/rhc/connect_cmd.go
@@ -234,15 +234,15 @@ func beforeConnectAction(ctx context.Context, cmd *cli.Command) (context.Context
 
 	// Do not continue if the host is already registered
 	slog.Info("Checking system connection status")
-	uuid, err := subman.GetConsumerUUID()
+	registered, err := subman.IsRegistered()
 	if err != nil {
 		return ctx, cli.Exit(
-			fmt.Sprintf("unable to get consumer UUID: %s", err),
+			fmt.Sprintf("unable to check connection status: %s", err),
 			exitcode.Software,
 		)
 	}
-	if uuid != "" {
-		slog.Info("Consumer UUID is set, system is already connected")
+	if registered {
+		slog.Info("System is already connected")
 		return ctx, cli.Exit("this system is already connected", exitcode.Usage)
 	}
 

--- a/cmd/rhc/status_cmd.go
+++ b/cmd/rhc/status_cmd.go
@@ -22,13 +22,13 @@ import (
 func rhsmStatus(systemStatus *SystemStatus) error {
 	slog.Info("Checking status of Red Hat Subscription Management")
 
-	uuid, err := subman.GetConsumerUUID()
+	registered, err := subman.IsRegistered()
 	if err != nil {
 		systemStatus.returnCode += 1
 		systemStatus.RHSMError = err.Error()
-		return fmt.Errorf("unable to get consumer UUID: %s", err)
+		return fmt.Errorf("unable to check registration status: %s", err)
 	}
-	if uuid == "" {
+	if !registered {
 		systemStatus.returnCode += 1
 		systemStatus.RHSMConnected = false
 		infoMsg := "Not connected to Red Hat Subscription Management"
@@ -43,8 +43,8 @@ func rhsmStatus(systemStatus *SystemStatus) error {
 	return nil
 }
 
-// isContentEnabled checks whether the system is registered and the content management
-// is enabled. Both conditions must be true for content access to be available.
+// isContentEnabled reports whether the system has access to RHSM content.
+// It relies on systemStatus.RHSMConnected already being populated by rhsmStatus.
 func isContentEnabled(systemStatus *SystemStatus) error {
 	slog.Info("Checking content status")
 
@@ -55,14 +55,7 @@ func isContentEnabled(systemStatus *SystemStatus) error {
 		return fmt.Errorf("unable to check content management: %w", err)
 	}
 
-	registered, err := subman.IsRegistered()
-	if err != nil {
-		systemStatus.returnCode += 1
-		systemStatus.ContentError = err.Error()
-		return fmt.Errorf("unable to check registration status: %s", err)
-	}
-
-	if contentEnabled && registered {
+	if contentEnabled && systemStatus.RHSMConnected {
 		systemStatus.ContentEnabled = true
 		infoMsg := "System has access to content"
 		slog.Info(infoMsg)

--- a/internal/subman/content.go
+++ b/internal/subman/content.go
@@ -5,61 +5,62 @@ import (
 	"log/slog"
 
 	"github.com/godbus/dbus/v5"
-
 	"github.com/redhatinsights/rhc/internal/localization"
 )
 
-// IsContentManagementEnabled returns true if content management is enabled for the system in rhsm.conf
+// IsContentManagementEnabled reports whether content management is enabled for
+// the system in rhsm.conf (rhsm.manage_repos).
 func IsContentManagementEnabled() (bool, error) {
-	conn, err := dbus.SystemBus()
+	slog.Debug("Checking content management status")
+	conn, err := bus()
 	if err != nil {
-		return false, fmt.Errorf("cannot connect to system D-Bus: %w", err)
+		return false, err
 	}
-	// godbus implements SystemBus as a singleton, do not call conn.Close()
 
 	locale := localization.GetLocale()
 	config := conn.Object("com.redhat.RHSM1", "/com/redhat/RHSM1/Config")
 
-	var contentEnabled string
+	var value string
 	err = config.Call(
 		"com.redhat.RHSM1.Config.Get",
 		dbus.Flags(0),
 		"rhsm.manage_repos",
-		locale).Store(&contentEnabled)
+		locale,
+	).Store(&value)
 	if err != nil {
-		slog.Debug("Failed to get rhsm.manage_repos config", "error", err)
-		return false, UnpackDBusError(err)
+		return false, fmt.Errorf("reading content management setting: %w", newDbusError(err))
 	}
 
-	return contentEnabled == "1", nil
+	return value == "1", nil
 }
 
-// SetContentManagement tries to enable or disable content management for the system in rhsm.conf
+// SetContentManagement enables or disables content management for the system
+// in rhsm.conf (rhsm.manage_repos).
 func SetContentManagement(enabled bool) error {
-	conn, err := dbus.SystemBus()
+	slog.Debug("Setting content management", "enabled", enabled)
+	conn, err := bus()
 	if err != nil {
-		return fmt.Errorf("cannot connect to system D-Bus: %w", err)
+		return err
 	}
-	// godbus implements SystemBus as a singleton, do not call conn.Close()
 
 	locale := localization.GetLocale()
 	config := conn.Object("com.redhat.RHSM1", "/com/redhat/RHSM1/Config")
-	enabledStr := "1"
-	if !enabled {
-		enabledStr = "0"
+
+	value := "0"
+	if enabled {
+		value = "1"
 	}
 
 	err = config.Call(
 		"com.redhat.RHSM1.Config.Set",
 		dbus.Flags(0),
 		"rhsm.manage_repos",
-		enabledStr,
+		value,
 		locale,
 	).Err
 	if err != nil {
-		slog.Debug("Failed to set rhsm.manage_repos config", "error", err)
-		return UnpackDBusError(err)
+		slog.Debug("Could not set rhsm.manage_repos", "error", err)
+		return fmt.Errorf("setting content management: %w", newDbusError(err))
 	}
-
 	return nil
 }

--- a/internal/subman/dbus.go
+++ b/internal/subman/dbus.go
@@ -1,0 +1,82 @@
+package subman
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/redhatinsights/rhc/internal/localization"
+)
+
+// bus returns the shared system D-Bus connection.
+// godbus implements SystemBus as a process-wide singleton; the returned
+// connection must never be closed by callers.
+func bus() (*dbus.Conn, error) {
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrDBusUnavailable, err)
+	}
+	return conn, nil
+}
+
+// unpackOrganizations unmarshals the JSON list of organizations returned by the D-Bus
+// GetOrgs method into a plain slice of organization key strings.
+func unpackOrganizations(s string) ([]string, error) {
+	// The D-Bus object contains multiple keys, but we only care about the organization names.
+	var orgs []struct {
+		Key string `json:"key"`
+	}
+	if err := json.Unmarshal([]byte(s), &orgs); err != nil {
+		return nil, err
+	}
+
+	keys := make([]string, 0, len(orgs))
+	for _, o := range orgs {
+		keys = append(keys, o.Key)
+	}
+
+	return keys, nil
+}
+
+// withPrivateRegisterSocket opens the private RHSM registration socket, authenticates,
+// and calls fn with the live connection and the resolved locale string.
+// It ensures the socket is stopped and closed on return regardless of outcome.
+// fn must not retain the connection after it returns.
+func withPrivateRegisterSocket(conn *dbus.Conn, fn func(*dbus.Conn, string) error) error {
+	locale := localization.GetLocale()
+	registerServer := conn.Object("com.redhat.RHSM1", "/com/redhat/RHSM1/RegisterServer")
+
+	slog.Debug("Opening private D-Bus UNIX socket")
+	var socketURI string
+	err := registerServer.Call(
+		"com.redhat.RHSM1.RegisterServer.Start",
+		dbus.Flags(0),
+		locale,
+	).Store(&socketURI)
+	if err != nil {
+		return fmt.Errorf("starting RHSM register server: %w", newDbusError(err))
+	}
+	defer func() {
+		slog.Debug("Closing private UNIX socket", "socket", socketURI)
+		registerServer.Call("com.redhat.RHSM1.RegisterServer.Stop", dbus.FlagNoReplyExpected, locale)
+	}()
+
+	slog.Debug("Connecting to private D-Bus UNIX socket", "socket", socketURI)
+	privConn, err := dbus.Dial(socketURI)
+	if err != nil {
+		return fmt.Errorf("connecting to private D-Bus socket: %w", err)
+	}
+	defer func() {
+		slog.Debug("Closing connection to private D-Bus UNIX socket", "socket", socketURI)
+		if closeErr := privConn.Close(); closeErr != nil {
+			slog.Debug("Unable to close private D-Bus socket", "socket", socketURI, "err", closeErr)
+		}
+	}()
+
+	if err = privConn.Auth(nil); err != nil {
+		return fmt.Errorf("authenticating private D-Bus connection: %w", err)
+	}
+
+	return fn(privConn, locale)
+}

--- a/internal/subman/doc.go
+++ b/internal/subman/doc.go
@@ -1,0 +1,35 @@
+// Package subman provides a D-Bus client adapter for subscription-manager.
+//
+// All operations communicate with com.redhat.RHSM1 over the system bus.
+// The underlying godbus library manages the system bus connection as
+// a process-wide singleton; functions in this package must never close
+// the connection they obtain from the bus.
+//
+// # Identity and registration
+//
+//   - [IsRegistered] reports whether the system is currently registered with RHSM.
+//   - [RegisterWithPassword] registers the system using a username and password.
+//     If the account belongs to multiple organizations, and none has been passed
+//     in, [ErrOrganizationRequired] is returned; the caller should call
+//     [GetOrganizations] to obtain the list, prompt the user, and retry with an
+//     explicit organization.
+//   - [GetOrganizations] returns the organization keys available for a username
+//     and password. Use this after [RegisterWithPassword] returns
+//     [ErrOrganizationRequired].
+//   - [RegisterWithActivationKeys] registers the system using activation keys.
+//     An organization must always be specified for this method.
+//   - [Unregister] removes the system's RHSM registration.
+//
+// # Content management
+//
+//   - [IsContentManagementEnabled] reports whether RHSM content management is
+//     enabled in rhsm.conf (rhsm.manage_repos).
+//   - [SetContentManagement] enables or disables RHSM content management.
+//
+// # Registration options
+//
+// Both registration methods accept a [RegisterOptions] value that groups the
+// options shared by all registration flows (environment names and content
+// enablement). The EnvironmentNames field corresponds to the --content-template
+// CLI flag.
+package subman

--- a/internal/subman/errors.go
+++ b/internal/subman/errors.go
@@ -3,29 +3,41 @@ package subman
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 
 	"github.com/godbus/dbus/v5"
 )
 
-// DBusError is used for parsing JSON document returned by D-Bus methods.
-type DBusError struct {
+// ErrDBusUnavailable is returned when the system D-Bus daemon cannot be reached.
+var ErrDBusUnavailable = errors.New("system D-Bus is not available")
+
+// ErrAlreadyRegistered is returned when an operation requires the system to be
+// unregistered, but it is already registered with RHSM.
+var ErrAlreadyRegistered = errors.New("system is already registered with RHSM")
+
+// ErrAlreadyUnregistered is returned when an operation requires the system to
+// be registered, but it is already unregistered from RHSM.
+var ErrAlreadyUnregistered = errors.New("system is already unregistered from RHSM")
+
+// ErrOrganizationRequired is returned when an organization must be specified
+// but was not.
+var ErrOrganizationRequired = errors.New("organization is required")
+
+// dbusError holds the structured error body returned by com.redhat.RHSM1 D-Bus methods.
+type dbusError struct {
 	Exception string `json:"exception"`
 	Severity  string `json:"severity"`
 	Message   string `json:"message"`
 }
 
-// Error returns textual representation of DBusError. This implements all necessary
-// methods for the error interface. Thus, DBusError can be handled as a regular error.
-func (dbusError DBusError) Error() string {
-	return fmt.Sprintf("%v: %v", dbusError.Severity, dbusError.Message)
+func (e dbusError) Error() string {
+	return e.Message
 }
 
-// UnpackDBusError tries to unpack a JSON document (part of the error) into the structure DBusError.
-// When it is not possible to parse an error into structure, then a corresponding or original error
-// is returned. When it is possible to parse error into structure, then DBusError is returned
-func UnpackDBusError(err error) error {
+// newDbusError translates a raw D-Bus error into a structured dbusError when
+// the error originates from com.redhat.RHSM1. Returns the original error
+// unchanged for all other cases or when the body cannot be parsed.
+func newDbusError(err error) error {
 	var e dbus.Error
 	ok := errors.As(err, &e)
 	if !ok {
@@ -35,10 +47,10 @@ func UnpackDBusError(err error) error {
 		return err
 	}
 
-	var dbusError DBusError
-	if jsonErr := json.Unmarshal([]byte(e.Error()), &dbusError); jsonErr != nil {
+	var d dbusError
+	if jsonErr := json.Unmarshal([]byte(e.Error()), &d); jsonErr != nil {
 		slog.Debug("Failed to unmarshal D-Bus error body", "error", jsonErr)
 		return err
 	}
-	return dbusError
+	return d
 }

--- a/internal/subman/identity.go
+++ b/internal/subman/identity.go
@@ -1,46 +1,68 @@
 package subman
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
+	"strings"
 
 	"github.com/godbus/dbus/v5"
-
 	"github.com/redhatinsights/rhc/internal/localization"
 )
 
-// GetConsumerUUID returns the consumer UUID from RHSM D-Bus API.
-// An empty string means the system is not registered.
-func GetConsumerUUID() (string, error) {
-	conn, err := dbus.SystemBus()
-	if err != nil {
-		return "", err
-	}
-	// godbus implements SystemBus as a singleton, do not call conn.Close()
+// RegisterOptions groups the options common to the registration methods.
+type RegisterOptions struct {
+	// EnvironmentNames is the list of content template names to associate with the host.
+	EnvironmentNames []string
+	// EnableContent controls whether RHSM content management (manage_repos)
+	// is enabled after registration.
+	EnableContent bool
+}
+
+// getConsumerUUID returns the RHSM consumer UUID via D-Bus.
+// An empty string indicates the system is not registered.
+func getConsumerUUID(conn *dbus.Conn) (string, error) {
+	var uuid string
 
 	locale := localization.GetLocale()
-
-	var uuid string
-	err = conn.Object(
+	err := conn.Object(
 		"com.redhat.RHSM1",
 		"/com/redhat/RHSM1/Consumer").Call(
 		"com.redhat.RHSM1.Consumer.GetUuid",
 		dbus.Flags(0),
-		locale).Store(&uuid)
+		locale,
+	).Store(&uuid)
 	if err != nil {
-		return "", UnpackDBusError(err)
+		return "", fmt.Errorf("getting consumer UUID: %w", newDbusError(err))
 	}
 
 	return uuid, nil
 }
 
-// IsRegistered returns true when the system is registered with RHSM.
+// buildOptions converts RegisterOptions into the D-Bus options map expected by
+// the RHSM registration methods.
+func buildOptions(opts RegisterOptions) map[string]string {
+	options := make(map[string]string)
+	if len(opts.EnvironmentNames) != 0 {
+		options["environment_type"] = "content-template"
+		options["environment_names"] = strings.Join(opts.EnvironmentNames, ",")
+	}
+	options["enable_content"] = strconv.FormatBool(opts.EnableContent)
+	return options
+}
+
+// IsRegistered reports whether the system is currently registered with RHSM.
 func IsRegistered() (bool, error) {
 	slog.Debug("Checking if system is registered to Red Hat Subscription Management")
-
-	uuid, err := GetConsumerUUID()
+	conn, err := bus()
 	if err != nil {
 		return false, err
+	}
+
+	uuid, err := getConsumerUUID(conn)
+	if err != nil {
+		return false, fmt.Errorf("could not determine registration status: %w", err)
 	}
 	if uuid != "" {
 		slog.Debug("Consumer UUID is set, system is registered")
@@ -51,34 +73,176 @@ func IsRegistered() (bool, error) {
 	return false, nil
 }
 
-// Unregister removes the system registration from RHSM.
-func Unregister() error {
-	conn, err := dbus.SystemBus()
+// GetOrganizations returns the list of organization names available for the
+// given username and password.
+func GetOrganizations(username, password string) ([]string, error) {
+	slog.Debug("Retrieving available organizations")
+	conn, err := bus()
+	if err != nil {
+		return nil, err
+	}
+
+	var organizations []string
+	getOrganizations := func(privConn *dbus.Conn, locale string) error {
+		slog.Debug("Calling method com.redhat.RHSM1.Register.GetOrgs")
+		var raw string
+		if err := privConn.Object(
+			"com.redhat.RHSM1",
+			"/com/redhat/RHSM1/Register").Call(
+			"com.redhat.RHSM1.Register.GetOrgs",
+			dbus.Flags(0),
+			username,
+			password,
+			map[string]string{},
+			locale,
+		).Store(&raw); err != nil {
+			return fmt.Errorf("retrieving available organizations: %w", newDbusError(err))
+		}
+
+		var parseErr error
+		organizations, parseErr = unpackOrganizations(raw)
+		if parseErr != nil {
+			return fmt.Errorf("parsing available organizations: %w", parseErr)
+		}
+
+		return nil
+	}
+
+	if err = withPrivateRegisterSocket(conn, getOrganizations); err != nil {
+		return nil, err
+	}
+
+	return organizations, nil
+}
+
+// RegisterWithPassword registers the system using username/password credentials.
+//
+// Returns [ErrAlreadyRegistered] if the system is already registered.
+//
+// If the account belongs to multiple organizations, and an empty string has been
+// passed in, the caller should call [GetOrganizations] to retrieve the available
+// organization names, prompt the user, and retry with an explicit value.
+func RegisterWithPassword(username, password, organization string, opts RegisterOptions) error {
+	slog.Debug("Registering system with username and password")
+	conn, err := bus()
 	if err != nil {
 		return err
 	}
-	// godbus implements SystemBus as a singleton, do not call conn.Close()
 
-	uuid, err := GetConsumerUUID()
+	registered, err := IsRegistered()
+	if err != nil {
+		return err
+	}
+	if registered {
+		return ErrAlreadyRegistered
+	}
+
+	registerWithPassword := func(privConn *dbus.Conn, locale string) error {
+		options := buildOptions(opts)
+		slog.Debug("Calling method com.redhat.RHSM1.Register.Register")
+		if err := privConn.Object(
+			"com.redhat.RHSM1",
+			"/com/redhat/RHSM1/Register").Call(
+			"com.redhat.RHSM1.Register.Register",
+			dbus.Flags(0),
+			organization,
+			username,
+			password,
+			options,
+			map[string]string{},
+			locale,
+		).Err; err != nil {
+			unpacked := newDbusError(err)
+			var d dbusError
+			if errors.As(unpacked, &d) && d.Exception == "OrgNotSpecifiedException" {
+				return ErrOrganizationRequired
+			}
+
+			return fmt.Errorf("registering with RHSM: %w", unpacked)
+		}
+
+		return nil
+	}
+
+	return withPrivateRegisterSocket(conn, registerWithPassword)
+}
+
+// RegisterWithActivationKeys registers the system using activation keys.
+//
+// Returns [ErrAlreadyRegistered] if the system is already registered.
+//
+// Returns [ErrOrganizationRequired] if it is empty.
+func RegisterWithActivationKeys(organization string, activationKeys []string, opts RegisterOptions) error {
+	slog.Debug("Registering system with activation keys")
+	if organization == "" {
+		return ErrOrganizationRequired
+	}
+
+	conn, err := bus()
+	if err != nil {
+		return err
+	}
+
+	registered, err := IsRegistered()
+	if err != nil {
+		return err
+	}
+	if registered {
+		return ErrAlreadyRegistered
+	}
+
+	registerWithActivationKeys := func(privConn *dbus.Conn, locale string) error {
+		options := buildOptions(opts)
+		slog.Debug("Calling method com.redhat.RHSM1.Register.RegisterWithActivationKeys")
+		if err := privConn.Object(
+			"com.redhat.RHSM1",
+			"/com/redhat/RHSM1/Register").Call(
+			"com.redhat.RHSM1.Register.RegisterWithActivationKeys",
+			dbus.Flags(0),
+			organization,
+			activationKeys,
+			options,
+			map[string]string{},
+			locale,
+		).Err; err != nil {
+			return fmt.Errorf("registering with RHSM: %w", newDbusError(err))
+		}
+		return nil
+	}
+
+	return withPrivateRegisterSocket(conn, registerWithActivationKeys)
+}
+
+// Unregister removes the system's RHSM registration.
+//
+// Returns [ErrAlreadyUnregistered] if the system is not currently registered.
+func Unregister() error {
+	slog.Debug("Unregistering system from Red Hat Subscription Management")
+	conn, err := bus()
+	if err != nil {
+		return err
+	}
+
+	uuid, err := getConsumerUUID(conn)
 	if err != nil {
 		return err
 	}
 	if uuid == "" {
-		return fmt.Errorf("warning: the system is already unregistered")
+		slog.Debug("System is not registered, nothing to unregister")
+		return ErrAlreadyUnregistered
 	}
 
-	locale := localization.GetLocale()
-
 	slog.Debug("Calling method com.redhat.RHSM1.Unregister.Unregister")
-	err = conn.Object(
+	locale := localization.GetLocale()
+	if err := conn.Object(
 		"com.redhat.RHSM1",
 		"/com/redhat/RHSM1/Unregister").Call(
 		"com.redhat.RHSM1.Unregister.Unregister",
 		dbus.Flags(0),
-		map[string]string{},
-		locale).Err
-	if err != nil {
-		return UnpackDBusError(err)
+		map[string]string{}, // reserved for future use
+		locale,
+	).Err; err != nil {
+		return fmt.Errorf("unregistering from RHSM: %w", newDbusError(err))
 	}
 
 	return nil


### PR DESCRIPTION
* Card ID: CCT-2401

Following previous commit starting the internal/subman refactor, this patch adds system registration functionality. It moves away from direct D-Bus calls into a structure more readable and concern-separated.

Since original rhsm.go and connect_cmd.go files mix and match layers, the code still isn't plugged into the actual CLI.

errors.go
- Defines several sentinel values the API consumers can match on.
- Makes D-Bus error handling private, isolating it to use within the package.
- newDbusError() is less nested than the original UnpackDBusError().

dbus.go
- bus() centralizes SystemBus acquisition and documents the singleton nature of the Go D-Bus library we use.
- withPrivateRegisterSocket() manages the details of connecting to the private UNIX socket, and allows callers to focus on their own business logic of calling methods over that socket.

identity.go
- Defines IsRegistered() and GetOrganizations() as a new clean API for external callers.
- Unexports GetConsumerUUID(), since none of the surrounding code read its value.
- Defines RegisterOptions{} to wrap common arguments both password-based and activation-key-based registration options accept.
- Defines RegisterWithPassword() and RegisterWithActivationKey() as public methods with cleaner implementations. They use aforementioned withPrivateRegisterSocket() and named closures instead of deeply nested code that gets tricky to follow.

content.go
- Nothing really notable.
- Switches to positive-branch convention and sets content="1" when the 'enabled' value is true.

connect_cmd.go, status_cmd.go
- Use some of the new subman.* API.
- Due to the layer mixing in connect_cmd, most of the original code has been kept intact to limit disruptions.


Generated-by: Claude Sonnet <noreply@anthropic.com>