### PR TITLE
feat(ci): add intelligent test selection shadow mode

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,3 +35,108 @@ jobs:
 
       - name: Go vet
         run: go vet ./...
+
+  its-compare:
+    name: "ITS compare (non-blocking)"
+    runs-on: ubuntu-latest
+    needs: build
+    if: always()
+    continue-on-error: true
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "stable"
+
+      - name: Install selector dependencies
+        run: python -m pip install --upgrade pip pyyaml
+
+      - name: Resolve base and head refs
+        id: refs
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE_REF="${{ github.event.pull_request.base.sha }}"
+            HEAD_REF="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE_REF="$(git merge-base HEAD origin/main)"
+            HEAD_REF="$(git rev-parse HEAD)"
+          fi
+          echo "base=${BASE_REF}" >> "${GITHUB_OUTPUT}"
+          echo "head=${HEAD_REF}" >> "${GITHUB_OUTPUT}"
+
+      - name: Run ITS selector
+        id: selector
+        run: |
+          python scripts/its_select_tests.py \
+            --base "${{ steps.refs.outputs.base }}" \
+            --head "${{ steps.refs.outputs.head }}" \
+            --map-file "scripts/its_test_map.yml" \
+            --output-json "selector-output.json" \
+            --github-output "${GITHUB_OUTPUT}"
+
+      - name: Run selected Go tests
+        id: selected-go
+        continue-on-error: true
+        run: |
+          GO_CMD="$(python - <<'PY'
+          import json
+          with open("selector-output.json", "r", encoding="utf-8") as file:
+              data = json.load(file)
+          print(data["recommended_commands"]["go"])
+          PY
+          )"
+          echo "Running: ${GO_CMD}"
+          eval "${GO_CMD}"
+
+      - name: Upload ITS compare artifact
+        uses: actions/upload-artifact@v5
+        if: always()
+        with:
+          name: its-selector-output
+          path: selector-output.json
+
+      - name: Publish ITS comparison summary
+        if: always()
+        env:
+          FULL_GO_RESULT: ${{ needs.build.result }}
+          SELECTED_GO_RESULT: ${{ steps.selected-go.outcome }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+
+          with open("selector-output.json", "r", encoding="utf-8") as file:
+              data = json.load(file)
+
+          full_result = os.environ["FULL_GO_RESULT"]
+          selected_result = os.environ["SELECTED_GO_RESULT"]
+
+          lines = [
+              "## ITS Compare (Non-Blocking)",
+              "",
+              f"- Full Go job result (existing CI): `{full_result}`",
+              f"- Selected Go run result (ITS): `{selected_result}`",
+              f"- Risk level: `{data['risk_level']}`",
+              f"- Full integration suggested: `{data['run_full_integration']}`",
+              f"- Matched rules: `{', '.join(data['matched_rules']) if data['matched_rules'] else 'none'}`",
+              "",
+              "### Selected Commands",
+              f"- `{data['recommended_commands']['go']}`",
+              f"- `{data['recommended_commands']['pytest']}`",
+              "",
+              "> Note: In this workflow we compare Go behavior only. Integration test selection remains informational in shadow mode.",
+          ]
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+              summary.write("\n".join(lines) + "\n")
+          PY

--- a/scripts/its_select_tests.py
+++ b/scripts/its_select_tests.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Select Go and integration tests from changed files.
+
+This script is intentionally deterministic and easy to reason about.
+It is designed for a "shadow mode" rollout where selection quality is measured
+before it is used for CI gating.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit(
+        "PyYAML is required. Install with: pip install pyyaml"
+    ) from exc
+
+
+def compile_patterns(patterns: list[str]) -> list[re.Pattern[str]]:
+    return [re.compile(pattern) for pattern in patterns]
+
+
+def matches_any(path: str, patterns: list[re.Pattern[str]]) -> bool:
+    return any(pattern.search(path) for pattern in patterns)
+
+
+def git_changed_files(base: str, head: str) -> list[str]:
+    diff_ref = f"{base}...{head}"
+    result = subprocess.run(
+        ["git", "diff", "--name-only", diff_ref],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    files = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    return sorted(set(files))
+
+
+def load_go_package_roots(config: dict[str, Any]) -> set[str]:
+    configured = config.get("go_package_roots")
+    if configured is None:
+        raise SystemExit(
+            "Missing required 'go_package_roots' in test map configuration."
+        )
+    if not isinstance(configured, list) or not all(
+        isinstance(item, str) and item.strip() for item in configured
+    ):
+        raise SystemExit(
+            "'go_package_roots' must be a non-empty list of non-empty strings."
+        )
+    return {item.strip() for item in configured}
+
+
+def normalize_go_package(path: str, go_package_roots: set[str]) -> str | None:
+    p = Path(path)
+
+    if p.suffix != ".go":
+        return None
+
+    if not p.parts or p.parts[0] not in go_package_roots:
+        return None
+
+    return f"./{p.parent}"
+
+
+def write_github_outputs(path: str, selection: dict[str, Any]) -> None:
+    outputs = {
+        "run_full_integration": "true"
+        if selection["run_full_integration"]
+        else "false",
+        "risk_level": selection["risk_level"],
+        "go_packages": ",".join(selection["selected_go_packages"]),
+        "pytest_files": ",".join(selection["selected_pytest_files"]),
+        "changed_files_count": len(selection["changed_files"]),
+        "docs_only": "true" if selection["docs_only_change"] else "false",
+    }
+
+    with open(path, "a", encoding="utf-8") as file:
+        for key, value in outputs.items():
+            file.write(f"{key}={value}\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Select test targets based on changed files."
+    )
+    parser.add_argument("--base", required=True, help="Base git ref/sha")
+    parser.add_argument("--head", required=True, help="Head git ref/sha")
+    parser.add_argument(
+        "--map-file",
+        default="scripts/its_test_map.yml",
+        help="Path to YAML map describing test selection rules.",
+    )
+    parser.add_argument(
+        "--output-json",
+        default="selector-output.json",
+        help="Where to write structured selection output.",
+    )
+    parser.add_argument(
+        "--github-output",
+        default="",
+        help="Optional path to GitHub output file ($GITHUB_OUTPUT).",
+    )
+    return parser.parse_args()
+
+
+def load_config(map_file: str) -> dict[str, Any]:
+    with open(map_file, "r", encoding="utf-8") as file:
+        loaded = yaml.safe_load(file)
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def compute_considered_files(
+    changed_files: list[str],
+    ignore_patterns: list[re.Pattern[str]],
+    docs_patterns: list[re.Pattern[str]],
+) -> tuple[list[str], bool]:
+    considered_files = [
+        path for path in changed_files if not matches_any(path, ignore_patterns)
+    ]
+    docs_only_change = bool(considered_files) and all(
+        matches_any(path, docs_patterns) for path in considered_files
+    )
+    return considered_files, docs_only_change
+
+
+def apply_rule_selection(
+    rules: list[dict[str, Any]],
+    considered_files: list[str],
+) -> tuple[set[str], set[str], list[str], list[str], dict[str, list[str]]]:
+    selected_go_packages: set[str] = set()
+    selected_pytest_files: set[str] = set()
+    matched_rules: list[str] = []
+    reasons: list[str] = []
+    rule_match_by_file: dict[str, list[str]] = {path: [] for path in considered_files}
+
+    for rule in rules:
+        compiled_rule_patterns = compile_patterns(rule.get("patterns", []))
+        matched = [
+            path for path in considered_files if matches_any(path, compiled_rule_patterns)
+        ]
+        if not matched:
+            continue
+
+        matched_rules.append(rule["id"])
+        selected_go_packages.update(rule.get("go_packages", []))
+        selected_pytest_files.update(rule.get("pytest_files", []))
+        reasons.append(f"rule:{rule['id']}")
+
+        for path in matched:
+            rule_match_by_file[path].append(rule["id"])
+
+    return (
+        selected_go_packages,
+        selected_pytest_files,
+        matched_rules,
+        reasons,
+        rule_match_by_file,
+    )
+
+
+def apply_direct_and_derived_targets(
+    considered_files: list[str],
+    go_package_roots: set[str],
+    rule_match_by_file: dict[str, list[str]],
+    selected_go_packages: set[str],
+    selected_pytest_files: set[str],
+    reasons: list[str],
+) -> None:
+    for path in considered_files:
+        if path.startswith("integration-tests/test_") and path.endswith(".py"):
+            selected_pytest_files.add(path)
+            reasons.append(f"direct-test-file:{path}")
+
+        package = normalize_go_package(path, go_package_roots)
+        if package and not rule_match_by_file[path]:
+            selected_go_packages.add(package)
+            reasons.append(f"derived-go-package:{package}")
+
+
+def compute_full_run_decision(
+    considered_files: list[str],
+    fallback_patterns: list[re.Pattern[str]],
+    reasons: list[str],
+) -> tuple[bool, list[str]]:
+    full_run_triggers = [
+        path for path in considered_files if matches_any(path, fallback_patterns)
+    ]
+    run_full_integration = bool(full_run_triggers)
+
+    if not considered_files:
+        run_full_integration = True
+        reasons.append("no-considered-files")
+
+    return run_full_integration, full_run_triggers
+
+
+def apply_smoke_or_full_policy(
+    run_full_integration: bool,
+    full_run_triggers: list[str],
+    docs_only_change: bool,
+    smoke_go: set[str],
+    smoke_pytest: set[str],
+    selected_go_packages: set[str],
+    selected_pytest_files: set[str],
+    reasons: list[str],
+) -> None:
+    if run_full_integration:
+        reasons.extend(f"full-trigger:{path}" for path in full_run_triggers)
+        return
+
+    selected_go_packages.update(smoke_go)
+    # Keep docs-only changes very cheap while still exercising basic CLI output.
+    selected_pytest_files.update(smoke_pytest)
+    if docs_only_change:
+        reasons.append("docs-only-change")
+
+
+def compute_risk_level(run_full_integration: bool, docs_only_change: bool) -> str:
+    if run_full_integration:
+        return "high"
+    if docs_only_change:
+        return "low"
+    return "medium"
+
+
+def build_recommended_commands(
+    selected_go_packages: set[str],
+    selected_pytest_files: set[str],
+    run_full_integration: bool,
+) -> dict[str, str]:
+    return {
+        "go": (
+            f"go test {' '.join(sorted(selected_go_packages))}"
+            if selected_go_packages
+            else "go test ./..."
+        ),
+        "pytest": (
+            "pytest -v integration-tests"
+            if run_full_integration
+            else (
+                "pytest -v " + " ".join(sorted(selected_pytest_files))
+                if selected_pytest_files
+                else "pytest -v integration-tests/test_version.py"
+            )
+        ),
+    }
+
+
+def build_selection(
+    args: argparse.Namespace,
+    changed_files: list[str],
+    considered_files: list[str],
+    docs_only_change: bool,
+    matched_rules: list[str],
+    selected_go_packages: set[str],
+    selected_pytest_files: set[str],
+    run_full_integration: bool,
+    risk_level: str,
+    reasons: list[str],
+) -> dict[str, Any]:
+    return {
+        "base": args.base,
+        "head": args.head,
+        "changed_files": changed_files,
+        "considered_files": considered_files,
+        "docs_only_change": docs_only_change,
+        "matched_rules": sorted(set(matched_rules)),
+        "selected_go_packages": sorted(selected_go_packages),
+        "selected_pytest_files": sorted(selected_pytest_files),
+        "run_full_integration": run_full_integration,
+        "risk_level": risk_level,
+        "reasons": sorted(set(reasons)),
+        "recommended_commands": build_recommended_commands(
+            selected_go_packages,
+            selected_pytest_files,
+            run_full_integration,
+        ),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+
+    config = load_config(args.map_file)
+
+    changed_files = git_changed_files(args.base, args.head)
+    ignore_patterns = compile_patterns(config.get("ignore_patterns", []))
+    docs_patterns = compile_patterns(config.get("docs_only_patterns", []))
+    fallback_patterns = compile_patterns(config.get("fallback_patterns", []))
+    go_package_roots = load_go_package_roots(config)
+
+    considered_files, docs_only_change = compute_considered_files(
+        changed_files, ignore_patterns, docs_patterns
+    )
+
+    smoke = config.get("smoke", {})
+    smoke_go = set(smoke.get("go_packages", []))
+    smoke_pytest = set(smoke.get("pytest_files", []))
+
+    (
+        selected_go_packages,
+        selected_pytest_files,
+        matched_rules,
+        reasons,
+        rule_match_by_file,
+    ) = apply_rule_selection(config.get("rules", []), considered_files)
+
+    apply_direct_and_derived_targets(
+        considered_files,
+        go_package_roots,
+        rule_match_by_file,
+        selected_go_packages,
+        selected_pytest_files,
+        reasons,
+    )
+
+    run_full_integration, full_run_triggers = compute_full_run_decision(
+        considered_files, fallback_patterns, reasons
+    )
+
+    apply_smoke_or_full_policy(
+        run_full_integration,
+        full_run_triggers,
+        docs_only_change,
+        smoke_go,
+        smoke_pytest,
+        selected_go_packages,
+        selected_pytest_files,
+        reasons,
+    )
+
+    risk_level = compute_risk_level(run_full_integration, docs_only_change)
+    selection = build_selection(
+        args,
+        changed_files,
+        considered_files,
+        docs_only_change,
+        matched_rules,
+        selected_go_packages,
+        selected_pytest_files,
+        run_full_integration,
+        risk_level,
+        reasons,
+    )
+
+    with open(args.output_json, "w", encoding="utf-8") as file:
+        json.dump(selection, file, indent=2, sort_keys=True)
+        file.write("\n")
+
+    if args.github_output:
+        write_github_outputs(args.github_output, selection)
+
+    print(json.dumps(selection, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/its_test_map.yml
+++ b/scripts/its_test_map.yml
@@ -1,0 +1,123 @@
+version: 1
+
+# Files that should never influence test selection.
+ignore_patterns:
+  - "^\\.gomodcache/"
+  - "^artifacts/"
+  - "^\\.pytest_cache/"
+  - "^venv/"
+
+# Changes matching only these patterns are considered low-risk.
+docs_only_patterns:
+  - "^README\\.md$"
+  - "^CONTRIBUTING\\.md$"
+  - "^SECURITY\\.md$"
+  - "^TESTING\\.md$"
+  - "^doc/"
+  - "^po/"
+  - "^.*\\.md$"
+
+# Any hit here escalates to full integration testing.
+fallback_patterns:
+  - "^integration-tests/conftest\\.py$"
+  - "^integration-tests/utils/"
+  - "^systemtest/"
+  - "^go\\.mod$"
+  - "^go\\.sum$"
+
+# Top-level directories that are treated as Go package roots
+# when deriving package targets from changed .go files.
+go_package_roots:
+  - "cmd"
+  - "internal"
+  - "pkg"
+
+# Smoke pack is always included unless full integration run is requested.
+smoke:
+  go_packages:
+    - "./cmd/rhc"
+    - "./cmd/rhc-collector"
+  pytest_files:
+    - "integration-tests/test_version.py"
+    - "integration-tests/test_man_page.py"
+
+rules:
+  - id: connect-surface
+    description: Connect/auth/proxy flows and status side effects.
+    patterns:
+      - "^cmd/rhc/connect_cmd\\.go$"
+      - "^cmd/rhc/main\\.go$"
+      - "^internal/rhsm/"
+      - "^internal/http/"
+      - "^internal/conf/"
+    go_packages:
+      - "./cmd/rhc"
+      - "./internal/rhsm"
+      - "./internal/http"
+      - "./internal/conf"
+    pytest_files:
+      - "integration-tests/test_connect.py"
+      - "integration-tests/test_status.py"
+      - "integration-tests/test_logging.py"
+
+  - id: disconnect-surface
+    description: Disconnect command and user-facing status/logging behavior.
+    patterns:
+      - "^cmd/rhc/disconnect_cmd\\.go$"
+      - "^cmd/rhc/status_cmd\\.go$"
+    go_packages:
+      - "./cmd/rhc"
+    pytest_files:
+      - "integration-tests/test_disconnect.py"
+      - "integration-tests/test_status.py"
+      - "integration-tests/test_logging.py"
+
+  - id: feature-config-surface
+    description: Feature toggle flow and dependency behavior.
+    patterns:
+      - "^cmd/rhc/configure_features_cmd\\.go$"
+      - "^pkg/feature/"
+      - "^pkg/operations/"
+    go_packages:
+      - "./cmd/rhc"
+      - "./pkg/feature"
+      - "./pkg/operations"
+    pytest_files:
+      - "integration-tests/test_configure_feature.py"
+      - "integration-tests/test_connect.py"
+
+  - id: collector-surface
+    description: Collector command, binary, and collector internals.
+    patterns:
+      - "^cmd/rhc/collector_cmd\\.go$"
+      - "^cmd/rhc-collector/"
+      - "^internal/collector/"
+    go_packages:
+      - "./cmd/rhc"
+      - "./cmd/rhc-collector"
+      - "./internal/collector"
+    pytest_files:
+      - "integration-tests/test_collector_api.py"
+
+  - id: systemd-service-surface
+    description: Service/socket/timer and activation behavior.
+    patterns:
+      - "^internal/systemd/"
+      - "^data/systemd/"
+      - "^cmd/rhc-server/"
+    go_packages:
+      - "./internal/systemd"
+      - "./cmd/rhc-server"
+    pytest_files:
+      - "integration-tests/test_socket_activated_service.py"
+      - "integration-tests/test_status.py"
+
+  - id: logging-surface
+    description: Logging implementation and logrotate packaging.
+    patterns:
+      - "^cmd/rhc/logging\\.go$"
+      - "^data/logrotate\\.d/"
+    go_packages:
+      - "./cmd/rhc"
+    pytest_files:
+      - "integration-tests/test_logging.py"


### PR DESCRIPTION
Implement an initial Intelligent Test Selection (ITS) flow in CI to evaluate selective test execution without affecting existing CI.

- add deterministic ITS selector script and test map
- run non-blocking its-compare in go.yml and publish selection summary/artifact

Running the Script Locally

To test the Intelligent Test Selection (ITS) script locally, run:

python3 scripts/its_select_tests.py \
  --base 167c83f9eb7b7b7909a711572f66c2d98eb3c963^ \
  --head 167c83f9eb7b7b7909a711572f66c2d98eb3c963

Replace the --base and --head values with the Git commits you want to compare.