### PR TITLE
chore: Release rhc-0.3.11

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('rhc', version : '0.3.10', meson_version : '>= 0.56.0')
+project('rhc', version : '0.3.11', meson_version : '>= 0.56.0')
 
 go = find_program('go')
 systemd = dependency('systemd', version: '>=239')

--- a/rhc.spec
+++ b/rhc.spec
@@ -8,7 +8,7 @@
 %endif
 
 %global goipath         github.com/redhatinsights/rhc
-Version:                0.3.10
+Version:                0.3.11
 
 %gometa
 


### PR DESCRIPTION
Updating the `meson.build` and `rhc.spec` to v0.3.11 because I didn't upload the assets for v0.3.10 before I publish the release.