### PR TITLE
chore: Explicit permissions of rhc-server.socket

### DIFF
--- a/data/systemd/rhc-server.service
+++ b/data/systemd/rhc-server.service
@@ -6,6 +6,8 @@ After=rhc-server.socket
 
 [Service]
 Type=simple
+User=root
+Group=root
 ExecStart=/usr/libexec/rhc/rhc-server
 StandardOutput=journal
 StandardError=journal

--- a/data/systemd/rhc-server.socket
+++ b/data/systemd/rhc-server.socket
@@ -5,7 +5,9 @@ Documentation=https://github.com/RedHatInsights/rhc
 [Socket]
 ListenStream=/run/rhc/com.redhat.rhc
 FileDescriptorName=varlink
-SocketMode=0660
+SocketUser=root
+SocketGroup=root
+SocketMode=0600
 
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION
When rhc-server.socket was introduced in 7ead513b, the permissions of com.redhat.rhc socket have not been discussed, and we went with 0660 semi-automatically. However, that opens a space to make assumptions about the API, which is generally not a good idea.

This patch explicity sets both User= and Group= values to 'root', as well as the socket mode to 0600 (dropping group permissions). This change matches the previous behavior, but makes the API explicit.

In the future, we might introduce a system user ('rhc' or otherwise) that will act as a group owner of the .socket, and any additional files rhc owns, allowing other trusted non-root processes running on the system to execute Varlink methods. Once we are there, we will alter the content of this file again to reflect it.


Assisted-by: Claude Sonnet <noreply@anthropic.com>