### PR TITLE
[release-0.2] ci: migrate from RHEL 9.7 to RHEL 9 nightly builds

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -53,7 +53,7 @@ jobs:
           - RHEL-8-Released
       rhel-9-x86_64:
         distros:
-          - RHEL-9.7.0-Nightly
+          - RHEL-9-Nightly
     labels:
       - integration_test
     tf_extra_params:


### PR DESCRIPTION
Update Packit configuration to use RHEL-9-Nightly instead of the RHEL-9.7.0-Nightly target, as RHEL 9.7 has reached end of life. This ensures CI tests run against the latest RHEL 9 y-stream release.