### PR TITLE
refactor(integration-tests): unify systemctl helpers and use shipped collector in tests

### DIFF
--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -2,8 +2,237 @@ import pytest
 import subprocess
 import logging
 import os
+import json
+import time
+import textwrap
+
+from utils.systemctl import is_service_active
 
 logger = logging.getLogger(__name__)
+
+RHC_COLLECTOR = "/usr/libexec/rhc/rhc-collector"
+TIMER_CACHE_DIR = "/var/cache/rhc/collectors"
+
+MINIMAL_COLLECTOR_ID = "com.redhat.minimal"
+MINIMAL_COLLECTOR_NAME = "Minimal Host Inventory Collector"
+MINIMAL_COLLECTOR_CONFIG_PATH = "/usr/lib/rhc/collectors/com.redhat.minimal.toml"
+MINIMAL_TIMER_UNIT = f"rhc-collector-{MINIMAL_COLLECTOR_ID}.timer"
+MINIMAL_SERVICE_UNIT = f"rhc-collector-{MINIMAL_COLLECTOR_ID}.service"
+
+
+@pytest.fixture(scope="module")
+def rhc_server_socket():
+    """
+    Fixture to ensure rhc-server.socket is enabled and running before collector tests.
+    This is required for varlinkctl to communicate with the rhc-server.
+    """
+    socket_name = "rhc-server.socket"
+
+    was_active = is_service_active(socket_name)
+
+    if not was_active:
+        subprocess.run(
+            ["systemctl", "enable", "--now", socket_name],
+            check=True,
+            capture_output=True,
+        )
+
+    yield
+
+    if not was_active:
+        subprocess.run(
+            ["systemctl", "disable", "--now", socket_name],
+            check=False,
+            capture_output=True,
+        )
+
+
+@pytest.fixture
+def collector_config():
+    """
+    Fixture to create a test collector configuration and binary
+    that has NO systemd timer/service units.
+    Used by tests that need a collector without systemd units
+    (e.g. testing the 'missing timer' error path).
+    """
+    collector_config_dir = "/usr/lib/rhc/collectors"
+    collector_bin_dir = "/usr/libexec/rhc/collectors"
+    collector_id = "test.integration.collector"
+    collector_config_path = os.path.join(collector_config_dir, f"{collector_id}.toml")
+    collector_bin_path = os.path.join(collector_bin_dir, collector_id)
+
+    config_content = textwrap.dedent("""
+        [meta]
+        name = "Test Integration Collector"
+        feature = "analytics"
+        type = "ingress"
+
+        [ingress]
+        user = "root"
+        group = "root"
+        content_type = "application/vnd.redhat.test.collection"
+    """).strip()
+
+    collector_script = textwrap.dedent("""
+        #!/bin/bash
+        if [ "$1" = "collect" ]; then
+            echo "test data" > "test-output.txt"
+            exit 0
+        else
+            echo "Usage: $0 collect"
+            exit 1
+        fi
+    """).strip()
+
+    os.makedirs(collector_config_dir, exist_ok=True)
+    with open(collector_config_path, "w") as f:
+        f.write(config_content)
+
+    os.makedirs(collector_bin_dir, exist_ok=True)
+    with open(collector_bin_path, "w") as f:
+        f.write(collector_script)
+    os.chmod(collector_bin_path, 0o755)
+
+    yield {
+        "id": collector_id,
+        "name": "Test Integration Collector",
+        "config_path": collector_config_path,
+        "bin_path": collector_bin_path,
+    }
+
+    if os.path.exists(collector_config_path):
+        os.remove(collector_config_path)
+    if os.path.exists(collector_bin_path):
+        os.remove(collector_bin_path)
+
+
+@pytest.fixture
+def collector_minimal():
+    """
+    Fixture to create a minimal collector with only a config file.
+    No binary, no cache, no systemd units.
+    """
+    collector_dir = "/usr/lib/rhc/collectors"
+    os.makedirs(collector_dir, exist_ok=True)
+
+    collector_id = "test.collector1"
+    collector_name = "Test Minimal Collector"
+
+    config_path = os.path.join(collector_dir, f"{collector_id}.toml")
+    config_content = textwrap.dedent("""
+        [meta]
+        name = "Test Minimal Collector"
+        feature = "analytics"
+        type = "ingress"
+
+        [ingress]
+        user = "root"
+        group = "root"
+        content_type = "application/vnd.redhat.advisor.collection"
+    """).strip()
+
+    with open(config_path, "w") as f:
+        f.write(config_content)
+
+    yield {
+        "id": collector_id,
+        "name": collector_name,
+        "config_path": config_path,
+    }
+
+    if os.path.exists(config_path):
+        os.remove(config_path)
+
+
+@pytest.fixture
+def minimal_collector_timer_disabled():
+    """
+    Ensure the shipped com.redhat.minimal timer starts disabled for the test
+    and is restored to enabled + daemon-reloaded afterwards.
+    """
+    subprocess.run(
+        ["systemctl", "disable", "--now", MINIMAL_TIMER_UNIT],
+        check=False,
+        capture_output=True,
+    )
+    subprocess.run(["systemctl", "daemon-reload"], check=True)
+
+    yield
+
+    subprocess.run(
+        ["systemctl", "enable", "--now", MINIMAL_TIMER_UNIT],
+        check=False,
+        capture_output=True,
+    )
+    subprocess.run(["systemctl", "daemon-reload"], check=True)
+
+
+@pytest.fixture
+def minimal_collector_with_timing():
+    """
+    Enable the shipped com.redhat.minimal timer and seed a timer cache
+    so the collector has both next_run and last_run data.
+    """
+    cache_dir = TIMER_CACHE_DIR
+    os.makedirs(cache_dir, exist_ok=True)
+
+    cache_path = os.path.join(cache_dir, f"{MINIMAL_COLLECTOR_ID}.json")
+    last_finished_timestamp = int(time.time()) - 3600
+    last_started_timestamp = last_finished_timestamp - 30
+
+    cache_content = {
+        "last_started": {"timestamp": last_started_timestamp},
+        "last_finished": {"timestamp": last_finished_timestamp, "exit_code": 0},
+    }
+    with open(cache_path, "w") as f:
+        json.dump(cache_content, f)
+
+    subprocess.run(["systemctl", "daemon-reload"], check=True)
+    subprocess.run(
+        ["systemctl", "enable", "--now", MINIMAL_TIMER_UNIT],
+        check=True,
+    )
+
+    yield {
+        "id": MINIMAL_COLLECTOR_ID,
+        "name": MINIMAL_COLLECTOR_NAME,
+        "config_path": MINIMAL_COLLECTOR_CONFIG_PATH,
+        "cache_path": cache_path,
+        "last_run": last_finished_timestamp,
+    }
+
+    subprocess.run(
+        ["systemctl", "disable", "--now", MINIMAL_TIMER_UNIT],
+        check=False,
+    )
+    subprocess.run(["systemctl", "daemon-reload"], check=True)
+
+    if os.path.exists(cache_path):
+        os.remove(cache_path)
+
+
+@pytest.fixture
+def minimal_collector_timer_cache():
+    """
+    Fixture to create a timer cache for the shipped com.redhat.minimal collector.
+    """
+    cache_dir = TIMER_CACHE_DIR
+    os.makedirs(cache_dir, exist_ok=True)
+
+    cache_path = os.path.join(cache_dir, f"{MINIMAL_COLLECTOR_ID}.json")
+    last_run_timestamp = int(time.time()) - 3600
+
+    cache_content = {
+        "last_started": {"timestamp": last_run_timestamp - 30},
+        "last_finished": {"timestamp": last_run_timestamp, "exit_code": 0},
+    }
+    with open(cache_path, "w") as f:
+        json.dump(cache_content, f)
+
+    yield {"path": cache_path, "last_run": last_run_timestamp}
+
+    if os.path.exists(cache_path):
+        os.remove(cache_path)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/integration-tests/test_collector_api.py
+++ b/integration-tests/test_collector_api.py
@@ -7,311 +7,83 @@
 """
 
 import pytest
-import json
 import subprocess
-import os
 import time
-import textwrap
 
+from conftest import (
+    MINIMAL_COLLECTOR_ID,
+    MINIMAL_COLLECTOR_NAME,
+    MINIMAL_COLLECTOR_CONFIG_PATH,
+    MINIMAL_SERVICE_UNIT,
+    MINIMAL_TIMER_UNIT,
+)
 from utils.varlink import run_varlinkctl
-from utils.systemctl import is_service_active
+from utils.systemctl import get_timer_next_trigger
 
-RHC_COLLECTOR = "/usr/libexec/rhc/rhc-collector"
-TIMER_CACHE_DIR = "/var/cache/rhc/collectors"
-
-
-@pytest.fixture(scope="module")
-def rhc_server_socket():
-    """
-    Fixture to ensure rhc-server.socket is enabled and running before collector tests.
-    This is required for varlinkctl to communicate with the rhc-server.
-    """
-    socket_name = "rhc-server.socket"
-
-    # Check if socket is already active
-    was_active = is_service_active(socket_name)
-
-    if not was_active:
-        # Enable and start the socket
-        subprocess.run(
-            ["systemctl", "enable", "--now", socket_name],
-            check=True,
-            capture_output=True,
-        )
-
-    yield
-
-    # Cleanup: restore original state
-    if not was_active:
-        subprocess.run(
-            ["systemctl", "disable", "--now", socket_name],
-            check=False,
-            capture_output=True,
-        )
-
-
-# Ensure rhc_server_socket fixture is used for all tests in this module
 pytestmark = pytest.mark.usefixtures("rhc_server_socket")
 
 
-@pytest.fixture
-def collector_config():
-    """
-    Fixture to create a test collector configuration and binary.
-    """
-    collector_config_dir = "/usr/lib/rhc/collectors"
-    collector_bin_dir = "/usr/libexec/rhc/collectors"
-    collector_id = "test.integration.collector"
-    collector_config_path = os.path.join(collector_config_dir, f"{collector_id}.toml")
-    collector_bin_path = os.path.join(collector_bin_dir, collector_id)
-
-    config_content = textwrap.dedent("""
-        [meta]
-        name = "Test Integration Collector"
-        feature = "analytics"
-        type = "ingress"
-
-        [ingress]
-        user = "root"
-        group = "root"
-        content_type = "application/vnd.redhat.test.collection"
-    """).strip()
-
-    # Create a simple collector binary that accepts "collect" subcommand
-    collector_script = textwrap.dedent("""
-        #!/bin/bash
-        if [ "$1" = "collect" ]; then
-            # Create a simple test file in the current working directory
-            echo "test data" > "test-output.txt"
-            exit 0
-        else
-            echo "Usage: $0 collect"
-            exit 1
-        fi
-    """).strip()
-
-    # Create the collector config
-    os.makedirs(collector_config_dir, exist_ok=True)
-    with open(collector_config_path, "w") as f:
-        f.write(config_content)
-
-    # Create the collector binary
-    os.makedirs(collector_bin_dir, exist_ok=True)
-    with open(collector_bin_path, "w") as f:
-        f.write(collector_script)
-    os.chmod(collector_bin_path, 0o755)
-
-    yield {
-        "id": collector_id,
-        "name": "Test Integration Collector",
-        "config_path": collector_config_path,
-        "bin_path": collector_bin_path,
-    }
-
-    # Cleanup
-    if os.path.exists(collector_config_path):
-        os.remove(collector_config_path)
-    if os.path.exists(collector_bin_path):
-        os.remove(collector_bin_path)
-
-
-@pytest.fixture
-def collector_timer_cache(collector_config):
-    """
-    Fixture to create timer cache for the test collector.
-    """
-    timer_dir = "/var/cache/rhc/collectors"
-    collector_id = collector_config["id"]
-    timer_cache_path = os.path.join(timer_dir, f"{collector_id}.json")
-
-    # Create a timer cache with last run timestamp
-    last_run_timestamp = int(time.time()) - 3600  # 1 hour ago
-    cache_content = {
-        "last_started": {"timestamp": last_run_timestamp - 30},
-        "last_finished": {"timestamp": last_run_timestamp, "exit_code": 0},
-    }
-
-    os.makedirs(timer_dir, exist_ok=True)
-    with open(timer_cache_path, "w") as f:
-        json.dump(cache_content, f)
-
-    yield {"path": timer_cache_path, "last_run": last_run_timestamp}
-
-    # Cleanup
-    if os.path.exists(timer_cache_path):
-        os.remove(timer_cache_path)
-
-
 @pytest.mark.tier2
-def test_collector_list_method(collector_config):
-    """
-    :id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-    :title: Verify collector List method returns all collectors
-    :description:
-        Test that the com.redhat.rhc.collector.List method returns
-        a list of all available collectors with their details.
-    :tags: Tier 2
-    :steps:
-        1. Call com.redhat.rhc.collector.List via varlinkctl
-        2. Verify the response structure
-        3. Verify collectors array is returned
-        4. Verify each collector has required fields
-    :expectedresults:
-        1. The varlink call succeeds
-        2. Response contains "collectors" key
-        3. Collectors array contains CollectorInfo objects
-        4. Each collector has id, name, config_path, service_name, timer_name
-    """
-    response = run_varlinkctl("com.redhat.rhc.collector.List")
-
-    # Verify response structure
-    assert "collectors" in response
-    assert isinstance(response["collectors"], list)
-
-    # If collectors exist, verify their structure
-    if len(response["collectors"]) > 0:
-        for collector in response["collectors"]:
-            # Required fields
-            assert "id" in collector
-            assert "name" in collector
-            assert "config_path" in collector
-            assert "service_name" in collector
-            assert "timer_name" in collector
-
-            # Check types
-            assert isinstance(collector["id"], str)
-            assert isinstance(collector["name"], str)
-            assert isinstance(collector["config_path"], str)
-            assert isinstance(collector["service_name"], str)
-            assert isinstance(collector["timer_name"], str)
-
-            # Optional fields
-            if "feature" in collector:
-                assert collector["feature"] is None or isinstance(
-                    collector["feature"], str
-                )
-            if "last_run" in collector:
-                assert isinstance(collector["last_run"], int)
-            if "next_run" in collector:
-                assert isinstance(collector["next_run"], int)
-
-
-@pytest.mark.tier2
-def test_collector_info_method_with_test_collector(collector_config):
+def test_collector_info_method():
     """
     :id: b2c3d4e5-f6a7-8901-bcde-f12345678901
