### PR TITLE
chore(cmd): Clean up status

### DIFF
--- a/cmd/rhc/status_cmd.go
+++ b/cmd/rhc/status_cmd.go
@@ -6,17 +6,11 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"reflect"
-	"time"
 
-	"github.com/godbus/dbus/v5"
 	"github.com/urfave/cli/v3"
 
-	"github.com/briandowns/spinner"
-	systemd "github.com/coreos/go-systemd/v22/dbus"
-
 	"github.com/redhatinsights/rhc/internal/datacollection"
-	"github.com/redhatinsights/rhc/internal/localization"
+	"github.com/redhatinsights/rhc/internal/remotemanagement"
 	"github.com/redhatinsights/rhc/internal/subman"
 	"github.com/redhatinsights/rhc/internal/ui"
 	"github.com/redhatinsights/rhc/pkg/exitcode"
@@ -49,40 +43,26 @@ func rhsmStatus(systemStatus *SystemStatus) error {
 	return nil
 }
 
-// isContentEnabled tries to read the configuration file rhsm.conf using D-Bus API
-// and get the manage_repos option from the section [rhsm]. If the option is equal
-// to "1", then content is managed by subscription-manager/RHSM
+// isContentEnabled checks whether the system is registered and the content management
+// is enabled. Both conditions must be true for content access to be available.
 func isContentEnabled(systemStatus *SystemStatus) error {
 	slog.Info("Checking content status")
 
-	conn, err := dbus.SystemBus()
-	if err != nil {
-		return fmt.Errorf("cannot connect to system D-Bus: %w", err)
-	}
-
-	locale := localization.GetLocale()
-
-	config := conn.Object("com.redhat.RHSM1", "/com/redhat/RHSM1/Config")
-
-	var contentEnabled string
-	if err := config.Call(
-		"com.redhat.RHSM1.Config.Get",
-		0,
-		"rhsm.manage_repos",
-		locale).Store(&contentEnabled); err != nil {
-		systemStatus.returnCode += 1
-		systemStatus.ContentError = err.Error()
-		return subman.UnpackDBusError(err)
-	}
-
-	uuid, err := subman.GetConsumerUUID()
+	contentEnabled, err := subman.IsContentManagementEnabled()
 	if err != nil {
 		systemStatus.returnCode += 1
 		systemStatus.ContentError = err.Error()
-		return fmt.Errorf("unable to get consumer UUID: %s", err)
+		return fmt.Errorf("unable to check content management: %w", err)
 	}
 
-	if contentEnabled == "1" && uuid != "" {
+	registered, err := subman.IsRegistered()
+	if err != nil {
+		systemStatus.returnCode += 1
+		systemStatus.ContentError = err.Error()
+		return fmt.Errorf("unable to check registration status: %s", err)
+	}
+
+	if contentEnabled && registered {
 		systemStatus.ContentEnabled = true
 		infoMsg := "System has access to content"
 		slog.Info(infoMsg)
@@ -100,17 +80,16 @@ func isContentEnabled(systemStatus *SystemStatus) error {
 func insightStatus(systemStatus *SystemStatus) error {
 	slog.Info("Checking status of Red Hat Lightspeed")
 
-	var s *spinner.Spinner
-	if ui.IsOutputRich() {
-		s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-		s.Prefix = ui.Indent.Medium + "["
-		s.Suffix = "] Checking Red Hat Lightspeed (formerly Insights)..."
-		s.Start()
+	var isRegistered bool
+	var err error
+	spinErr := ui.Spinner(func() error {
+		isRegistered, err = datacollection.InsightsClientIsRegistered()
+		return nil
+	}, ui.Indent.Medium, "Checking Red Hat Lightspeed (formerly Insights)...")
+	if spinErr != nil {
+		return spinErr
 	}
-	isRegistered, err := datacollection.InsightsClientIsRegistered()
-	if ui.IsOutputRich() {
-		s.Stop()
-	}
+
 	if isRegistered {
 		systemStatus.InsightsConnected = true
 		slog.Info("Connected to Red Hat Lightspeed")
@@ -134,64 +113,35 @@ func insightStatus(systemStatus *SystemStatus) error {
 func serviceStatus(systemStatus *SystemStatus) error {
 	slog.Info("Checking status of yggdrasil service")
 
-	ctx := context.Background()
-	conn, err := systemd.NewSystemConnectionContext(ctx)
+	state, err := remotemanagement.GetUnitState("yggdrasil.service")
 	if err != nil {
 		systemStatus.YggdrasilRunning = false
 		systemStatus.YggdrasilError = err.Error()
-		return fmt.Errorf("unable to connect to systemd: %s", err)
-	}
-	defer conn.Close()
-	unitName := "yggdrasil.service"
-	properties, err := conn.GetUnitPropertiesContext(ctx, unitName)
-	if err != nil {
-		systemStatus.YggdrasilRunning = false
-		systemStatus.YggdrasilError = err.Error()
-		return fmt.Errorf("unable to get properties of %s: %s", unitName, err)
+		return err
 	}
 
-	activeState := properties["ActiveState"]
-	if activeState.(string) == "active" {
+	if state.ActiveState == "active" {
 		systemStatus.YggdrasilRunning = true
 		infoMsg := "The yggdrasil service is active"
 		slog.Info(infoMsg)
 		ui.Printf("%s[%v] Remote Management ... %v\n", ui.Indent.Medium, ui.Icons.Ok, infoMsg)
+	} else if state.LoadState == "loaded" {
+		systemStatus.returnCode += 1
+		systemStatus.YggdrasilRunning = false
+		warnMsg := "The yggdrasil service is not running"
+		slog.Warn(warnMsg)
+		ui.Printf("%s[ ] Remote Management ... %v\n", ui.Indent.Medium, warnMsg)
 	} else {
 		systemStatus.returnCode += 1
-		loadState := properties["LoadState"]
-		if loadState == "loaded" {
-			systemStatus.YggdrasilRunning = false
-			warnMsg := "The yggdrasil service is inactive but loaded"
-			slog.Warn(warnMsg)
-			ui.Printf("%s[ ] Remote Management ... %v\n", ui.Indent.Medium, warnMsg)
+		systemStatus.YggdrasilRunning = false
+		errMsg := "The yggdrasil service is not available"
+		systemStatus.YggdrasilError = errMsg
+		if state.LoadError != "" {
+			slog.Error(errMsg, "reason", state.LoadError)
 		} else {
-			loadError := properties["LoadError"]
-			// This part of the systemd D-Bus API is a little bit tricky. It returns
-			// an empty interface. It should contain a slice of two interfaces. The first
-			// interface in the slice should be the string representing error ID
-			// (e.g. "org.freedesktop.systemd1.NoSuchUnit"). The second interface should be
-			// also string representing the human-readable error message.
-			loadErrorType := reflect.TypeOf(loadError)
-			// Check if the type is []interface{}
-			if loadErrorType.Kind() == reflect.Slice && loadErrorType.Elem().Kind() == reflect.Interface {
-				loadErrorSlice := loadError.([]interface{})
-				if len(loadErrorSlice) >= 2 {
-					// Check if the type of the second interface is string
-					if reflect.TypeOf(loadErrorSlice[1]).Kind() == reflect.String {
-						loadErrorString := loadErrorSlice[1].(string)
-						systemStatus.YggdrasilRunning = false
-						systemStatus.YggdrasilError = loadErrorString
-						slog.Error(loadErrorString)
-						ui.Printf(
-							"%s[%s] Remote Management ... %v\n",
-							ui.Indent.Medium,
-							ui.Icons.Error,
-							loadErrorString,
-						)
-					}
-				}
-			}
+			slog.Error(errMsg)
 		}
+		ui.Printf("%s[%s] Remote Management ... %v\n", ui.Indent.Medium, ui.Icons.Error, errMsg)
 	}
 	return nil
 }

--- a/integration-tests/test_status.py
+++ b/integration-tests/test_status.py
@@ -175,7 +175,7 @@ def test_status_disconnected(rhc):
     assert "Not connected to Red Hat Subscription Management" in status_result.stdout
     assert "System has no access to content" in status_result.stdout
     assert "Not connected to Red Hat Lightspeed (formerly Insights)" in status_result.stdout
-    assert "The yggdrasil service is inactive" in status_result.stdout
+    assert "The yggdrasil service is not running" in status_result.stdout
 
 
 @pytest.fixture
@@ -276,7 +276,7 @@ def test_status_disconnected_rhsm_masked(rhc):
     assert status_result.returncode != 0
     assert "Could not activate remote peer" in status_result.stdout
     assert "Not connected to Red Hat Lightspeed (formerly Insights)" in status_result.stdout
-    assert "The yggdrasil service is inactive" in status_result.stdout
+    assert "The yggdrasil service is not running" in status_result.stdout
 
 
 @pytest.mark.tier1
@@ -386,7 +386,7 @@ def test_status_connected_yggdrasil_masked(external_candlepin, rhc, test_config)
         4.  The exit code is not 0.
         5.  The output contains "Connected to Red Hat Subscription Management",
             "Connected to Red Hat Lightspeed (formerly Insights)", "System has access to content",
-            "Unit yggdrasil.service is masked"
+            "The yggdrasil service is not available"
         6.  The 'yggdrasil.service' is unmasked.
     """
 
@@ -409,7 +409,7 @@ def test_status_connected_yggdrasil_masked(external_candlepin, rhc, test_config)
     assert "Connected to Red Hat Lightspeed (formerly Insights)" in status_result.stdout
     # yggdrasil
     assert not yggdrasil_service_is_active()
-    assert "Unit yggdrasil.service is masked" in status_result.stdout
+    assert "The yggdrasil service is not available" in status_result.stdout
 
 
 @pytest.mark.tier1
@@ -471,7 +471,7 @@ def test_status_connected_yggdrasil_masked_format_json(external_candlepin, rhc, 
     assert status_json["yggdrasil_running"] == False
     assert "yggdrasil_error" in status_json
     assert type(status_json["yggdrasil_error"]) == str
-    assert "Unit yggdrasil.service is masked" in status_json["yggdrasil_error"]
+    assert "The yggdrasil service is not available" in status_json["yggdrasil_error"]
 
 
 def test_yggdrasil_service_restart(external_candlepin, rhc, test_config):

--- a/internal/remotemanagement/remotemanagement.go
+++ b/internal/remotemanagement/remotemanagement.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"reflect"
 
 	"github.com/redhatinsights/rhc/internal/systemd"
 )
@@ -41,6 +42,54 @@ func ActivateServices() error {
 	}
 
 	return nil
+}
+
+// UnitState holds the state of a systemd unit as reported by systemd.
+type UnitState struct {
+	// ActiveState is the systemd ActiveState property value (e.g. "active", "inactive").
+	ActiveState string
+	// LoadState is the systemd LoadState property value (e.g. "loaded", "not-found").
+	LoadState string
+	// LoadError is the human-readable error message from the systemd LoadError
+	// property. It is non-empty only when the unit failed to load.
+	LoadError string
+}
+
+// GetUnitState returns the current state of a systemd unit.
+func GetUnitState(name string) (*UnitState, error) {
+	conn, err := systemd.NewConnectionContext(context.Background(), systemd.ConnectionTypeSystem)
+	if err != nil {
+		return nil, fmt.Errorf("cannot connect to systemd: %v", err)
+	}
+	defer conn.Close()
+
+	props, err := conn.GetUnitProperties(name)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get properties of %s: %v", name, err)
+	}
+
+	result := &UnitState{}
+	result.ActiveState, _ = props["ActiveState"].(string)
+	result.LoadState, _ = props["LoadState"].(string)
+
+	if result.ActiveState != "active" && result.LoadState != "loaded" {
+		// This part of the systemd D-Bus API returns two objects, one is a slice
+		// representing the error ID ("org.freedesktop.systemd1.NoSuchUnit"), the
+		// other a string representing a human-readable error message.
+		// systemd returns LoadError as []interface{}{errorID string, errorMessage string}.
+		raw := props["LoadError"]
+		t := reflect.TypeOf(raw)
+		if t != nil && t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Interface {
+			slice := raw.([]interface{})
+			if len(slice) >= 2 {
+				if msg, ok := slice[1].(string); ok {
+					result.LoadError = msg
+				}
+			}
+		}
+	}
+
+	return result, nil
 }
 
 // AssertYggdrasilServiceState returns true, when yggdrasil.service is in given state

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -137,6 +137,15 @@ func (c *Conn) StopUnit(name string, wait bool) error {
 	return nil
 }
 
+// GetUnitProperties returns all properties of the given unit as a map.
+func (c *Conn) GetUnitProperties(name string) (map[string]interface{}, error) {
+	props, err := c.conn.GetUnitPropertiesContext(c.ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get unit properties for %q: %v", name, err)
+	}
+	return props, nil
+}
+
 // GetUnitState checks the given unit's "ActiveState" property.
 func (c *Conn) GetUnitState(name string) (string, error) {
 	prop, err := c.conn.GetUnitPropertyContext(c.ctx, name, "ActiveState")


### PR DESCRIPTION
* Card ID: CCT-2404

- Status command code, as a presentation layer, should not be making direct D-Bus calls to obtain systemd service states.
- Low-level calls to spinner.Spinner in insightsStatus() should be using our abstraction internal/ui.Spinner() that also handles machine-readable output.
- rhc should not be displaying raw systemd messages, as they cannot be translated. Instead, it should present its own higher-level message that provides the user with information whether the state is fine or not. The integration tests for this have been updated.

Generated-by: Claude Sonnet <noreply@anthropic.com>