### PR TITLE
test(ci): Added integration tests for RHSM Varlink API

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,136 @@
+name: Varlink Integration Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build-rpms:
+    uses: ./.github/workflows/rpmbuild.yml
+
+  integration-tests:
+    name: "Integration Tests (${{ matrix.name }})"
+    needs: build-rpms
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "Fedora latest"
+            image: "registry.fedoraproject.org/fedora:latest"
+            artifact: "rpms-fedora-latest"
+          - name: "Fedora Rawhide"
+            image: "registry.fedoraproject.org/fedora:rawhide"
+            artifact: "rpms-fedora-rawhide"
+
+    container:
+      image: ${{ matrix.image }}
+
+    services:
+      postgres:
+        image: ghcr.io/candlepin/candlepin-db:latest
+      candlepin:
+        image: ghcr.io/candlepin/candlepin-app:latest
+        options: --hostname candlepin.local
+        ports:
+          - 8443:8443
+      candlepin-repo:
+        image: ghcr.io/candlepin/candlepin-repo:latest
+        ports:
+          - 8080:8080
+
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v7
+
+      - name: "Download RPM artifacts"
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ matrix.artifact }}
+          path: ./rpms
+
+      - name: "Install test dependencies"
+        run: |
+          dnf --setopt install_weak_deps=False install -y \
+            subscription-manager rhc python3-behave openssl curl \
+            python3-jsonschema dbus-daemon
+
+      - name: "Install built RPMs"
+        run: |
+          dnf install -y ./rpms/*.rpm
+
+      - name: "Wait for candlepin to be ready"
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sfk https://candlepin:8443/candlepin/status > /dev/null 2>&1; then
+              echo "Candlepin is ready"
+              curl -sk https://candlepin:8443/candlepin/status
+              exit 0
+            fi
+            echo "Waiting for candlepin... attempt $i/60"
+            sleep 5
+          done
+          echo "ERROR: Candlepin failed to start within timeout"
+          exit 1
+
+      - name: "Configure subscription-manager for candlepin"
+        run: |
+          subscription-manager config \
+            --server.hostname candlepin \
+            --server.port 8443 \
+            --server.prefix /candlepin \
+            --server.insecure 1 \
+            --rhsm.baseurl http://candlepin-repo:8080
+
+      - name: "Trust candlepin TLS certificate"
+        run: |
+          openssl s_client -connect candlepin:8443 -showcerts </dev/null 2>/dev/null \
+            | openssl x509 -outform PEM > /etc/rhsm/ca/candlepin-ca.pem
+          ln -sf /etc/rhsm/ca/candlepin-ca.pem \
+            /etc/pki/ca-trust/source/anchors/candlepin-ca.pem
+          update-ca-trust
+
+      - name: "Import candlepin RPM GPG key"
+        run: |
+          curl -sf http://candlepin-repo:8080/RPM-GPG-KEY-candlepin \
+            > /etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin
+
+      - name: "Start D-Bus system bus"
+        run: |
+          mkdir -p /run/dbus
+          dbus-daemon --system --fork
+          sleep 1
+
+      - name: "Start RHSM D-Bus service"
+        run: |
+          /usr/libexec/rhsm-service &
+          sleep 2
+          busctl --system status com.redhat.RHSM1
+
+      - name: "Verify candlepin connectivity"
+        run: |
+          subscription-manager version
+
+      - name: "Start RHC Varlink service"
+        run: |
+          /usr/libexec/rhc/rhc-server &
+          sleep 2
+          varlinkctl info /run/rhc/com.redhat.rhc
+
+      - name: "Run integration tests"
+        run: |
+          mkdir -p results
+          behave features/ --no-capture --verbose \
+            --junit --junit-directory results/
+
+      - name: "Upload test results"
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-${{ matrix.artifact }}
+          path: results/
+          retention-days: 30

--- a/features/com.redhat.rhsm.feature
+++ b/features/com.redhat.rhsm.feature
@@ -1,0 +1,78 @@
+Feature: The Varlink interface com.redhat.rhsm
+  The basic Varlink interface com.redhat.rhsm provides basic
+  methods that allows to check if the system is registered and
+  if the system can reach candlepin server
+
+
+  Scenario: IsRegistered() method returns false on unregistered system
+    Given system is not registered
+    When varlink method is called
+      | method       | interface               | arguments |
+      | IsRegistered | com.redhat.rhsm.testing | '{}'      |
+    Then varlink method returns
+      """
+      {"registered":false}
+      """
+
+  Scenario: Ping() method gets status of candlepin server on unregistered system
+    Given system is not registered
+    When varlink method is called
+      | method | interface               | arguments |
+      | Ping   | com.redhat.rhsm.testing | '{}'      |
+    Then method call was successful
+    And method returned JSON compliant with 'com.redhat.rhsm.testing.Ping.json' schema
+
+
+  Scenario: IsRegistered() method returns true on registered system
+    Given system is registered against candlepin server
+    When varlink method is called
+      | method       | interface               | arguments |
+      | IsRegistered | com.redhat.rhsm.testing | '{}'      |
+    Then varlink method returns
+      """
+      {"registered":true}
+      """
+
+  Scenario: Ping() method gets status of candlepin server on registered system
+    Given system is registered against candlepin server
+    When varlink method is called
+      | method | interface               | arguments |
+      | Ping   | com.redhat.rhsm.testing | '{}'      |
+    Then method call was successful
+    And method returned JSON compliant with 'com.redhat.rhsm.testing.Ping.json' schema
+
+
+  Scenario: Ping() method gets status of candlepin server on registered system with metadata
+    Given system is registered against candlepin server
+    When varlink method is called
+      | method | interface               | arguments          |
+      | Ping   | com.redhat.rhsm.testing | '{"metadata": {}}' |
+    Then method call was successful
+    And method returned JSON compliant with 'com.redhat.rhsm.testing.Ping.json' schema
+
+
+  Scenario: Ping() method gets status of candlepin server on registered system with metadata (user_agent)
+    Given system is registered against candlepin server
+    When varlink method is called
+      | method | interface               | arguments                             |
+      | Ping   | com.redhat.rhsm.testing | '{"metadata": {"user_agent": "foo"}}' |
+    Then method call was successful
+    And method returned JSON compliant with 'com.redhat.rhsm.testing.Ping.json' schema
+
+
+  Scenario: Ping() method gets status of candlepin server on registered system with metadata (correlation ID)
+    Given system is registered against candlepin server
+    When varlink method is called
+      | method | interface               | arguments                                                                  |
+      | Ping   | com.redhat.rhsm.testing | '{"metadata": {"correlation_id": "670fcfe2-d87c-40f1-8ea9-1bfd17664fe4"}}' |
+    Then method call was successful
+    And method returned JSON compliant with 'com.redhat.rhsm.testing.Ping.json' schema
+
+
+  Scenario: Ping() method gets status of candlepin server on registered system with metadata (locale)
+    Given system is registered against candlepin server
+    When varlink method is called
+      | method | interface               | arguments                           |
+      | Ping   | com.redhat.rhsm.testing | '{"metadata": {"locale": "de_DE"}}' |
+    Then method call was successful
+    And method returned JSON compliant with 'com.redhat.rhsm.testing.Ping.json' schema

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,0 +1,59 @@
+"""
+This module contains environment setup and teardown functions for the test suite.
+"""
+
+ENTITLEMENT_CERT_DIR = "/etc/pki/entitlement/"
+ENTITLEMENT_BACKUP_DIR_PREFIX = "entitlement-backup-"
+RELEASEVER_FILE = "/etc/dnf/vars/releasever"
+RHSM_HOST_CONFIG_DIR = "/etc/rhsm-host"
+ENTITLEMENT_HOST_CERT_DIR = "/etc/pki/entitlement-host"
+
+
+def before_scenario(context, scenario) -> None:
+    """
+    This function is executed before each scenario in the test suite.
+    :param context: Context object
+    :param scenario: Scenario object
+    :return: None
+    """
+    pass
+
+
+def after_scenario(context, scenario) -> None:
+    """
+    This function is executed after each scenario in the test suite.
+    :param context: Context object
+    :param scenario: Scenario object
+    :return: None
+    """
+    pass
+
+
+def before_step(context, step) -> None:
+    """
+    This function is executed before each step in the test suite.
+    :param context: Context object
+    :param step: Step object
+    :return: None
+    """
+    pass
+
+
+def after_step(context, step) -> None:
+    """
+    This function is executed after each step in the test suite.
+    It checks if the step failed, and if so, it tries to print stdout and stderr
+    of the failed process
+
+    :param context: Context object
+    :param step: Step object
+    :return: None
+    """
+    if step.status == "failed":
+        print(f"Step '{step.name}' failed!")
+        if hasattr(context, "cmd_stdout") and context.cmd_stdout:
+            print(f"context stdout: {context.cmd_stdout}")
+        if hasattr(context, "cmd_stderr") and context.cmd_stderr:
+            print(f"context stderr: {context.cmd_stderr}")
+        # TODO: Print logs of rhc-server since the scenario was started, which
+        #       could be useful for debugging

--- a/features/json-schemas/com.redhat.rhsm.testing.Ping.json
+++ b/features/json-schemas/com.redhat.rhsm.testing.Ping.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Generated schema for Root",
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string"
+        },
+        "modeReason": {},
+        "modeChangeTime": {},
+        "result": {
+          "type": "boolean"
+        },
+        "version": {
+          "type": "string"
+        },
+        "release": {
+          "type": "string"
+        },
+        "standalone": {
+          "type": "boolean"
+        },
+        "timeUTC": {
+          "type": "string"
+        },
+        "rulesSource": {
+          "type": "string"
+        },
+        "rulesVersion": {
+          "type": "string"
+        },
+        "managerCapabilities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "keycloakRealm": {},
+        "keycloakAuthUrl": {},
+        "keycloakResource": {},
+        "deviceAuthRealm": {},
+        "deviceAuthUrl": {},
+        "deviceAuthClientId": {},
+        "deviceAuthScope": {}
+      },
+      "required": [
+        "mode",
+        "modeReason",
+        "modeChangeTime",
+        "result",
+        "version",
+        "release",
+        "standalone",
+        "timeUTC",
+        "rulesSource",
+        "rulesVersion",
+        "managerCapabilities",
+        "keycloakRealm",
+        "keycloakAuthUrl",
+        "keycloakResource",
+        "deviceAuthRealm",
+        "deviceAuthUrl",
+        "deviceAuthClientId",
+        "deviceAuthScope"
+      ]
+    }
+  },
+  "required": [
+    "status"
+  ]
+}

--- a/features/steps/common.py
+++ b/features/steps/common.py
@@ -1,0 +1,52 @@
+import subprocess
+
+
+def run(cmd, shell=True, cwd=None):
+    """
+    Run a command.
+    Return exitcode, stdout, stderr
+    """
+
+    proc = subprocess.Popen(
+        cmd,
+        shell=shell,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        errors="surrogateescape",
+    )
+
+    stdout, stderr = proc.communicate()
+    return proc.returncode, stdout, stderr
+
+
+def run_in_context(context, cmd, can_fail=False, expected_exit_code=None, **run_args):
+    """
+    Run a command in the context of a behave scenario.
+    :param context: behave context
+    :param cmd: command to run
+    :param can_fail: whether the command can fail without raising an error
+    :param expected_exit_code: expected exit code of the command
+    :param run_args: additional arguments to pass to subprocess.Popen
+    :return: None
+    """
+
+    context.cmd = cmd
+
+    if hasattr(context.scenario, "working_dir") and "cwd" not in run_args:
+        run_args["cwd"] = context.scenario.working_dir
+
+    context.cmd_exitcode, context.cmd_stdout, context.cmd_stderr = run(cmd, **run_args)
+
+    if expected_exit_code is not None:
+        if expected_exit_code != context.cmd_exitcode:
+            raise AssertionError(
+                f'Running command "{cmd}" had unexpected exit code: {context.cmd_exitcode}\n'
+                f'stdout: {context.cmd_stdout}\nstderr: {context.cmd_stderr}'
+            )
+    elif not can_fail and context.cmd_exitcode != 0:
+        raise AssertionError(
+            f'Running command "{cmd}" failed: {context.cmd_exitcode}\n'
+            f'stdout: {context.cmd_stdout}\nstderr: {context.cmd_stderr}'
+        )

--- a/features/steps/constants.py
+++ b/features/steps/constants.py
@@ -1,0 +1,1 @@
+VARLINK_SOCKET = "/run/rhc/com.redhat.rhc"

--- a/features/steps/test_varlink_method.py
+++ b/features/steps/test_varlink_method.py
@@ -1,0 +1,119 @@
+from behave import given, when, then, step
+import behave.runner
+
+import json
+import jsonschema
+from pathlib import Path
+
+from common import run_in_context
+from constants import VARLINK_SOCKET
+
+@given("system is registered against candlepin server")
+def step_impl(context: behave.runner.Context):
+    """
+    Check if the system is registered against the candlepin server. If not, register it.
+    :param context: behave context
+    :return: None
+    """
+    cmd = "rhc status --format json"
+    run_in_context(context, cmd, can_fail=True)
+    result = json.loads(context.cmd_stdout)
+    if not result["rhsm_connected"]:
+        # Try to load credentials from settings file
+        settings = {}
+        settings_file = Path(__file__).parent / "settings.json"
+        try:
+            with open(settings_file, 'r') as f:
+                settings = json.load(f)
+        except FileNotFoundError:
+            pass
+
+        # Try to load credentials from settings file, when it was not possible to read
+        # settings file or some credential is missing, then use default values.
+        username = settings.get("candlepin.username", "admin")
+        password = settings.get("candlepin.password", "admin")
+        organization = settings.get("candlepin.organization", "donaldduck")
+
+        cmd = (
+            f"rhc connect --username {username} --password {password} --organization {organization} "
+            "--enable-feature content --disable-feature analytics --disable-feature remote-management"
+        )
+        run_in_context(context, cmd, can_fail=False)
+
+
+@given("system is not registered")
+def step_impl(context: behave.runner.Context):
+    """
+    Ensure the system is not registered. If currently registered, disconnect.
+    :param context: behave context
+    :return: None
+    """
+    cmd = "rhc status --format json"
+    run_in_context(context, cmd, can_fail=True)
+    result = json.loads(context.cmd_stdout)
+    if result["rhsm_connected"]:
+        cmd = "rhc disconnect"
+        run_in_context(context, cmd, can_fail=False)
+
+@when("varlink method is called")
+def step_impl(context: behave.runner.Context):
+    """
+    Call a varlink method on a specified interface.
+    Example of a Gherkin table containing the name of the method, Varlink interface, and argument:
+      | method | interface               | arguments          |
+      | Ping   | com.redhat.rhsm.testing | '{"metadata": {}}' |
+    :param context: behave context
+    :return: None
+    """
+    varlink_interface = None
+    varlink_method = None
+    varlink_args = None
+    counter = 0
+    for row in context.table:
+        varlink_interface = row["interface"]
+        varlink_method = row["method"]
+        varlink_args = row["arguments"]
+        counter += 1
+    assert counter == 1, f"Expected exactly one row in table for 'varlink method called' ({counter} provided)"
+
+    cmd = f"varlinkctl call --no-pager --json=short {VARLINK_SOCKET} {varlink_interface}.{varlink_method} {varlink_args}"
+    run_in_context(context, cmd, can_fail=False)
+
+
+@then("varlink method returns")
+def step_impl(context: behave.runner.Context):
+    """
+    Verify the return value of the varlink method.
+    :param context: behave context
+    :return: None
+    """
+    json_object = context.text
+    result = json.loads(context.cmd_stdout)
+    assert result == json.loads(json_object), f"Expected {json_object}, got {result}"
+
+@step("method returned JSON compliant with '{json_schema_doc}' schema")
+def step_impl(context: behave.runner.Context, json_schema_doc):
+    """
+    Verify that the varlink method returns JSON document and the document is
+    compliant with given JSON schema
+    :param context: behave context
+    :param json_schema_doc: name of JSON schema document in ./features/json-schemas/
+    :return: None
+    """
+    with open(f"./features/json-schemas/{json_schema_doc}") as f:
+        schema = json.load(f)
+    result = json.loads(context.cmd_stdout)
+    try:
+        jsonschema.validate(instance=result, schema=schema)
+    except jsonschema.ValidationError as e:
+        raise AssertionError(f"JSON validation failed: {e.message}")
+
+
+@then("method call was successful")
+def step_impl(context: behave.runner.Context):
+    """
+    Verify that the varlink method call was successful.
+    :param context: behave context
+    :return: None
+    """
+    assert context.cmd_exitcode == 0, f"Method call failed with exit code {context.cmd_exitcode}"


### PR DESCRIPTION
* Added integration tests for Varlink interface com.redhat.rhsm.testing
* The [behave](https://behave.readthedocs.io/en/latest/) testing framework is used
* Tests are written in Gherkin language, but steps are written in Python programming language
* The com.redhat.rhsm.testing contains only two simple methods and integration tests are written for many combinations of use cases
* Added GitHub action for triggering integration tests
* We use the same approach for testing dnf5 plugins in https://github.com/candlepin/rhsm-dnf5-plugins