-    :title: Verify collector Info method returns details for a specific collector
+    :title: Verify collector Info method returns details for the shipped collector
     :description:
         Test that the com.redhat.rhc.collector.Info method returns
-        detailed information for a specific collector.
+        detailed information for the shipped com.redhat.minimal collector.
     :tags: Tier 2
     :steps:
-        1. Create a test collector configuration
-        2. Call com.redhat.rhc.collector.Info with the test collector ID
-        3. Verify the response structure
-        4. Verify collector details match configuration
+        1. Call com.redhat.rhc.collector.Info with the shipped collector ID
+        2. Verify the response structure
+        3. Verify collector details match the shipped configuration
     :expectedresults:
-        1. Test collector is created successfully
-        2. The varlink call succeeds
-        3. Response contains "info" key with CollectorInfo
-        4. Collector details match the test configuration
+        1. The varlink call succeeds
+        2. Response contains "info" key with CollectorInfo
+        3. Collector details match the shipped configuration
     """
-    collector_id = collector_config["id"]
+    response = run_varlinkctl(
+        "com.redhat.rhc.collector.Info", {"id": MINIMAL_COLLECTOR_ID}
+    )
 
-    response = run_varlinkctl("com.redhat.rhc.collector.Info", {"id": collector_id})
-
-    # Verify response structure
     assert "info" in response
     info = response["info"]
 
-    # Verify required fields match
-    assert info["id"] == collector_id
-    assert info["name"] == collector_config["name"]
-    assert info["config_path"] == collector_config["config_path"]
-    assert info["service_name"] == f"rhc-collector-{collector_id}.service"
-    assert info["timer_name"] == f"rhc-collector-{collector_id}.timer"
-
-    # Verify optional fields
+    assert info["id"] == MINIMAL_COLLECTOR_ID
+    assert info["name"] == MINIMAL_COLLECTOR_NAME
+    assert info["config_path"] == MINIMAL_COLLECTOR_CONFIG_PATH
+    assert info["service_name"] == MINIMAL_SERVICE_UNIT
+    assert info["timer_name"] == MINIMAL_TIMER_UNIT
     assert info.get("feature") == "analytics"
 
 
 @pytest.mark.tier2
-def test_collector_info_with_timer_cache(
-    collector_config, collector_timer_cache
-):
+def test_collector_info_with_timer_cache(minimal_collector_timer_cache):
     """
     :id: c3d4e5f6-a7b8-9012-cdef-123456789012
     :title: Verify collector Info includes timing information from cache
     :description:
         Test that the Info method returns last_run timestamp when
