### PR TITLE
chore: Harden actions/checkout

### DIFF
--- a/.github/workflows/betelgeuse_dry-run.yml
+++ b/.github/workflows/betelgeuse_dry-run.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Base setup for Betelgeuse
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,6 +19,8 @@ jobs:
         run: sudo apt-get -qq update
 
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup go
         uses: actions/setup-go@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: actions/cache@v6
         with:
           path: ~/go/pkg/mod
@@ -36,6 +37,8 @@ jobs:
           go-version: "stable"
       - name: Check out code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9.3.0
         with:
@@ -51,6 +54,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Run woke
         uses: get-woke/woke-action@v0
         with:

--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: "Checkout repository"
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: "Adding repository directory to the temporary git global config as a safe directory (again)"
         run: |


### PR DESCRIPTION
This patch turns of credential provisioning for the local git checkout using tokens or SSH keys, eliminating the risk of leakage through accidental misconfigurations.

Generated-by: Claude Sonnet <noreply@anthropic.com>