### PR TITLE
feat(operations): add EnableFeature and DisableFeature operations

### DIFF
--- a/pkg/operations/feature_disable.go
+++ b/pkg/operations/feature_disable.go
@@ -1,0 +1,122 @@
+package operations
+
+import (
+	"fmt"
+
+	"github.com/redhatinsights/rhc/internal/datacollection"
+	"github.com/redhatinsights/rhc/internal/remotemanagement"
+	"github.com/redhatinsights/rhc/internal/subman"
+)
+
+// DisableFeatureResult represents the result of disabling a feature.
+// It includes the target feature, status of the operation, nested results
+// for dependents, and any error that occurred.
+type DisableFeatureResult struct {
+	// Feature is the target feature that was requested to be disabled.
+	Feature Feature
+	// Status indicates the outcome: "disabled", "already-disabled", "failed", "dependent-failed"
+	Status string
+	// DependentsDisabled contains the nested results for dependent features that were
+	// disabled during the cascade, in the order they were disabled.
+	DependentsDisabled []DisableFeatureResult
+	// Err contains any error that occurred during the disable operation.
+	// If non-nil, the operation failed and Feature may not be disabled.
+	Err error
+}
+
+// Status constants for DisableFeatureResult
+const (
+	DisableStatusDisabled        = "disabled"
+	DisableStatusAlreadyDisabled = "already-disabled"
+	DisableStatusFailed          = "failed"
+	DisableStatusDependentFailed = "dependent-failed"
+)
+
+// DisableFeature disables a feature and its dependents.
+// It follows the dependent cascade: if other features depend on this feature,
+// those dependents are disabled first, recursively.
+//
+// The dependency graph (explicit, compile-time verified):
+//   - Analytics: required by RemoteManagement
+//   - Content: required by RemoteManagement
+//   - RemoteManagement: no dependents
+//
+// If any dependent fails to disable, the operation stops immediately and returns
+// Status="dependent-failed" with partial progress visible in DependentsDisabled.
+//
+// The operation is idempotent: if the feature is already disabled, it returns
+// immediately with Status="already-disabled" and no error.
+func DisableFeature(opts FeatureOperationOptions) DisableFeatureResult {
+	result := DisableFeatureResult{
+		Feature:            opts.Feature,
+		Status:             DisableStatusFailed,
+		DependentsDisabled: []DisableFeatureResult{},
+		Err:                nil,
+	}
+
+	// Check if already disabled
+	status := FeatureStatus(opts)
+	if status.Err != nil {
+		result.Err = fmt.Errorf("checking feature status: %w", status.Err)
+		result.Status = DisableStatusFailed
+		return result
+	}
+	if !status.Enabled {
+		result.Status = DisableStatusAlreadyDisabled
+		return result
+	}
+
+	// Disable dependents first (explicit dependency graph reversed)
+	switch opts.Feature {
+	case Analytics, Content:
+		// Analytics and Content are required by RemoteManagement
+		// Check if RemoteManagement is enabled and disable it first
+		rmStatus := FeatureStatus(FeatureOperationOptions{Feature: RemoteManagement})
+		if rmStatus.Err != nil {
+			result.Err = fmt.Errorf("checking dependent %s status: %w", RemoteManagement, rmStatus.Err)
+			result.Status = DisableStatusFailed
+			return result
+		}
+		if rmStatus.Enabled {
+			rmResult := DisableFeature(FeatureOperationOptions{Feature: RemoteManagement})
+			result.DependentsDisabled = append(result.DependentsDisabled, rmResult)
+			if rmResult.Err != nil {
+				result.Err = fmt.Errorf("disabling dependent %s: %w", RemoteManagement, rmResult.Err)
+				result.Status = DisableStatusDependentFailed
+				return result
+			}
+		}
+	case RemoteManagement:
+		// No dependents
+	default:
+		result.Err = fmt.Errorf("unknown feature: %s", opts.Feature)
+		result.Status = DisableStatusFailed
+		return result
+	}
+
+	// Disable the target feature
+	var err error
+	switch opts.Feature {
+	case Analytics:
+		err = datacollection.UnregisterInsightsClient()
+	case Content:
+		var client *subman.RHSMClient
+		client, err = subman.NewRHSMClient()
+		if err == nil {
+			err = client.SetContentManagement(false)
+		}
+	case RemoteManagement:
+		err = remotemanagement.DeactivateServices()
+	default:
+		err = fmt.Errorf("unknown feature: %s", opts.Feature)
+	}
+
+	if err != nil {
+		result.Err = fmt.Errorf("disabling feature %s: %w", opts.Feature, err)
+		result.Status = DisableStatusFailed
+		return result
+	}
+
+	result.Status = DisableStatusDisabled
+	return result
+}