-        timer cache exists for the collector.
+        timer cache exists for the shipped collector.
     :tags: Tier 2
     :steps:
-        1. Create test collector configuration
-        2. Create timer cache with last run information
-        3. Call com.redhat.rhc.collector.Info
-        4. Verify last_run field is present and correct
+        1. Create timer cache with last run information for the shipped collector
+        2. Call com.redhat.rhc.collector.Info
+        3. Verify last_run field is present and correct
     :expectedresults:
-        1. Test collector and cache are created
+        1. Timer cache is created
         2. The varlink call succeeds
-        3. Response includes last_run field
-        4. last_run timestamp matches cache value
+        3. last_run timestamp matches cache value
     """
-    collector_id = collector_config["id"]
-    expected_last_run = collector_timer_cache["last_run"]
+    expected_last_run = minimal_collector_timer_cache["last_run"]
 
-    response = run_varlinkctl("com.redhat.rhc.collector.Info", {"id": collector_id})
+    response = run_varlinkctl(
+        "com.redhat.rhc.collector.Info", {"id": MINIMAL_COLLECTOR_ID}
+    )
 
     info = response["info"]
 
-    # Verify last_run is present and matches
     assert "last_run" in info
     assert info["last_run"] == expected_last_run
-
-
-@pytest.mark.tier2
-def test_rhc_collector_writes_timer_cache(collector_config, rhc):
-    """
-    :id: b3644f21-1f2c-429b-b0eb-686749213a6a
-    :title: Verify rhc-collector writes timer cache after execution
-    :description:
-        Test that running rhc-collector creates a timer cache file with
-        execution timing information.
-    :tags: Tier 2
-    :steps:
-        1. Create test collector configuration
-        2. Run rhc-collector with a simple command
-        3. Verify timer cache file is created with expected fields
-    :expectedresults:
-        1. Test collector is created
-        2. rhc-collector runs the command
-        3. Cache file contains last_started and last_finished timestamps
-    """
-    collector_id = collector_config["id"]
-    cache_path = os.path.join(TIMER_CACHE_DIR, f"{collector_id}.json")
-
-    os.makedirs("/var/tmp/rhc", exist_ok=True)
-    os.makedirs(TIMER_CACHE_DIR, exist_ok=True)
-    if os.path.exists(cache_path):
-        os.remove(cache_path)
-
-    try:
-        subprocess.run(
-            [RHC_COLLECTOR, "run", collector_id],
-            capture_output=True,
-            check=False,
-        )
-        assert os.path.exists(cache_path), "Timer cache file should be created"
-
-        with open(cache_path) as cache_file:
-            cache = json.load(cache_file)
-
-        assert "last_started" in cache
-        assert "last_finished" in cache
-        assert cache["last_finished"]["exit_code"] == 0
-    finally:
-        if os.path.exists(cache_path):
-            os.remove(cache_path)
 
 
 @pytest.mark.tier2
@@ -336,9 +108,7 @@ def test_collector_info_nonexistent_id():
         "com.redhat.rhc.collector.Info", {"id": nonexistent_id}, check=False
     )
 
-    # Should fail with non-zero exit code
     assert result.returncode != 0
-    # Error output should mention NoSuchCollector
     assert "NoSuchCollector" in result.stderr
 
 
@@ -374,329 +144,33 @@ def test_collector_info_malformed_id():
             "com.redhat.rhc.collector.Info", {"id": malformed_id}, check=False
         )
 
-        # Should fail with non-zero exit code
         assert result.returncode != 0, f"Expected failure for ID: {malformed_id}"
-        # Error output should mention InvalidParameter
         assert (
             "InvalidParameter" in result.stderr
         ), f"Expected InvalidParameter for ID: {malformed_id}, got: {result.stderr}"
 
 
 @pytest.mark.tier2
-def test_collector_list_includes_test_collector(collector_config):
-    """
-    :id: e5f6a7b8-c9d0-1234-ef01-23456789abcd
-    :title: Verify List method includes newly added collector
-    :description:
-        Test that when a new collector configuration is added,
-        it appears in the List method output.
-    :tags: Tier 2
-    :steps:
-        1. Create a test collector configuration
-        2. Call com.redhat.rhc.collector.List
-        3. Verify test collector appears in the list
-        4. Verify test collector has correct details
-    :expectedresults:
-        1. Test collector is created
-        2. List call succeeds
-        3. Test collector is in the returned list
-        4. Details match the configuration
-    """
-    collector_id = collector_config["id"]
-
-    response = run_varlinkctl("com.redhat.rhc.collector.List")
-
-    collectors = response["collectors"]
-
-    # Find our test collector in the list
-    test_collector = None
-    for collector in collectors:
-        if collector["id"] == collector_id:
-            test_collector = collector
-            break
-
-    # Verify test collector was found
-    assert (
-        test_collector is not None
-    ), f"Test collector {collector_id} not found in list"
-
-    # Verify details
-    assert test_collector["name"] == collector_config["name"]
-    assert test_collector["config_path"] == collector_config["config_path"]
-    assert test_collector.get("feature") == "analytics"
-
-
-@pytest.fixture
-def collector_with_timing():
-    """
-    Fixture to create a fully-featured collector with config, cache, and systemd units.
-    """
-    collector_dir = "/usr/lib/rhc/collectors"
-    cache_dir = "/var/cache/rhc/collectors"
-    systemd_dir = "/etc/systemd/system"
-
-    os.makedirs(collector_dir, exist_ok=True)
-    os.makedirs(cache_dir, exist_ok=True)
-
-    collector_id = "test.collector"
-    collector_name = "Red Hat Lightspeed Advisor"
-
-    # Create collector config
-    config_path = os.path.join(collector_dir, f"{collector_id}.toml")
-    config_content = textwrap.dedent("""
-        [meta]
-        name = "Red Hat Lightspeed Advisor"
-        feature = "analytics"
-        type = "ingress"
-
-        [ingress]
-        user = "root"
-        group = "root"
-        content_type = "application/vnd.redhat.advisor.collection"
-    """).strip()
-
-    with open(config_path, "w") as f:
-        f.write(config_content)
-
-    # Create timer cache
-    cache_path = os.path.join(cache_dir, f"{collector_id}.json")
-    last_finished_timestamp = int(time.time()) - 3600  # 1 hour ago
-    last_started_timestamp = last_finished_timestamp - 30  # Started 30 seconds before finish
-
-    cache_content = {
-        "last_started": {"timestamp": last_started_timestamp},
-        "last_finished": {"timestamp": last_finished_timestamp, "exit_code": 0},
-    }
-
-    with open(cache_path, "w") as f:
-        json.dump(cache_content, f)
-
-    # Create systemd timer and service
-    timer_path = os.path.join(systemd_dir, f"rhc-collector-{collector_id}.timer")
-    service_path = os.path.join(systemd_dir, f"rhc-collector-{collector_id}.service")
-
-    timer_content = textwrap.dedent("""
-        [Unit]
-        Description=RHC Test Collector Timer
-        Documentation=https://github.com/RedHatInsights/rhc
-
-        [Timer]
-        OnCalendar=hourly
-        Persistent=true
-
-        [Install]
-        WantedBy=timers.target
-    """).strip()
-
-    service_content = textwrap.dedent("""
-        [Unit]
-        Description=RHC Test Collector Service
-        Documentation=https://github.com/RedHatInsights/rhc
-
-        [Service]
-        Type=oneshot
-        ExecStart=/bin/true
-    """).strip()
-
-    with open(timer_path, "w") as f:
-        f.write(timer_content)
-
-    with open(service_path, "w") as f:
-        f.write(service_content)
-
-    # Enable and start the timer
-    subprocess.run(["systemctl", "daemon-reload"], check=True)
-    subprocess.run(
-        ["systemctl", "enable", "--now", f"rhc-collector-{collector_id}.timer"],
-        check=True,
-    )
-
-    yield {
-        "id": collector_id,
-        "name": collector_name,
-        "config_path": config_path,
-        "cache_path": cache_path,
-        "timer_path": timer_path,
-        "service_path": service_path,
-        "last_run": last_finished_timestamp,
-    }
-
-    # Cleanup
-    subprocess.run(
-        ["systemctl", "disable", "--now", f"rhc-collector-{collector_id}.timer"],
-        check=False,
-    )
-
-    for path in [timer_path, service_path]:
-        if os.path.exists(path):
-            os.remove(path)
-
-    subprocess.run(["systemctl", "daemon-reload"], check=True)
-
-    if os.path.exists(config_path):
-        os.remove(config_path)
-
-    if os.path.exists(cache_path):
-        os.remove(cache_path)
-
-
-@pytest.fixture
-def collector_minimal():
-    """
-    Fixture to create a minimal collector with only a config file.
-    """
-    collector_dir = "/usr/lib/rhc/collectors"
-    os.makedirs(collector_dir, exist_ok=True)
-
-    collector_id = "test.collector1"
-    collector_name = "Red Hat Lightspeed Advisor"
-
-    config_path = os.path.join(collector_dir, f"{collector_id}.toml")
-    config_content = textwrap.dedent("""
-        [meta]
-        name = "Red Hat Lightspeed Advisor"
-        feature = "analytics"
-        type = "ingress"
-
-        [ingress]
-        user = "root"
-        group = "root"
-        content_type = "application/vnd.redhat.advisor.collection"
-    """).strip()
-
-    with open(config_path, "w") as f:
-        f.write(config_content)
-
-    yield {
-        "id": collector_id,
-        "name": collector_name,
-        "config_path": config_path,
-    }
-
-    # Cleanup
-    if os.path.exists(config_path):
-        os.remove(config_path)
-
-
-@pytest.fixture
-def multiple_test_collectors(collector_with_timing, collector_minimal):
-    """
-    Fixture that combines a fully-featured collector and a minimal collector.
-    Simulates real-world scenarios with varied collector configurations.
-    """
-    return {
-        "collector1": collector_with_timing,
-        "collector2": collector_minimal,
-    }
-
-
-@pytest.mark.tier2
-def test_collector_list_with_multiple_collectors(multiple_test_collectors):
-    """
-    :id: f6a7b8c9-d0e1-2345-f012-3456789abcde
-    :title: Verify List method with multiple collectors and varied configurations
-    :description:
-        Test the com.redhat.rhc.collector.List method with multiple collectors
-        where one has cache/timer data and one does not, simulating real-world scenarios.
-    :tags: Tier 2
-    :steps:
-        1. Create two test collectors
-        2. Create cache and systemd timer/service for first collector
-        3. Enable and start the timer
-        4. Call com.redhat.rhc.collector.List
-        5. Verify both collectors appear in the list
-        6. Verify first collector has last_run and next_run fields
-        7. Verify second collector does not have last_run or next_run
-    :expectedresults:
-        1. Both collectors are created
-        2. Timer is enabled and started successfully
-        3. List call succeeds
-        4. Both collectors appear in the list
-        5. Collector with cache shows last_run timestamp
-        6. Collector with timer shows next_run timestamp
-        7. Collector without cache/timer has no timing fields
-    """
-    collector1_info = multiple_test_collectors["collector1"]
-    collector2_info = multiple_test_collectors["collector2"]
-
-    response = run_varlinkctl("com.redhat.rhc.collector.List")
-
-    assert "collectors" in response
-    collectors = response["collectors"]
-
-    # Find both collectors in the list
-    collector1_data = None
-    collector2_data = None
-
-    for collector in collectors:
-        if collector["id"] == collector1_info["id"]:
-            collector1_data = collector
-        elif collector["id"] == collector2_info["id"]:
-            collector2_data = collector
-
-    # Verify both collectors were found
-    assert collector1_data is not None, f"Collector {collector1_info['id']} not found"
-    assert collector2_data is not None, f"Collector {collector2_info['id']} not found"
-
-    # Verify collector1 (with cache and timer)
-    assert collector1_data["name"] == collector1_info["name"]
-    assert collector1_data["config_path"] == collector1_info["config_path"]
-    assert collector1_data["feature"] == "analytics"
-    assert (
-        collector1_data["service_name"]
-        == f"rhc-collector-{collector1_info['id']}.service"
-    )
-    assert (
-        collector1_data["timer_name"] == f"rhc-collector-{collector1_info['id']}.timer"
-    )
-
-    # Verify last_run is present and matches cache
-    assert "last_run" in collector1_data
-    assert collector1_data["last_run"] == collector1_info["last_run"]
-
-    # Verify next_run is present (timer is enabled)
-    assert "next_run" in collector1_data
-    assert isinstance(collector1_data["next_run"], int)
-    assert collector1_data["next_run"] > 0
-
-    # Verify collector2 (without cache and timer)
-    assert collector2_data["name"] == collector2_info["name"]
-    assert collector2_data["config_path"] == collector2_info["config_path"]
-    assert collector2_data["feature"] == "analytics"
-    assert (
-        collector2_data["service_name"]
-        == f"rhc-collector-{collector2_info['id']}.service"
-    )
-    assert (
-        collector2_data["timer_name"] == f"rhc-collector-{collector2_info['id']}.timer"
-    )
-
-    # Verify last_run and next_run are not present (no cache, no timer)
-    assert "last_run" not in collector2_data or collector2_data.get("last_run") is None
-    assert "next_run" not in collector2_data or collector2_data.get("next_run") is None
-
-
-@pytest.mark.tier2
-def test_collector_info_with_systemd_timer(multiple_test_collectors):
+def test_collector_info_with_systemd_timer(minimal_collector_with_timing):
     """
     :id: a7b8c9d0-e1f2-3456-0123-456789abcdef
     :title: Verify Info method returns next_run from systemd timer
     :description:
         Test that the com.redhat.rhc.collector.Info method returns next_run
