### PR TITLE
docs(rhc-collector): add manpages for rhc-collector

### DIFF
--- a/doc/source/markdown/rhc-collector.5.md
+++ b/doc/source/markdown/rhc-collector.5.md
@@ -1,0 +1,118 @@
+% rhc-collector 5
+
+# NAME
+
+rhc-collector - execute a data collector and upload its archive
+
+# SYNOPSIS
+
+```
+/usr/libexec/rhc/rhc-collector run COLLECTOR
+```
+
+# DESCRIPTION
+
+**rhc-collector** is the binary responsible for executing a data collector, compressing the collected data into an archive, and uploading it to Red Hat's Ingress service. It is normally invoked by systemd service units and not run directly by users.
+
+The binary performs the following steps for a given collector:
+
+1. Loads the collector configuration from **/usr/lib/rhc/collectors/**_COLLECTOR_**.toml**.
+2. Creates a temporary directory under **/var/tmp/rhc/**.
+3. Executes the collector binary at **/usr/libexec/rhc/collectors/**_COLLECTOR_ with the **collect** subcommand, using the temporary directory as the working directory.
+4. If the collector exits with a non-zero status, the temporary directory is removed and **rhc-collector** exits with an error.
+5. Compresses the temporary directory into a **.tar.xz** archive.
+6. Uploads the archive to the Ingress service.
+7. Removes both the temporary directory and the archive.
+
+# COMMANDS
+
+**run** *COLLECTOR*
+: Execute the full collection workflow for the specified collector (load configuration, create temporary directory, run the collector, compress, upload, clean up).
+
+# COLLECTOR API
+
+Each data collector is an executable shipped as part of an RPM package. Collectors must conform to the following API contract.
+
+## Identification
+
+Each collector has a unique ID in reverse-domain notation (e.g., **com.redhat.minimal**, **org.foreman**). The ID must match the regular expression **^[a-z0-9]+\.[a-z0-9]+(\.[a-z0-9]+)*$**.
+
+## Executable
+
+The collector executable must be installed at **/usr/libexec/rhc/collectors/**_COLLECTOR_. It must implement a **collect** subcommand that writes collected data into the current working directory.
+
+The collector must not perform any network communication or upload. It only collects data into the working directory; **rhc-collector** handles compression and upload.
+
+## Configuration file
+
+Each collector must ship a TOML configuration file at **/usr/lib/rhc/collectors/**_COLLECTOR_**.toml** with the following structure:
+
+```
+[meta]
+name = "Minimal Host Inventory Collector"
+feature = "analytics"
+type = "ingress"
+
+[ingress]
+user = "root"
+group = "root"
+content_type = "application/vnd.redhat.advisor.minimal"
+```
+
+### meta section
+
+**meta.name** (required)
+: Human-readable name of the collector.
+
+**meta.feature** (optional)
+: Reserved for future use. Only **"analytics"** value is supported.
+
+**meta.type** (required)
+: Must be set to **"ingress"** for data collectors that use the standard upload workflow.
+
+### ingress section
+
+**ingress.user** (optional)
+: System user under which the collector runs. Defaults to **"root"**.
+
+**ingress.group** (optional)
+: System group under which the collector runs. Defaults to **"root"**.
+
+**ingress.content_type** (required)
+: MIME content type used when uploading the archive to the Ingress service (e.g., **"application/vnd.redhat.advisor.minimal"**).
+
+## systemd units
+
+Each collector must ship a systemd service and timer unit. Unit file names must be prefixed with **rhc-collector-** and use the collector ID as the base name:
+
+- **rhc-collector-**_COLLECTOR_**.service**
+- **rhc-collector-**_COLLECTOR_**.timer**
+
+The service unit invokes **/usr/libexec/rhc/rhc-collector run** _COLLECTOR_.
+
+# FILES
+
+**/usr/libexec/rhc/rhc-collector**
+: The rhc-collector binary.
+
+**/usr/libexec/rhc/collectors/**
+: Directory containing collector executables. Each file name matches the collector ID.
+
+**/usr/lib/rhc/collectors/**
+: Directory containing collector TOML configuration files.
+
+**/var/tmp/rhc/**
+: Parent directory for temporary directories created during data collection.
+
+**/var/cache/rhc/collectors/**
+: Directory containing cached execution data (start time, finish time, exit code) in JSON format.
+
+# EXIT STATUS
+
+**0**: Collection and upload completed successfully.
+
+**Non-zero**: An error occurred.
+
+# SEE ALSO
+
+**rhc(1)**, **rhc-collector(8)**, **rhc-connect(8)**

--- a/doc/source/markdown/rhc-collector.8.md
+++ b/doc/source/markdown/rhc-collector.8.md
@@ -1,0 +1,126 @@
+% rhc-collector 8
+
+# NAME
+
+rhc-collector - Manage data collectors for Red Hat hosted services
+
+# SYNOPSIS
+
+```
+rhc collector list [--format json]
+rhc collector timers [--format json]
+rhc collector info [--format json] COLLECTOR
+rhc collector enable [--now] COLLECTOR
+rhc collector disable [--now] COLLECTOR
+```
+
+# DESCRIPTION
+
+The **rhc collector** command manages data collectors that gather system data and upload it to Red Hat hosted services. Each collector is identified by a reverse-domain-notation ID (e.g., **com.redhat.minimal**) and runs on a systemd timer.
+
+Collectors are shipped by Red Hat teams as RPM packages. Each package provides an executable, a TOML configuration file, and systemd service and timer units. The **rhc collector** command provides a unified interface to list, inspect, enable, and disable these collectors.
+
+Data collection itself is performed by the **/usr/libexec/rhc/rhc-collector** binary, which is invoked by the systemd service units. See **rhc-collector(5)** for details on the binary and the collector API.
+
+# SUBCOMMANDS
+
+**list** [**--format** json]
+: List all available collectors. Displays the collector ID and human-readable name. When **--format json** is specified, output is printed as a JSON array.
+
+**timers** [**--format** json]
+: List timer information for all available collectors. Displays the collector ID, time since the last run finished, and time until the next scheduled run. When **--format json** is specified, output is printed as a JSON array.
+
+**info** [**--format** json] *COLLECTOR*
+: Display detailed information about a specific collector, including its name, feature, last and next run times, configuration file path, and associated systemd units. When **--format json** is specified, output is printed as a JSON object.
+
+**enable** [**--now**] *COLLECTOR*
+: Enable the systemd timer for the specified collector. The collector will run on its configured schedule. If **--now** is specified, an immediate collection is also triggered.
+
+**disable** [**--now**] *COLLECTOR*
+: Disable the systemd timer for the specified collector. If the collector is currently running, it will be allowed to finish. If **--now** is specified, any running collection is stopped immediately.
+
+# OPTIONS
+
+**--format** json
+: Print output in machine-readable JSON format. Available for the **list**, **timers**, and **info** subcommands.
+
+**--now**
+: When used with **enable**, trigger an immediate collection in addition to enabling the timer. When used with **disable**, stop any running collection immediately in addition to disabling the timer.
+
+# EXAMPLES
+
+**List all available collectors:**
+
+```
+# rhc collector list
+ID                      NAME
+com.redhat.minimal      Minimal Host Inventory Collector
+com.redhat.compliance   Red Hat Lightspeed Compliance
+org.foreman             Red Hat Satellite
+```
+
+**Show timer status for all collectors:**
+
+```
+# rhc collector timers
+ID                      LAST    NEXT
+com.redhat.minimal       18h    6h
+com.redhat.compliance  3h 47m   13m
+org.foreman              28d    -
+
+Hint: Run 'rhc collector info COLLECTOR' to show more details.
+```
+
+**Show detailed information about a collector:**
+
+```
+# rhc collector info com.redhat.minimal
+Name:      Minimal Host Inventory Collector
+Feature:   analytics
+
+Last run:  Wed 2026-06-17 17:21 CEST (1h 15m ago)
+Next run:  Wed 2026-06-17 20:00 CEST (1h 24m)
+
+Config:   /usr/lib/rhc/collectors/com.redhat.minimal.toml
+Service:  rhc-collector-com.redhat.minimal.service
+Timer:    rhc-collector-com.redhat.minimal.timer
+```
+
+**Enable a collector with immediate data collection:**
+
+```
+# rhc collector enable --now com.redhat.minimal
+Enabled timer rhc-collector-com.redhat.minimal.timer and triggered immediate collection.
+```
+
+**Disable a collector:**
+
+```
+# rhc collector disable com.redhat.minimal
+Disabled timer rhc-collector-com.redhat.minimal.timer.
+```
+
+# SYSTEMD REQUIREMENTS
+
+The **enable** and **disable** subcommands require systemd. In environments without systemd (e.g., containers), these commands will print an error:
+
+```
+automatic execution requires systemd, which is not present in your environment
+```
+
+In such environments, the data collection must be triggered manually. See **rhc-collector(5)** for details.
+
+# EXIT STATUS
+
+**0**: Success
+
+**Non-zero**: An error occurred. Common errors include:
+
+- Collector ID not found or invalid
+- rhc-server socket not available
+- systemd not present (for enable/disable)
+- Timer unit not installed
+
+# SEE ALSO
+
+**rhc(1)**, **rhc-collector(5)**, **rhc-connect(8)**, **rhc-configure(8)**


### PR DESCRIPTION
* Card ID: CCT-1844

rhc-collector.8.md documents the `rhc collector` CLI and its subcommands (list, timers, info, enable, disable).
rhc-collector.5.md documents the `/usr/libexec/rhc/rhc-collector` binary, the collection workflow, and the collector API contract.

Assisted-By: Claude Opus <noreply@anthropic.com>