--- a/pkg/operations/feature_disable_test.go
+++ b/pkg/operations/feature_disable_test.go
@@ -1,0 +1,178 @@
+package operations
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDisableRemoteManagement tests disabling RemoteManagement when it has no enabled dependents.
+func TestDisableRemoteManagement(t *testing.T) {
+	result := DisableFeature(FeatureOperationOptions{Feature: RemoteManagement})
+	if len(result.DependentsDisabled) != 0 {
+		t.Errorf("DependentsDisabled length = %d, want 0 for RemoteManagement",
+			len(result.DependentsDisabled))
+	}
+	if result.Feature != RemoteManagement {
+		t.Errorf("Feature = %v, want %v", result.Feature, RemoteManagement)
+	}
+
+	validStatuses := []string{DisableStatusDisabled, DisableStatusAlreadyDisabled, DisableStatusFailed}
+	statusValid := false
+	for _, s := range validStatuses {
+		if result.Status == s {
+			statusValid = true
+			break
+		}
+	}
+	if !statusValid {
+		t.Errorf("expected status to be one of %v, got %q", validStatuses, result.Status)
+	}
+	if result.Status == DisableStatusAlreadyDisabled && result.Err != nil {
+		t.Errorf("Status=%q but Err=%v, expected nil error", DisableStatusAlreadyDisabled, result.Err)
+	}
+}
+
+// TestDisableAnalytics tests disabling Analytics when RemoteManagement depends on it.
+func TestDisableAnalytics(t *testing.T) {
+	rmStatus := FeatureStatus(FeatureOperationOptions{Feature: RemoteManagement})
+	if rmStatus.Err != nil {
+		t.Skipf("Cannot determine RemoteManagement status: %v", rmStatus.Err)
+	}
+
+	result := DisableFeature(FeatureOperationOptions{Feature: Analytics})
+	if result.Feature != Analytics {
+		t.Errorf("Feature = %v, want %v", result.Feature, Analytics)
+	}
+	if rmStatus.Enabled {
+		if result.Err != nil {
+			if result.Status != DisableStatusFailed && result.Status != DisableStatusDependentFailed {
+				t.Errorf("expected status to be failed or dependent-failed when error occurred, got %q", result.Status)
+			}
+		} else {
+			found := false
+			for _, dep := range result.DependentsDisabled {
+				if dep.Feature == RemoteManagement {
+					found = true
+					break
+				}
+			}
+			if !found && result.Status != DisableStatusAlreadyDisabled {
+				t.Errorf("RemoteManagement should be in DependentsDisabled when it was enabled, got: %v",
+					result.DependentsDisabled)
+			}
+		}
+	}
+}
+
+// TestDisableContent tests disabling Content when RemoteManagement depends on it.
+func TestDisableContent(t *testing.T) {
+	rmStatus := FeatureStatus(FeatureOperationOptions{Feature: RemoteManagement})
+	if rmStatus.Err != nil {
+		t.Skipf("Cannot determine RemoteManagement status: %v", rmStatus.Err)
+	}
+
+	result := DisableFeature(FeatureOperationOptions{Feature: Content})
+	if result.Feature != Content {
+		t.Errorf("Feature = %v, want %v", result.Feature, Content)
+	}
+	if rmStatus.Enabled {
+		if result.Err != nil {
+			if result.Status != DisableStatusFailed && result.Status != DisableStatusDependentFailed {
+				t.Errorf("expected status to be failed or dependent-failed when error occurred, got %q", result.Status)
+			}
+		} else {
+			found := false
+			for _, dep := range result.DependentsDisabled {
+				if dep.Feature == RemoteManagement {
+					found = true
+					break
+				}
+			}
+			if !found && result.Status != DisableStatusAlreadyDisabled {
+				t.Errorf("RemoteManagement should be in DependentsDisabled when it was enabled, got: %v",
+					result.DependentsDisabled)
+			}
+		}
+	}
+}
+
+// TestDisableResultStructure tests the structure of DisableFeatureResult.
+func TestDisableResultStructure(t *testing.T) {
+	tests := []struct {
+		name    string
+		feature Feature
+	}{
+		{"Analytics", Analytics},
+		{"Content", Content},
+		{"RemoteManagement", RemoteManagement},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DisableFeature(FeatureOperationOptions{Feature: tt.feature})
+			if result.Feature != tt.feature {
+				t.Errorf("Feature = %v, want %v", result.Feature, tt.feature)
+			}
+			if result.DependentsDisabled == nil {
+				t.Error("DependentsDisabled should never be nil, should be empty slice")
+			}
+			if result.Status == "" {
+				t.Error("Status should not be empty")
+			}
+			if result.Status == DisableStatusAlreadyDisabled && result.Err != nil {
+				t.Errorf("Status=%q but Err=%v, should be mutually exclusive",
+					DisableStatusAlreadyDisabled, result.Err)
+			}
+			if result.Err != nil {
+				if result.Status != DisableStatusFailed && result.Status != DisableStatusDependentFailed {
+					t.Errorf("expected status to be failed when Err is non-nil, got %q", result.Status)
+				}
+			}
+		})
+	}
+}
+
+// TestDisableUnknownFeature tests error handling for invalid feature.
+func TestDisableUnknownFeature(t *testing.T) {
+	invalidFeature := Feature(999)
+
+	result := DisableFeature(FeatureOperationOptions{Feature: invalidFeature})
+	if result.Feature != invalidFeature {
+		t.Errorf("Feature = %v, want %v", result.Feature, invalidFeature)
+	}
+	if result.Err == nil {
+		t.Error("Err = nil, want error for unknown feature")
+	}
+	if !strings.Contains(result.Err.Error(), "unknown feature") {
+		t.Errorf("Err = %v, want error message containing 'unknown feature'", result.Err)
+	}
+	if result.Status != DisableStatusFailed {
+		t.Errorf("Status = %q, want %q for unknown feature", result.Status, DisableStatusFailed)
+	}
+}
+
+// TestDisableIdempotency tests that calling DisableFeature multiple times is safe.
+func TestDisableIdempotency(t *testing.T) {
+	feature := RemoteManagement
+
+	// First call
+	result1 := DisableFeature(FeatureOperationOptions{Feature: feature})
+	// Second call (should be idempotent)
+	result2 := DisableFeature(FeatureOperationOptions{Feature: feature})
+
+	// If the first call succeeded or indicated already disabled,
+	// the second call should indicate already disabled
+	if result1.Err == nil || result1.Status == DisableStatusAlreadyDisabled {
+		if result2.Status != DisableStatusAlreadyDisabled {
+			t.Errorf("Second call Status = %q, want %q after successful first call",
+				result2.Status, DisableStatusAlreadyDisabled)
+		}
+		if result2.Err != nil {
+			t.Errorf("Second call Err = %v, want nil after successful first call", result2.Err)
+		}
+	}
+
+	if result1.Feature != result2.Feature {
+		t.Errorf("Feature mismatch: first=%v, second=%v", result1.Feature, result2.Feature)
+	}
+}