-        timestamp when a systemd timer is enabled for the collector.
+        timestamp when the shipped collector's systemd timer is enabled.
     :tags: Tier 2
     :steps:
-        1. Create test collector with systemd timer and service
-        2. Enable and start the timer
-        3. Call com.redhat.rhc.collector.Info
-        4. Verify next_run field is present and valid
+        1. Enable the shipped collector's timer and seed cache
+        2. Call com.redhat.rhc.collector.Info
+        3. Verify next_run field is present and valid
+        4. Verify last_run from cache
     :expectedresults:
-        1. Collector and timer are created
-        2. Timer is enabled successfully
-        3. Info call succeeds
-        4. next_run field contains valid future timestamp
+        1. Timer is enabled and cache is seeded
+        2. Info call succeeds
+        3. next_run field contains valid future timestamp
+        4. last_run matches the seeded cache value
     """
-    collector_info = multiple_test_collectors["collector1"]
+    collector_info = minimal_collector_with_timing
 
     response = run_varlinkctl(
         "com.redhat.rhc.collector.Info", {"id": collector_info["id"]}
@@ -705,22 +179,19 @@ def test_collector_info_with_systemd_timer(multiple_test_collectors):
     assert "info" in response
     info = response["info"]
 
-    # Verify basic fields
     assert info["id"] == collector_info["id"]
     assert info["name"] == collector_info["name"]
 
-    # Verify next_run is present from systemd timer
     assert "next_run" in info
     assert isinstance(info["next_run"], int)
     assert info["next_run"] > 0
 
-    # Verify last_run from cache
     assert "last_run" in info
     assert info["last_run"] == collector_info["last_run"]
 
 
 @pytest.mark.tier2
-def test_collector_info_without_cache_or_timer(multiple_test_collectors):
+def test_collector_info_without_cache_or_timer(collector_minimal):
     """
     :id: b8c9d0e1-f2a3-4567-1234-56789abcdef0
     :title: Verify Info method for collector without cache or timer
