### PR TITLE
[release-0.2] ci: stop testing on CentOS Stream 8

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -40,7 +40,6 @@ jobs:
     trigger: pull_request
     identifier: "unit/centos-stream"
     targets:
-      - centos-stream-8
       - centos-stream-9
     labels:
       - integration_test


### PR DESCRIPTION
Since CentOS Stream 8 has reached end of life, it does not make sense to run the tests on this distribution.