--- a/pkg/operations/feature_enable.go
+++ b/pkg/operations/feature_enable.go
@@ -1,0 +1,121 @@
+package operations
+
+import (
+	"fmt"
+
+	"github.com/redhatinsights/rhc/internal/datacollection"
+	"github.com/redhatinsights/rhc/internal/remotemanagement"
+	"github.com/redhatinsights/rhc/internal/subman"
+)
+
+// EnableFeatureResult represents the result of enabling a feature.
+// It includes the target feature, status of the operation, nested results
+// for dependencies, and any error that occurred.
+type EnableFeatureResult struct {
+	// Feature is the target feature that was requested to be enabled.
+	Feature Feature
+	// Status indicates the outcome: "enabled", "already-enabled", "failed", "dependency-failed"
+	Status string
+	// DependenciesEnabled contains the nested results for dependency features that were
+	// processed during the cascade, in the order they were processed.
+	DependenciesEnabled []EnableFeatureResult
+	// Err contains any error that occurred during the enable operation.
+	// If non-nil, the operation failed and Feature may not be enabled.
+	Err error
+}
+
+// Status constants for EnableFeatureResult
+const (
+	EnableStatusEnabled          = "enabled"
+	EnableStatusAlreadyEnabled   = "already-enabled"
+	EnableStatusFailed           = "failed"
+	EnableStatusDependencyFailed = "dependency-failed"
+)
+
+// EnableFeature enables a feature and its dependencies.
+// It follows the dependency cascade: if a feature requires other features,
+// those dependencies are enabled first, recursively.
+//
+// The dependency graph (explicit, compile-time verified):
+//   - Analytics: no dependencies
+//   - Content: no dependencies
+//   - RemoteManagement: requires Content and Analytics
+//
+// If any dependency fails to enable, the operation stops immediately and returns
+// Status="dependency-failed" with partial progress visible in DependenciesEnabled.
+//
+// The operation is idempotent: if the feature is already enabled, it returns
+// immediately with Status="already-enabled" and no error.
+func EnableFeature(opts FeatureOperationOptions) EnableFeatureResult {
+	result := EnableFeatureResult{
+		Feature:             opts.Feature,
+		Status:              EnableStatusFailed,
+		DependenciesEnabled: []EnableFeatureResult{},
+		Err:                 nil,
+	}
+
+	// Check if already enabled
+	status := FeatureStatus(opts)
+	if status.Err != nil {
+		result.Err = fmt.Errorf("checking feature status: %w", status.Err)
+		result.Status = EnableStatusFailed
+		return result
+	}
+	if status.Enabled {
+		result.Status = EnableStatusAlreadyEnabled
+		return result
+	}
+
+	// Enable dependencies first (explicit dependency graph)
+	switch opts.Feature {
+	case Analytics, Content:
+		// No dependencies
+	case RemoteManagement:
+		// RemoteManagement requires Content and Analytics
+		contentResult := EnableFeature(FeatureOperationOptions{Feature: Content})
+		result.DependenciesEnabled = append(result.DependenciesEnabled, contentResult)
+		if contentResult.Err != nil {
+			result.Err = fmt.Errorf("enabling dependency %s: %w", Content, contentResult.Err)
+			result.Status = EnableStatusDependencyFailed
+			return result
+		}
+
+		analyticsResult := EnableFeature(FeatureOperationOptions{Feature: Analytics})
+		result.DependenciesEnabled = append(result.DependenciesEnabled, analyticsResult)
+		if analyticsResult.Err != nil {
+			result.Err = fmt.Errorf("enabling dependency %s: %w", Analytics, analyticsResult.Err)
+			result.Status = EnableStatusDependencyFailed
+			return result
+		}
+	default:
+		result.Err = fmt.Errorf("unknown feature: %s", opts.Feature)
+		result.Status = EnableStatusFailed
+		return result
+	}
+
+	// Enable the target feature
+	var err error
+	switch opts.Feature {
+	case Analytics:
+		err = datacollection.RegisterInsightsClient()
+	case Content:
+		var client *subman.RHSMClient
+		client, err = subman.NewRHSMClient()
+		if err == nil {
+			err = client.SetContentManagement(true)
+		}
+	case RemoteManagement:
+		err = remotemanagement.ActivateServices()
+	default:
+		err = fmt.Errorf("unknown feature: %s", opts.Feature)
+	}
+
+	if err != nil {
+		result.Err = fmt.Errorf("enabling feature %s: %w", opts.Feature, err)
+		result.Status = EnableStatusFailed
+		return result
+	}
+
+	result.Status = EnableStatusEnabled
+	return result
+}