@@ -739,7 +210,7 @@ def test_collector_info_without_cache_or_timer(multiple_test_collectors):
         3. Basic fields (id, name, config_path, etc.) are correct
         4. last_run and next_run are not present
     """
-    collector_info = multiple_test_collectors["collector2"]
+    collector_info = collector_minimal
 
     response = run_varlinkctl(
         "com.redhat.rhc.collector.Info", {"id": collector_info["id"]}
@@ -748,7 +219,6 @@ def test_collector_info_without_cache_or_timer(multiple_test_collectors):
     assert "info" in response
     info = response["info"]
 
-    # Verify basic fields
     assert info["id"] == collector_info["id"]
     assert info["name"] == collector_info["name"]
     assert info["config_path"] == collector_info["config_path"]
@@ -756,13 +226,12 @@ def test_collector_info_without_cache_or_timer(multiple_test_collectors):
     assert info["timer_name"] == f"rhc-collector-{collector_info['id']}.timer"
     assert info.get("feature") == "analytics"
 
-    # Verify timing fields are not present
     assert "last_run" not in info or info.get("last_run") is None
     assert "next_run" not in info or info.get("next_run") is None
 
 
 @pytest.mark.tier2
-def test_collector_info_multiple_calls_consistency(multiple_test_collectors):
+def test_collector_info_multiple_calls_consistency(minimal_collector_with_timing):
     """
     :id: c9d0e1f2-a3b4-5678-2345-6789abcdef01
     :title: Verify Info method returns consistent data across multiple calls
