### PR TITLE
feat(operations): make enable and disable feature operations convergent

### DIFF
--- a/pkg/operations/feature_disable.go
+++ b/pkg/operations/feature_disable.go
@@ -44,8 +44,11 @@ const (
 // If any dependent fails to disable, the operation stops immediately and returns
 // Status="dependent-failed" with partial progress visible in DependentsDisabled.
 //
-// The operation is idempotent: if the feature is already disabled, it returns
-// immediately with Status="already-disabled" and no error.
+// The operation is convergent: dependents are always verified and disabled even
+// if the target feature is already disabled, repairing inconsistent states where
+// the target is stopped but its dependents are still running. If the target is
+// already disabled and no dependents need teardown, it returns
+// Status="already-disabled" and no error.
 func DisableFeature(opts FeatureOperationOptions) DisableFeatureResult {
 	result := DisableFeatureResult{
 		Feature:            opts.Feature,
@@ -61,12 +64,12 @@ func DisableFeature(opts FeatureOperationOptions) DisableFeatureResult {
 		result.Status = DisableStatusFailed
 		return result
 	}
-	if !status.Enabled {
-		result.Status = DisableStatusAlreadyDisabled
-		return result
-	}
+	targetAlreadyDisabled := !status.Enabled
 
-	// Disable dependents first (explicit dependency graph reversed)
+	// Disable dependents first (explicit dependency graph reversed).
+	// This runs even when the target is already disabled, so that
+	// re-running disable converges to a consistent state when
+	// dependents are still running (e.g. after a partial disconnect).
 	switch opts.Feature {
 	case Analytics, Content:
 		// Analytics and Content are required by RemoteManagement
@@ -91,6 +94,11 @@ func DisableFeature(opts FeatureOperationOptions) DisableFeatureResult {
 	default:
 		result.Err = fmt.Errorf("unknown feature: %s", opts.Feature)
 		result.Status = DisableStatusFailed
+		return result
+	}
+
+	if targetAlreadyDisabled {
+		result.Status = DisableStatusAlreadyDisabled
 		return result
 	}
 

--- a/pkg/operations/feature_disable_test.go
+++ b/pkg/operations/feature_disable_test.go
@@ -151,6 +151,39 @@ func TestDisableUnknownFeature(t *testing.T) {
 	}
 }
 
+// TestDisableAnalyticsAlwaysProcessesDependents verifies the convergent
+// behavior: disabling Analytics always checks whether RemoteManagement (its
+// dependent) is still running, even when Analytics itself is already disabled.
+// This repairs inconsistent states where a dependency was disabled but
+// RemoteManagement was not torn down (e.g. after a partial disconnect).
+func TestDisableAnalyticsAlwaysProcessesDependents(t *testing.T) {
+	rmStatus := FeatureStatus(FeatureOperationOptions{Feature: RemoteManagement})
+	if rmStatus.Err != nil {
+		t.Skipf("Cannot determine RemoteManagement status: %v", rmStatus.Err)
+	}
+
+	result := DisableFeature(FeatureOperationOptions{Feature: Analytics})
+	if result.Feature != Analytics {
+		t.Fatalf("Feature = %v, want %v", result.Feature, Analytics)
+	}
+
+	if rmStatus.Enabled {
+		// RemoteManagement was running — disable should have attempted to
+		// tear it down regardless of Analytics' own state
+		found := false
+		for _, dep := range result.DependentsDisabled {
+			if dep.Feature == RemoteManagement {
+				found = true
+				break
+			}
+		}
+		if !found && result.Status != DisableStatusFailed && result.Status != DisableStatusDependentFailed {
+			t.Errorf("RemoteManagement was enabled but not in DependentsDisabled "+
+				"(status=%q, err=%v)", result.Status, result.Err)
+		}
+	}
+}
+
 // TestDisableIdempotency tests that calling DisableFeature multiple times is safe.
 func TestDisableIdempotency(t *testing.T) {
 	feature := RemoteManagement

--- a/pkg/operations/feature_enable.go
+++ b/pkg/operations/feature_enable.go
@@ -44,8 +44,11 @@ const (
 // If any dependency fails to enable, the operation stops immediately and returns
 // Status="dependency-failed" with partial progress visible in DependenciesEnabled.
 //
-// The operation is idempotent: if the feature is already enabled, it returns
-// immediately with Status="already-enabled" and no error.
+// The operation is convergent: dependencies are always verified and enabled even
+// if the target feature is already enabled, repairing inconsistent states where
+// the target is running but its dependencies are not (e.g. after a partial
+// disconnect). If the target is already enabled and all dependencies are
+// satisfied, it returns Status="already-enabled" and no error.
 func EnableFeature(opts FeatureOperationOptions) EnableFeatureResult {
 	result := EnableFeatureResult{
 		Feature:             opts.Feature,
@@ -61,12 +64,12 @@ func EnableFeature(opts FeatureOperationOptions) EnableFeatureResult {
 		result.Status = EnableStatusFailed
 		return result
 	}
-	if status.Enabled {
-		result.Status = EnableStatusAlreadyEnabled
-		return result
-	}
+	targetAlreadyEnabled := status.Enabled
 
-	// Enable dependencies first (explicit dependency graph)
+	// Enable dependencies first (explicit dependency graph).
+	// This runs even when the target is already enabled, so that
+	// re-running enable converges to a consistent state when
+	// dependencies were disabled externally or by a partial disconnect.
 	switch opts.Feature {
 	case Analytics, Content:
 		// No dependencies
@@ -90,6 +93,11 @@ func EnableFeature(opts FeatureOperationOptions) EnableFeatureResult {
 	default:
 		result.Err = fmt.Errorf("unknown feature: %s", opts.Feature)
 		result.Status = EnableStatusFailed
+		return result
+	}
+
+	if targetAlreadyEnabled {
+		result.Status = EnableStatusAlreadyEnabled
 		return result
 	}
 

--- a/pkg/operations/feature_enable_test.go
+++ b/pkg/operations/feature_enable_test.go
@@ -112,6 +112,37 @@ func TestEnableResultStructure(t *testing.T) {
 	}
 }
 
+// TestEnableRemoteManagementAlwaysProcessesDependencies verifies the convergent
+// behavior: enabling RemoteManagement always walks the dependency chain (Content
+// and Analytics), even when RemoteManagement itself is already enabled. This
+// repairs inconsistent states where yggdrasil is running but dependencies were
+// disabled externally.
+func TestEnableRemoteManagementAlwaysProcessesDependencies(t *testing.T) {
+	result := EnableFeature(FeatureOperationOptions{Feature: RemoteManagement})
+	if result.Feature != RemoteManagement {
+		t.Fatalf("Feature = %v, want %v", result.Feature, RemoteManagement)
+	}
+
+	switch result.Status {
+	case EnableStatusEnabled, EnableStatusAlreadyEnabled:
+		// In both cases, dependencies must have been processed
+		if len(result.DependenciesEnabled) != 2 {
+			t.Fatalf("DependenciesEnabled length = %d, want 2 (Content, Analytics) "+
+				"even when status is %q", len(result.DependenciesEnabled), result.Status)
+		}
+		if result.DependenciesEnabled[0].Feature != Content {
+			t.Errorf("first dependency = %v, want Content", result.DependenciesEnabled[0].Feature)
+		}
+		if result.DependenciesEnabled[1].Feature != Analytics {
+			t.Errorf("second dependency = %v, want Analytics", result.DependenciesEnabled[1].Feature)
+		}
+	case EnableStatusFailed, EnableStatusDependencyFailed:
+		// Status check or dependency failed — can't verify further, but
+		// the test should not fail on systems without the required services
+		t.Skipf("enable failed (expected on systems without required services): %v", result.Err)
+	}
+}
+
 // TestEnableUnknownFeature tests handling of an unknown/invalid feature type.
 func TestEnableUnknownFeature(t *testing.T) {
 	invalidFeature := Feature(999)


### PR DESCRIPTION
This commit makes EnableFeature and DisableFeature convergent so re-running them repairs broken dependency chains instead of returning early. Both functions, doc comments, and tests are updated.