### PR TITLE
feat(collector): run as configured user/group

### DIFF
--- a/cmd/rhc-collector/main.go
+++ b/cmd/rhc-collector/main.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"os/user"
 	"time"
 
 	"github.com/redhatinsights/rhc/internal/collector"
@@ -57,7 +58,7 @@ func run(collectorId, command string) error {
 	}
 	defer cleanup(tmpDir)
 
-	if err = executeCollector(collectorId, tmpDir); err != nil {
+	if err = executeCollector(config, tmpDir); err != nil {
 		return err
 	}
 	archivePath, err := getArchivePath(tmpDir)
@@ -125,14 +126,21 @@ func getConfig(collectorId string) (collector.Config, error) {
 }
 
 // executeCollector runs the specified collector binary with the collect argument in tmpDir as the working directory.
+// The collector process is executed as the user and group defined in the collector configuration.
 // Returns an error if the command execution fails.
-func executeCollector(collectorId, tmpDir string) error {
-	// Construct path to the collector binary
-	collectorPath := fmt.Sprintf("/usr/libexec/rhc/collectors/%s", collectorId)
+func executeCollector(config collector.Config, tmpDir string) error {
+	collectorPath := fmt.Sprintf("/usr/libexec/rhc/collectors/%s", config.ID)
 
-	// TODO: Run collector as specific user and group (defined in config of collector)
+	sysProcAttr, err := collector.ResolveUserGroupAttr(config.User, config.Group, user.Lookup, user.LookupGroup)
+	if err != nil {
+		return fmt.Errorf("failed to resolve user and group: %w", err)
+	}
+
+	slog.Info("executing collector as configured user/group", "collector", config.ID, "user", config.User, "group", config.Group)
+
 	cmd := exec.Command(collectorPath, "collect")
 	cmd.Dir = tmpDir
+	cmd.SysProcAttr = sysProcAttr
 
 	// Capture start/end time and execute the command
 	startTime := time.Now()
@@ -150,12 +158,12 @@ func executeCollector(collectorId, tmpDir string) error {
 
 	// Timer payload and writing to cache
 	timerPayload := collector.Timer{
-		ID:           collectorId,
+		ID:           config.ID,
 		LastStarted:  startTime,
 		LastFinished: endTime,
 		ExitCode:     exitCode,
 	}
-	cacheErr := collector.WriteTimerCache(collectorId, timerPayload)
+	cacheErr := collector.WriteTimerCache(config.ID, timerPayload)
 	if cacheErr != nil {
 		slog.Error("Failed to write timer cache", "error", cacheErr)
 	}

--- a/cmd/rhc-collector/rhc-collector_test.go
+++ b/cmd/rhc-collector/rhc-collector_test.go
@@ -106,8 +106,12 @@ func TestGetConfig(t *testing.T) {
 func TestExecuteCollector(t *testing.T) {
 	t.Run("nonexistent collector binary", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		collectorId := "com.redhat.nonexistent"
-		err := executeCollector(collectorId, tmpDir)
+		config := collector.Config{
+			ID:    "com.redhat.nonexistent",
+			User:  "root",
+			Group: "root",
+		}
+		err := executeCollector(config, tmpDir)
 		if err == nil {
 			t.Error("executeCollector() expected error for nonexistent collector binary")
 		}
@@ -118,8 +122,12 @@ func TestExecuteCollector(t *testing.T) {
 
 	t.Run("collector binary with invalid ID characters", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		collectorId := "../../../etc/passwd"
-		err := executeCollector(collectorId, tmpDir)
+		config := collector.Config{
+			ID:    "../../../etc/passwd",
+			User:  "root",
+			Group: "root",
+		}
+		err := executeCollector(config, tmpDir)
 		if err == nil {
 			t.Error("executeCollector() expected error for path traversal attempt")
 		}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -7,14 +7,23 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/redhatinsights/rhc/internal/systemd"
 )
+
+// UserLookupFunc is a function that looks up a user by username.
+type UserLookupFunc func(string) (*user.User, error)
+
+// GroupLookupFunc is a function that looks up a group by name.
+type GroupLookupFunc func(string) (*user.Group, error)
 
 // ConfigDir is the default directory path where collector configuration files are stored.
 const ConfigDir = "/usr/lib/rhc/collectors/"
@@ -204,6 +213,37 @@ func ValidateID(id string) (string, error) {
 		return "", fmt.Errorf("invalid collector ID %q", id)
 	}
 	return filepath.Base(id), nil
+}
+
+// ResolveUserGroupAttr resolves a username and group name into a syscall.SysProcAttr
+// suitable for setting on exec.Cmd to run a process as the specified user and group.
+func ResolveUserGroupAttr(username, groupname string, lookupUser UserLookupFunc, lookupGroup GroupLookupFunc) (*syscall.SysProcAttr, error) {
+	slog.Debug("resolving user and group for collector execution", "user", username, "group", groupname)
+
+	u, err := lookupUser(username)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up user %q: %w", username, err)
+	}
+	uid, err := strconv.ParseUint(u.Uid, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse UID %q: %w", u.Uid, err)
+	}
+
+	g, err := lookupGroup(groupname)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up group %q: %w", groupname, err)
+	}
+	gid, err := strconv.ParseUint(g.Gid, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse GID %q: %w", g.Gid, err)
+	}
+
+	return &syscall.SysProcAttr{
+		Credential: &syscall.Credential{
+			Uid: uint32(uid),
+			Gid: uint32(gid),
+		},
+	}, nil
 }
 
 // writeTimerToFile marshals a timerDto to JSON and writes it to the cache file.

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -1,8 +1,10 @@
 package collector
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -848,4 +850,120 @@ func TestValidateID(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveUserGroupAttr(t *testing.T) {
+	mockLookupUser := func(uid, username string) UserLookupFunc {
+		return func(name string) (*user.User, error) {
+			if name == username {
+				return &user.User{Uid: uid, Username: username}, nil
+			}
+			return nil, fmt.Errorf("user %q not found", name)
+		}
+	}
+
+	mockLookupGroup := func(gid, groupname string) GroupLookupFunc {
+		return func(name string) (*user.Group, error) {
+			if name == groupname {
+				return &user.Group{Gid: gid, Name: groupname}, nil
+			}
+			return nil, fmt.Errorf("group %q not found", name)
+		}
+	}
+
+	t.Run("valid user and group", func(t *testing.T) {
+		attr, err := ResolveUserGroupAttr(
+			"testuser", "testgroup",
+			mockLookupUser("1000", "testuser"),
+			mockLookupGroup("1000", "testgroup"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if attr.Credential.Uid != 1000 {
+			t.Errorf("UID = %d, want 1000", attr.Credential.Uid)
+		}
+		if attr.Credential.Gid != 1000 {
+			t.Errorf("GID = %d, want 1000", attr.Credential.Gid)
+		}
+	})
+
+	t.Run("root user and group", func(t *testing.T) {
+		attr, err := ResolveUserGroupAttr(
+			"root", "root",
+			mockLookupUser("0", "root"),
+			mockLookupGroup("0", "root"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if attr.Credential.Uid != 0 {
+			t.Errorf("UID = %d, want 0", attr.Credential.Uid)
+		}
+		if attr.Credential.Gid != 0 {
+			t.Errorf("GID = %d, want 0", attr.Credential.Gid)
+		}
+	})
+
+	t.Run("user lookup failure", func(t *testing.T) {
+		_, err := ResolveUserGroupAttr(
+			"nonexistent", "testgroup",
+			mockLookupUser("1000", "testuser"),
+			mockLookupGroup("1000", "testgroup"),
+		)
+		if err == nil {
+			t.Fatal("expected error for nonexistent user")
+		}
+		if !strings.Contains(err.Error(), "failed to look up user") {
+			t.Errorf("error = %v, want error containing %q", err, "failed to look up user")
+		}
+	})
+
+	t.Run("group lookup failure", func(t *testing.T) {
+		_, err := ResolveUserGroupAttr(
+			"testuser", "nonexistent",
+			mockLookupUser("1000", "testuser"),
+			mockLookupGroup("1000", "testgroup"),
+		)
+		if err == nil {
+			t.Fatal("expected error for nonexistent group")
+		}
+		if !strings.Contains(err.Error(), "failed to look up group") {
+			t.Errorf("error = %v, want error containing %q", err, "failed to look up group")
+		}
+	})
+
+	t.Run("invalid UID", func(t *testing.T) {
+		badUserLookup := func(name string) (*user.User, error) {
+			return &user.User{Uid: "notanumber", Username: name}, nil
+		}
+		_, err := ResolveUserGroupAttr(
+			"testuser", "testgroup",
+			badUserLookup,
+			mockLookupGroup("1000", "testgroup"),
+		)
+		if err == nil {
+			t.Fatal("expected error for invalid UID")
+		}
+		if !strings.Contains(err.Error(), "failed to parse UID") {
+			t.Errorf("error = %v, want error containing %q", err, "failed to parse UID")
+		}
+	})
+
+	t.Run("invalid GID", func(t *testing.T) {
+		badGroupLookup := func(name string) (*user.Group, error) {
+			return &user.Group{Gid: "notanumber", Name: name}, nil
+		}
+		_, err := ResolveUserGroupAttr(
+			"testuser", "testgroup",
+			mockLookupUser("1000", "testuser"),
+			badGroupLookup,
+		)
+		if err == nil {
+			t.Fatal("expected error for invalid GID")
+		}
+		if !strings.Contains(err.Error(), "failed to parse GID") {
+			t.Errorf("error = %v, want error containing %q", err, "failed to parse GID")
+		}
+	})
 }


### PR DESCRIPTION
* Card ID: CCT-2128

Execute the collector binary as the user and group defined in the collector TOML configuration instead of inheriting the rhc-collector process privileges.