@@ -771,17 +240,16 @@ def test_collector_info_multiple_calls_consistency(multiple_test_collectors):
         returns consistent data.
     :tags: Tier 2
     :steps:
-        1. Create test collector with cache and timer
+        1. Enable the shipped collector's timer and seed cache
         2. Call com.redhat.rhc.collector.Info multiple times
         3. Verify all responses are identical
     :expectedresults:
-        1. Collector is created
+        1. Collector timer is enabled and cache is seeded
         2. All Info calls succeed
         3. All responses contain the same data
     """
-    collector_info = multiple_test_collectors["collector1"]
+    collector_info = minimal_collector_with_timing
 
-    # Call Info method three times
     responses = []
     for _ in range(3):
         response = run_varlinkctl(
@@ -789,9 +257,7 @@ def test_collector_info_multiple_calls_consistency(multiple_test_collectors):
         )
         responses.append(response["info"])
 
-    # Verify all responses are identical
     for i in range(1, len(responses)):
-        # Compare all fields except next_run (which might change)
         for key in [
             "id",
             "name",
@@ -804,3 +270,215 @@ def test_collector_info_multiple_calls_consistency(multiple_test_collectors):
             assert responses[0].get(key) == responses[i].get(
                 key
             ), f"Field {key} differs between calls"
+
+
+@pytest.mark.tier2
+def test_collector_list_method():
+    """
+    :id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+    :title: Verify collector List method returns all collectors
+    :description:
+        Test that the com.redhat.rhc.collector.List method returns
+        a list of all available collectors with their details.
+        The shipped com.redhat.minimal collector is always present.
+    :tags: Tier 2
+    :steps:
+        1. Call com.redhat.rhc.collector.List via varlinkctl
+        2. Verify the response structure
+        3. Verify collectors array is returned
+        4. Verify each collector has required fields
+    :expectedresults:
+        1. The varlink call succeeds
+        2. Response contains "collectors" key
+        3. Collectors array contains CollectorInfo objects
+        4. Each collector has id, name, config_path, service_name, timer_name
+    """
+    response = run_varlinkctl("com.redhat.rhc.collector.List")
+
+    assert "collectors" in response
+    assert isinstance(response["collectors"], list)
+    assert len(response["collectors"]) > 0
+
+    for collector in response["collectors"]:
+        assert "id" in collector
+        assert "name" in collector
+        assert "config_path" in collector
+        assert "service_name" in collector
+        assert "timer_name" in collector
+
+        assert isinstance(collector["id"], str)
+        assert isinstance(collector["name"], str)
+        assert isinstance(collector["config_path"], str)
+        assert isinstance(collector["service_name"], str)
+        assert isinstance(collector["timer_name"], str)
+
+        if "feature" in collector:
+            assert collector["feature"] is None or isinstance(
+                collector["feature"], str
+            )
+        if "last_run" in collector:
+            assert isinstance(collector["last_run"], int)
+        if "next_run" in collector:
+            assert isinstance(collector["next_run"], int)
+
+
+@pytest.mark.tier2
+def test_collector_list_includes_minimal_collector():
+    """
+    :id: 3b86be46-2add-4eeb-992e-6b89f9ce1cb6
+    :title: Verify List method includes the shipped collector
+    :description:
+        Test that the shipped com.redhat.minimal collector appears
+        in the List method output with correct details.
+    :tags: Tier 2
+    :steps:
+        1. Call com.redhat.rhc.collector.List
+        2. Verify the shipped collector appears in the list
+        3. Verify the collector has correct details
+    :expectedresults:
+        1. List call succeeds
+        2. Shipped collector is in the returned list
+        3. Details match the shipped configuration
+    """
+    response = run_varlinkctl("com.redhat.rhc.collector.List")
+
+    collectors = response["collectors"]
+
+    shipped_collector = None
+    for collector in collectors:
+        if collector["id"] == MINIMAL_COLLECTOR_ID:
+            shipped_collector = collector
+            break
+
+    assert (
+        shipped_collector is not None
+    ), f"Shipped collector {MINIMAL_COLLECTOR_ID} not found in list"
+
+    assert shipped_collector["name"] == MINIMAL_COLLECTOR_NAME
+    assert shipped_collector["config_path"] == MINIMAL_COLLECTOR_CONFIG_PATH
+    assert shipped_collector.get("feature") == "analytics"
+
+
+@pytest.mark.tier2
+def test_collector_list_with_multiple_collectors(
+    minimal_collector_with_timing, collector_minimal
+):
+    """
+    :id: f6a7b8c9-d0e1-2345-f012-3456789abcde
+    :title: Verify List method with multiple collectors and varied configurations
+    :description:
+        Test the com.redhat.rhc.collector.List method with the shipped
+        com.redhat.minimal collector (with cache and active timer) and
+        a minimal test collector (without cache or timer).
+    :tags: Tier 2
+    :steps:
+        1. Enable timer and seed cache for the shipped collector
+        2. Create a minimal test collector with config only
+        3. Call com.redhat.rhc.collector.List
+        4. Verify both collectors appear in the list
+        5. Verify the shipped collector has last_run and next_run fields
+        6. Verify the minimal collector does not have last_run or next_run
+    :expectedresults:
+        1. Timer is enabled and cache is seeded
+        2. Minimal collector is created
+        3. List call succeeds
+        4. Both collectors appear in the list
+        5. Shipped collector with cache shows last_run and next_run
+        6. Minimal collector without cache/timer has no timing fields
+    """
+    collector1_info = minimal_collector_with_timing
+    collector2_info = collector_minimal
+
+    response = run_varlinkctl("com.redhat.rhc.collector.List")
+
+    assert "collectors" in response
+    collectors = response["collectors"]
+
+    collector1_data = None
+    collector2_data = None
+
+    for collector in collectors:
+        if collector["id"] == collector1_info["id"]:
+            collector1_data = collector
+        elif collector["id"] == collector2_info["id"]:
+            collector2_data = collector
+
+    assert collector1_data is not None, f"Collector {collector1_info['id']} not found"
+    assert collector2_data is not None, f"Collector {collector2_info['id']} not found"
+
+    assert collector1_data["name"] == collector1_info["name"]
+    assert collector1_data["config_path"] == collector1_info["config_path"]
+    assert collector1_data["feature"] == "analytics"
+    assert collector1_data["service_name"] == MINIMAL_SERVICE_UNIT
+    assert collector1_data["timer_name"] == MINIMAL_TIMER_UNIT
+
+    assert "last_run" in collector1_data
+    assert collector1_data["last_run"] == collector1_info["last_run"]
+
+    assert "next_run" in collector1_data
+    assert isinstance(collector1_data["next_run"], int)
+    assert collector1_data["next_run"] > 0
+
+    assert collector2_data["name"] == collector2_info["name"]
+    assert collector2_data["config_path"] == collector2_info["config_path"]
+    assert collector2_data["feature"] == "analytics"
+    assert (
+        collector2_data["service_name"]
+        == f"rhc-collector-{collector2_info['id']}.service"
+    )
+    assert (
+        collector2_data["timer_name"] == f"rhc-collector-{collector2_info['id']}.timer"
+    )
+
+    assert "last_run" not in collector2_data or collector2_data.get("last_run") is None
+    assert "next_run" not in collector2_data or collector2_data.get("next_run") is None
+
+
+@pytest.mark.tier2
+def test_collector_next_run_matches_systemctl(minimal_collector_timer_disabled):
+    """
+    :id: f2a3b4c5-d6e7-8901-2cde-f01234567890
+    :title: Verify next_run in Info matches systemctl timer schedule
+    :description:
+        Test that the ``next_run`` timestamp returned by the varlink
+        ``Info`` method matches the next trigger time reported by
+        ``systemctl list-timers`` within an acceptable tolerance.
+    :tags: Tier 2
+    :steps:
+        1. Enable the minimal collector timer via CLI
+        2. Query collector Info via varlinkctl
+        3. Query ``systemctl list-timers`` for the same timer
+        4. Verify both next trigger timestamps match (within tolerance)
+    :expectedresults:
+        1. Timer is enabled and running
+        2. Info response contains ``next_run``
+        3. ``systemctl list-timers`` reports a next trigger
+        4. Timestamps are within 60 seconds of each other
+    """
+    result = subprocess.run(
+        ["rhc", "collector", "enable", MINIMAL_COLLECTOR_ID],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"enable failed: {result.stderr}"
+
+    time.sleep(1)
+
+    response = run_varlinkctl(
+        "com.redhat.rhc.collector.Info", {"id": MINIMAL_COLLECTOR_ID}
+    )
+    info = response["info"]
+    assert "next_run" in info, "Info response should contain next_run"
+    assert isinstance(info["next_run"], int)
+    varlink_next_run = info["next_run"]
+
+    systemctl_next_run = get_timer_next_trigger(MINIMAL_TIMER_UNIT)
+    assert systemctl_next_run is not None, (
+        f"systemctl list-timers should report a next trigger for {MINIMAL_TIMER_UNIT}"
+    )
+
+    diff = abs(varlink_next_run - systemctl_next_run)
+    assert diff <= 60, (
+        f"next_run mismatch: varlink={varlink_next_run}, "
+        f"systemctl={systemctl_next_run}, diff={diff}s (tolerance=60s)"
+    )

--- a/integration-tests/test_collector_cli.py
+++ b/integration-tests/test_collector_cli.py
@@ -1,0 +1,156 @@
+"""
+:casecomponent: rhc
+:requirement: RHSS-XXXXX
+:subsystemteam: rhel-sst-csi-client-tools
+:caseautomation: Automated
+:upstream: Yes
+"""
+
+import pytest
+import json
+import subprocess
+import os
+
+from conftest import (
+    RHC_COLLECTOR,
+    TIMER_CACHE_DIR,
+    MINIMAL_COLLECTOR_ID,
+    MINIMAL_TIMER_UNIT,
+)
+from utils.systemctl import is_unit_enabled
+
+pytestmark = pytest.mark.usefixtures("rhc_server_socket")
+
+
+@pytest.mark.tier2
+def test_rhc_collector_writes_timer_cache(collector_config):
+    """
+    :id: b3644f21-1f2c-429b-b0eb-686749213a6a
+    :title: Verify rhc-collector writes timer cache after execution
+    :description:
+        Test that running rhc-collector creates a timer cache file with
+        execution timing information.
+    :tags: Tier 2
+    :steps:
+        1. Create test collector configuration
+        2. Run rhc-collector with a simple command
+        3. Verify timer cache file is created with expected fields
+    :expectedresults:
+        1. Test collector is created
+        2. rhc-collector runs the command
+        3. Cache file contains last_started and last_finished timestamps
+    """
+    collector_id = collector_config["id"]
+    cache_path = os.path.join(TIMER_CACHE_DIR, f"{collector_id}.json")
+
+    os.makedirs("/var/tmp/rhc", exist_ok=True)
+    os.makedirs(TIMER_CACHE_DIR, exist_ok=True)
+    if os.path.exists(cache_path):
+        os.remove(cache_path)
+
+    try:
+        subprocess.run(
+            [RHC_COLLECTOR, "run", collector_id],
+            capture_output=True,
+            check=False,
+        )
+        assert os.path.exists(cache_path), "Timer cache file should be created"
+
+        with open(cache_path) as cache_file:
+            cache = json.load(cache_file)
+
+        assert "last_started" in cache
+        assert "last_finished" in cache
+        assert cache["last_finished"]["exit_code"] == 0
+    finally:
+        if os.path.exists(cache_path):
+            os.remove(cache_path)
+
+
+@pytest.mark.tier2
+def test_collector_enable_disable_via_cli(minimal_collector_timer_disabled):
+    """
+    :id: d0e1f2a3-b4c5-6789-0abc-def012345678
+    :title: Verify enable/disable via CLI updates systemd timer state
+    :description:
+        Test that ``rhc collector enable`` enables the systemd timer and
+        ``rhc collector disable`` disables it again, using the shipped
+        com.redhat.minimal collector.
+    :tags: Tier 2
+    :steps:
+        1. Ensure the minimal collector timer starts disabled
+        2. Run ``rhc collector enable com.redhat.minimal``
+        3. Verify the timer is enabled via systemctl
+        4. Run ``rhc collector disable com.redhat.minimal``
+        5. Verify the timer is disabled via systemctl
+    :expectedresults:
+        1. Timer is initially disabled
+        2. ``rhc collector enable`` succeeds
+        3. ``systemctl is-enabled`` reports enabled
+        4. ``rhc collector disable`` succeeds
+        5. ``systemctl is-enabled`` reports disabled
+    """
+    assert not is_unit_enabled(MINIMAL_TIMER_UNIT), "Timer should start disabled"
+
+    result = subprocess.run(
+        ["rhc", "collector", "enable", MINIMAL_COLLECTOR_ID],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"enable failed: {result.stderr}"
+    assert is_unit_enabled(MINIMAL_TIMER_UNIT), (
+        "Timer should be enabled after 'rhc collector enable'"
+    )
+
+    result = subprocess.run(
+        ["rhc", "collector", "disable", MINIMAL_COLLECTOR_ID],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"disable failed: {result.stderr}"
+    assert not is_unit_enabled(MINIMAL_TIMER_UNIT), (
+        "Timer should be disabled after 'rhc collector disable'"
+    )
+
+
+@pytest.mark.tier2
+def test_collector_enable_missing_timer(collector_config):
+    """
+    :id: e1f2a3b4-c5d6-7890-1bcd-ef0123456789
+    :title: Verify enable fails with actionable message when timer unit is missing
+    :description:
+        Test that ``rhc collector enable`` returns a non-zero exit code and
+        an actionable error message when the systemd timer unit does not
+        exist on disk.  Uses a test collector that has a config
+        but no systemd units.
+    :tags: Tier 2
+    :steps:
+        1. Create a collector config (no systemd timer/service units)
+        2. Run ``rhc collector enable ID``
+        3. Verify the command fails with non-zero exit code
+        4. Verify output contains an actionable error about the missing timer
+    :expectedresults:
+        1. Collector config is created
+        2. ``rhc collector enable`` fails
+        3. Exit code is non-zero
+        4. Output mentions the missing timer or failure to enable
+    """
+    collector_id = collector_config["id"]
+
+    result = subprocess.run(
+        ["rhc", "collector", "enable", collector_id],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0, "enable should fail when timer unit is missing"
+
+    combined_output = result.stdout + result.stderr
+    assert any(
+        phrase in combined_output.lower()
+        for phrase in [
+            "does not exist",
+            "failed to enable timer",
+            "need to be installed",
+        ]
+    ), f"Expected actionable error about missing timer, got: {combined_output}"

--- a/integration-tests/test_socket_activated_service.py
+++ b/integration-tests/test_socket_activated_service.py
@@ -11,7 +11,7 @@ import pytest
 from utils.varlink import run_varlinkctl
 from utils.systemctl import (
     is_service_active,
-    is_socket_enabled,
+    is_unit_enabled,
     stop_service,
     enable_and_start_socket,
     disable_and_stop_socket,
@@ -27,7 +27,7 @@ def fd3_socket_setup():
     socket_name = "rhc-server.socket"
     service_name = "rhc-server.service"
 
-    socket_was_enabled = is_socket_enabled(socket_name)
+    socket_was_enabled = is_unit_enabled(socket_name)
 
     if not socket_was_enabled:
         enable_and_start_socket(socket_name)

--- a/integration-tests/utils/systemctl.py
+++ b/integration-tests/utils/systemctl.py
@@ -5,6 +5,7 @@ This module provides helper functions for managing systemd services, sockets,
 and units using systemctl commands.
 """
 