--- a/pkg/operations/feature_enable_test.go
+++ b/pkg/operations/feature_enable_test.go
@@ -1,0 +1,136 @@
+package operations
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEnableAnalytics tests enabling the Analytics feature with no dependencies.
+func TestEnableAnalytics(t *testing.T) {
+	result := EnableFeature(FeatureOperationOptions{Feature: Analytics})
+	if len(result.DependenciesEnabled) != 0 {
+		t.Errorf("expected 0 dependencies enabled, got %d: %v",
+			len(result.DependenciesEnabled), result.DependenciesEnabled)
+	}
+	if result.Feature != Analytics {
+		t.Errorf("expected feature to be Analytics, got %v", result.Feature)
+	}
+
+	validStatuses := []string{EnableStatusEnabled, EnableStatusAlreadyEnabled, EnableStatusFailed}
+	statusValid := false
+	for _, s := range validStatuses {
+		if result.Status == s {
+			statusValid = true
+			break
+		}
+	}
+	if !statusValid {
+		t.Errorf("expected status to be one of %v, got %q", validStatuses, result.Status)
+	}
+}
+
+// TestEnableContent tests enabling the Content feature with no dependencies.
+func TestEnableContent(t *testing.T) {
+	result := EnableFeature(FeatureOperationOptions{Feature: Content})
+	if len(result.DependenciesEnabled) != 0 {
+		t.Errorf("expected 0 dependencies enabled, got %d: %v",
+			len(result.DependenciesEnabled), result.DependenciesEnabled)
+	}
+	if result.Feature != Content {
+		t.Errorf("expected feature to be Content, got %v", result.Feature)
+	}
+
+	validStatuses := []string{EnableStatusEnabled, EnableStatusAlreadyEnabled, EnableStatusFailed}
+	statusValid := false
+	for _, s := range validStatuses {
+		if result.Status == s {
+			statusValid = true
+			break
+		}
+	}
+	if !statusValid {
+		t.Errorf("expected status to be one of %v, got %q", validStatuses, result.Status)
+	}
+}
+
+// TestEnableRemoteManagement tests enabling RemoteManagement which requires both Content and Analytics dependencies.
+func TestEnableRemoteManagement(t *testing.T) {
+	result := EnableFeature(FeatureOperationOptions{Feature: RemoteManagement})
+	if result.Feature != RemoteManagement {
+		t.Errorf("expected feature to be RemoteManagement, got %v", result.Feature)
+	}
+
+	if len(result.DependenciesEnabled) == 2 {
+		if result.DependenciesEnabled[0].Feature != Content {
+			t.Errorf("expected first dependency to be Content, got %v", result.DependenciesEnabled[0].Feature)
+		}
+		if result.DependenciesEnabled[1].Feature != Analytics {
+			t.Errorf("expected second dependency to be Analytics, got %v", result.DependenciesEnabled[1].Feature)
+		}
+	}
+
+	if result.Err != nil {
+		if result.Status != EnableStatusFailed && result.Status != EnableStatusDependencyFailed {
+			t.Errorf("expected status to be %q or %q when error occurred, got %q",
+				EnableStatusFailed, EnableStatusDependencyFailed, result.Status)
+		}
+	}
+}
+
+// TestEnableResultStructure tests the structure of EnableFeatureResult.
+func TestEnableResultStructure(t *testing.T) {
+	features := []Feature{Analytics, Content, RemoteManagement}
+
+	for _, feature := range features {
+		t.Run(feature.String(), func(t *testing.T) {
+			result := EnableFeature(FeatureOperationOptions{Feature: feature})
+			if result.Feature != feature {
+				t.Errorf("expected Feature=%v, got %v", feature, result.Feature)
+			}
+			if result.Status == "" {
+				t.Error("Status should not be empty")
+			}
+			if result.DependenciesEnabled == nil {
+				t.Error("DependenciesEnabled should not be nil")
+			}
+
+			if result.Err != nil {
+				// When error occurs, status should be "failed" or "dependency-failed"
+				if result.Status != EnableStatusFailed && result.Status != EnableStatusDependencyFailed {
+					t.Errorf("expected status to be %q or %q when Err is non-nil, got %q",
+						EnableStatusFailed, EnableStatusDependencyFailed, result.Status)
+				}
+			}
+
+			if result.Status == EnableStatusAlreadyEnabled {
+				// When already enabled, should have no error
+				if result.Err != nil {
+					t.Errorf("expected no error when Status=%q, got: %v", EnableStatusAlreadyEnabled, result.Err)
+				}
+			}
+		})
+	}
+}
+
+// TestEnableUnknownFeature tests handling of an unknown/invalid feature type.
+func TestEnableUnknownFeature(t *testing.T) {
+	invalidFeature := Feature(999)
+
+	result := EnableFeature(FeatureOperationOptions{Feature: invalidFeature})
+	if result.Err == nil {
+		t.Error("expected error for unknown feature, got nil")
+	}
+	if result.Err != nil && !strings.Contains(result.Err.Error(), "unknown feature") {
+		t.Errorf("expected error to mention 'unknown feature', got: %v", result.Err)
+	}
+	if result.Status != EnableStatusFailed {
+		t.Errorf("expected status to be %q, got %q", EnableStatusFailed, result.Status)
+	}
+	if result.Feature != invalidFeature {
+		t.Errorf("expected feature to be %v, got %v", invalidFeature, result.Feature)
+	}
+	if len(result.DependenciesEnabled) != 0 {
+		t.Errorf("expected no dependencies enabled for invalid feature, got: %v",
+			result.DependenciesEnabled)
+	}
+}


### PR DESCRIPTION
* Card ID: CCT-2406

Creates `EnableFeature()` and `DisableFeature()` methods in `pkg/operations/` with explicit dependency cascade using hardcoded switch statements rather than string-based graph traversal. `RemoteManagement` explicitly calls `EnableFeature` for `Content` and `Analytics`. `Results` use `Status` string field ("enabled", "already-enabled", "failed", "dependency-failed") with nested result trees for full cascade visibility.

Assisted-by: Claude Sonnet <noreply@anthropic.com>