+import json
 import subprocess
 
 
@@ -35,18 +36,19 @@ def stop_service(service_name: str) -> None:
     )
 
 
-def is_socket_enabled(socket_name: str) -> bool:
+def is_unit_enabled(unit_name: str) -> bool:
     """
-    Check if a systemd socket is enabled.
+    Check if a systemd unit (timer, socket, service, etc.) is enabled.
 
-    :param socket_name: Name of the systemd socket
-    :return: True if the socket is enabled, False otherwise
+    :param unit_name: Name of the systemd unit
+    :return: True if the unit is enabled, False otherwise
     """
     result = subprocess.run(
-        ["systemctl", "is-enabled", socket_name],
+        ["systemctl", "is-enabled", unit_name],
         capture_output=True,
+        text=True,
     )
-    return result.returncode == 0
+    return result.stdout.strip() == "enabled"
 
 
 def enable_and_start_socket(socket_name: str) -> None:
@@ -72,3 +74,26 @@ def disable_and_stop_socket(socket_name: str) -> None:
         ["systemctl", "disable", "--now", socket_name],
         capture_output=True,
     )
+
+
+def get_timer_next_trigger(timer_unit: str):
+    """
+    Return the next trigger time for *timer_unit* as a Unix timestamp (int),
+    or None if the timer is not scheduled.
+
+    :param timer_unit: Name of the systemd timer unit
+    :return: Unix timestamp (seconds) or None
+    """
+    result = subprocess.run(
+        ["systemctl", "list-timers", timer_unit, "--all", "--output=json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    timers = json.loads(result.stdout)
+    if not timers:
+        return None
+    next_us = timers[0].get("next")
+    if next_us and next_us > 0:
+        return next_us // 1_000_000
+    return None


### PR DESCRIPTION
* Card ID: CCT-2713
    
Replace is_socket_enabled and is_timer_enabled with a single
is_unit_enabled helper. Migrate collector API tests to use the shipped
com.redhat.minimal collector instead of generating configs, binaries,
and systemd units from scratch. Add integration tests for CLI
enable/disable, missing timer error, and next_run cross-check against
systemctl.
    
It also splits test_collector_api.py into three focused modules:
- test_collector_api.py: varlink api calls are made
- test_collector_cli.py: rhc collector CLI tests