### PR TITLE
test: Added integration tests for content override Varlink API

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -56,7 +56,7 @@ jobs:
       - name: "Install test dependencies"
         run: |
           dnf --setopt install_weak_deps=False install -y \
-            subscription-manager rhc python3-behave openssl curl \
+            subscription-manager python3-behave openssl curl \
             python3-jsonschema dbus-daemon
 
       - name: "Install built RPMs"

--- a/cmd/rhc-server/rhsm.go
+++ b/cmd/rhc-server/rhsm.go
@@ -87,6 +87,10 @@ func UploadContentOverrides(ipcSender *string, locale *string, correlationID *st
 		return &ServerError{Message: fmt.Sprintf("failed to read local DNF5 repo overrides: %s", err)}
 	}
 
+	if len(overrides) == 0 {
+		return nil
+	}
+
 	clientInfo := rhsm2.RequestMetadata{IPCSender: ipcSender, Locale: locale, CorrelationId: correlationID}
 	if err := rhsmClient.SendContentOverrides(overrides, &clientInfo); err != nil {
 		return &ServerError{Message: err.Error()}

--- a/features/com.redhat.rhsm.testing.content.override.feature
+++ b/features/com.redhat.rhsm.testing.content.override.feature
@@ -1,0 +1,108 @@
+Feature: The Varlink interface com.redhat.rhsm.testing.content.override
+  The Varlink interface com.redhat.rhsm.testing.content.override provides
+  methods for downloading content overrides from the candlepin server and
+  uploading local DNF5 repo overrides to the server.
+
+
+  Scenario: Download() method raises error on unregistered system
+    Given system is not registered
+    When varlink method is called and error is expected
+      | method   | interface                                | arguments |
+      | Download | com.redhat.rhsm.testing.content.override | '{}'      |
+    Then varlink error is raised
+      """
+      com.redhat.rhsm.testing.content.override.SystemNotRegistered
+      """
+
+
+  Scenario: Upload() method raises error on unregistered system
+    Given system is not registered
+    When varlink method is called and error is expected
+      | method | interface                                | arguments |
+      | Upload | com.redhat.rhsm.testing.content.override | '{}'      |
+    Then varlink error is raised
+      """
+      com.redhat.rhsm.testing.content.override.SystemNotRegistered
+      """
+
+
+  Scenario: Download() method returns content overrides on registered system
+    Given system is registered against candlepin server
+    When varlink method is called
+      | method   | interface                                | arguments |
+      | Download | com.redhat.rhsm.testing.content.override | '{}'      |
+    Then method call was successful
+    And method returned JSON compliant with 'com.redhat.rhsm.testing.content.override.Download.json' schema
+
+
+  Scenario: Download() method returns content overrides on registered system with metadata
+    Given system is registered against candlepin server
+    When varlink method is called
+      | method   | interface                                | arguments                                        |
+      | Download | com.redhat.rhsm.testing.content.override | '{"metadata": {"user_agent": "foo"}}' |
+    Then method call was successful
+    And method returned JSON compliant with 'com.redhat.rhsm.testing.content.override.Download.json' schema
+
+
+  @fixture.dnf5_override
+  Scenario: Upload() method uploads local overrides on registered system
+    Given system is registered against candlepin server
+    And local DNF5 repo override file exists with content
+      """
+      [test-override-repo]
+      enabled = 1
+      """
+    When varlink method is called
+      | method | interface                                | arguments |
+      | Upload | com.redhat.rhsm.testing.content.override | '{}'      |
+    Then varlink method returns
+      """
+      {"success":true}
+      """
+
+
+  @fixture.dnf5_override
+  Scenario: Upload() then Download() round-trip preserves overrides
+    Given system is registered against candlepin server
+    And local DNF5 repo override file exists with content
+      """
+      [test-roundtrip-repo]
+      enabled = 1
+      gpgcheck = 0
+      """
+    When varlink method is called
+      | method | interface                                | arguments |
+      | Upload | com.redhat.rhsm.testing.content.override | '{}'      |
+    Then method call was successful
+    When varlink method is called
+      | method   | interface                                | arguments |
+      | Download | com.redhat.rhsm.testing.content.override | '{}'      |
+    Then method call was successful
+    And downloaded content overrides contain label 'test-roundtrip-repo'
+
+
+  @fixture.dnf5_override
+  Scenario: Upload() succeeds with empty override file on registered system
+    Given system is registered against candlepin server
+    And local DNF5 repo override file is empty
+    When varlink method is called
+      | method | interface                                | arguments |
+      | Upload | com.redhat.rhsm.testing.content.override | '{}'      |
+    Then varlink method returns
+      """
+      {"success":true}
+      """
+
+
+  Scenario: Download() returns consistent results across multiple calls
+    Given system is registered against candlepin server
+    When varlink method is called
+      | method   | interface                                | arguments |
+      | Download | com.redhat.rhsm.testing.content.override | '{}'      |
+    Then method call was successful
+    And method result is saved as 'first_download'
+    When varlink method is called
+      | method   | interface                                | arguments |
+      | Download | com.redhat.rhsm.testing.content.override | '{}'      |
+    Then method call was successful
+    And method result matches saved 'first_download'

--- a/features/com.redhat.rhsm.testing.content.override.feature
+++ b/features/com.redhat.rhsm.testing.content.override.feature
@@ -1,0 +1,108 @@
+Feature: The Varlink interface com.redhat.rhsm.testing.content.override
+  The Varlink interface com.redhat.rhsm.testing.content.override provides
+  methods for downloading content overrides from the candlepin server and
+  uploading local DNF5 repo overrides to the server.
+
+
+  Scenario: Download() method raises error on unregistered system
+    Given system is not registered
+    When varlink method is called and error is expected
+      | method   | interface                                | arguments |
+      | Download | com.redhat.rhsm.testing.content.override | '{}'      |
+    Then varlink error is raised
+      """
+      com.redhat.rhsm.testing.content.override.SystemNotRegistered
+      """
+
+
+  Scenario: Upload() method raises error on unregistered system
+    Given system is not registered
+    When varlink method is called and error is expected
+      | method | interface                                | arguments |
+      | Upload | com.redhat.rhsm.testing.content.override | '{}'      |
+    Then varlink error is raised
+      """
+      com.redhat.rhsm.testing.content.override.SystemNotRegistered
+      """
+
+
+  Scenario: Download() method returns content overrides on registered system
+    Given system is registered against candlepin server
+    When varlink method is called
+      | method   | interface                                | arguments |
+      | Download | com.redhat.rhsm.testing.content.override | '{}'      |
+    Then method call was successful
+    And method returned JSON compliant with 'com.redhat.rhsm.testing.content.override.Download.json' schema
+
+
+  Scenario: Download() method returns content overrides on registered system with metadata
+    Given system is registered against candlepin server
+    When varlink method is called
+      | method   | interface                                | arguments                             |
+      | Download | com.redhat.rhsm.testing.content.override | '{"metadata": {"user_agent": "foo"}}' |
+    Then method call was successful
+    And method returned JSON compliant with 'com.redhat.rhsm.testing.content.override.Download.json' schema
+
+
+  @fixture.no_redhat_dnf5_override_installed
+  Scenario: Upload() method uploads local overrides on registered system
+    Given system is registered against candlepin server
+    And local DNF5 repo override file exists with content
+      """
+      [test-override-repo]
+      enabled = 1
+      """
+    When varlink method is called
+      | method | interface                                | arguments |
+      | Upload | com.redhat.rhsm.testing.content.override | '{}'      |
+    Then varlink method returns
+      """
+      {"success":true}
+      """
+
+
+  @fixture.no_redhat_dnf5_override_installed
+  Scenario: Upload() then Download() round-trip preserves overrides
+    Given system is registered against candlepin server
+    And local DNF5 repo override file exists with content
+      """
+      [test-roundtrip-repo]
+      enabled = 1
+      gpgcheck = 0
+      """
+    When varlink method is called
+      | method | interface                                | arguments |
+      | Upload | com.redhat.rhsm.testing.content.override | '{}'      |
+    Then method call was successful
+    When varlink method is called
+      | method   | interface                                | arguments |
+      | Download | com.redhat.rhsm.testing.content.override | '{}'      |
+    Then method call was successful
+    And downloaded content overrides contain label 'test-roundtrip-repo'
+
+
+  @fixture.no_redhat_dnf5_override_installed
+  Scenario: Upload() succeeds with empty override file on registered system
+    Given system is registered against candlepin server
+    And local DNF5 repo override file is empty
+    When varlink method is called
+      | method | interface                                | arguments |
+      | Upload | com.redhat.rhsm.testing.content.override | '{}'      |
+    Then varlink method returns
+      """
+      {"success":true}
+      """
+
+
+  Scenario: Download() returns consistent results across multiple calls
+    Given system is registered against candlepin server
+    When varlink method is called
+      | method   | interface                                | arguments |
+      | Download | com.redhat.rhsm.testing.content.override | '{}'      |
+    Then method call was successful
+    And method result is saved as 'first_download'
+    When varlink method is called
+      | method   | interface                                | arguments |
+      | Download | com.redhat.rhsm.testing.content.override | '{}'      |
+    Then method call was successful
+    And method result matches saved 'first_download'

--- a/features/environment.py
+++ b/features/environment.py
@@ -2,11 +2,30 @@
 This module contains environment setup and teardown functions for the test suite.
 """
 
+import os
+
+from behave.fixture import use_fixture_by_tag
+from fixtures import fixture_registry
+
 ENTITLEMENT_CERT_DIR = "/etc/pki/entitlement/"
 ENTITLEMENT_BACKUP_DIR_PREFIX = "entitlement-backup-"
 RELEASEVER_FILE = "/etc/dnf/vars/releasever"
 RHSM_HOST_CONFIG_DIR = "/etc/rhsm-host"
 ENTITLEMENT_HOST_CERT_DIR = "/etc/pki/entitlement-host"
+DNF5_REPOS_OVERRIDE_DIR = "/etc/dnf/repos.override.d"
+DNF5_REDHAT_REPOS_OVERRIDE_FILE = os.path.join(DNF5_REPOS_OVERRIDE_DIR, "98-redhat.repo")
+
+
+def before_tag(context, tag) -> None:
+    """
+    This function is executed before each tag in the test suite.
+    It is used to activate fixtures based on tags.
+    :param context: Context object
+    :param tag: Tag string
+    :return: None
+    """
+    if tag.startswith("fixture."):
+        return use_fixture_by_tag(tag, context, fixture_registry)
 
 
 def before_scenario(context, scenario) -> None:

--- a/features/environment.py
+++ b/features/environment.py
@@ -2,11 +2,26 @@
 This module contains environment setup and teardown functions for the test suite.
 """
 
+from behave.fixture import use_fixture_by_tag
+from fixtures import fixture_registry
+
 ENTITLEMENT_CERT_DIR = "/etc/pki/entitlement/"
 ENTITLEMENT_BACKUP_DIR_PREFIX = "entitlement-backup-"
 RELEASEVER_FILE = "/etc/dnf/vars/releasever"
 RHSM_HOST_CONFIG_DIR = "/etc/rhsm-host"
 ENTITLEMENT_HOST_CERT_DIR = "/etc/pki/entitlement-host"
+
+
+def before_tag(context, tag) -> None:
+    """
+    This function is executed before each tag in the test suite.
+    It is used to activate fixtures based on tags.
+    :param context: Context object
+    :param tag: Tag string
+    :return: None
+    """
+    if tag.startswith("fixture."):
+        return use_fixture_by_tag(tag, context, fixture_registry)
 
 
 def before_scenario(context, scenario) -> None:

--- a/features/fixtures.py
+++ b/features/fixtures.py
@@ -1,0 +1,44 @@
+"""
+Behave fixtures for the rhc integration test suite.
+
+Each fixture is a generator function decorated with @fixture.
+Setup runs before yield, teardown runs after the scenario ends.
+Fixtures are activated via @fixture.<name> tags in feature files
+and looked up in fixture_registry by the before_tag hook in
+environment.py.
+"""
+
+import os
+import shutil
+
+from behave import fixture
+
+from steps.constants import OVERRIDE_DIR, OVERRIDE_FILE
+
+
+@fixture
+def dnf5_repo_override_file(context):
+    """
+    Backup and restore the DNF5 repo override file around a scenario.
+    Activated via the @fixture.dnf5_override tag in feature files.
+    :param context: behave context
+    :return: path of the override file
+    """
+    os.makedirs(OVERRIDE_DIR, exist_ok=True)
+
+    backup_file = None
+    if os.path.exists(OVERRIDE_FILE):
+        backup_file = OVERRIDE_FILE + ".behave-backup"
+        shutil.copy2(OVERRIDE_FILE, backup_file)
+
+    yield OVERRIDE_FILE
+
+    if backup_file and os.path.exists(backup_file):
+        shutil.move(backup_file, OVERRIDE_FILE)
+    elif os.path.exists(OVERRIDE_FILE):
+        os.remove(OVERRIDE_FILE)
+
+
+fixture_registry = {
+    "fixture.dnf5_override": dnf5_repo_override_file,
+}

--- a/features/fixtures.py
+++ b/features/fixtures.py
@@ -1,0 +1,50 @@
+"""
+Behave fixtures for the rhc integration test suite.
+
+Each fixture is a generator function decorated with @fixture.
+Setup runs before yield, teardown runs after the scenario ends.
+Fixtures are activated via @fixture.<name> tags in feature files
+and looked up in fixture_registry by the before_tag hook in
+environment.py.
+"""
+
+import os
+import shutil
+
+from behave import fixture
+
+
+@fixture
+def no_redhat_dnf5_override_installed(context):
+    """
+    Ensure that no Red Hat DNF5 repo override file is present during
+    a scenario. If the override file already exists, it is moved to a
+    backup location so the scenario starts with a clean state. On
+    teardown, any override file created during the scenario is removed
+    and the original backup is restored.
+
+    Activated via the @fixture.no_redhat_dnf5_override_installed tag
+    in feature files.
+    :param context: behave context
+    :return: path of the override file
+    """
+    from environment import DNF5_REPOS_OVERRIDE_DIR, DNF5_REDHAT_REPOS_OVERRIDE_FILE
+
+    os.makedirs(DNF5_REPOS_OVERRIDE_DIR, exist_ok=True)
+
+    context.redhat_repo_override_backup = None
+    if os.path.exists(DNF5_REDHAT_REPOS_OVERRIDE_FILE):
+        context.redhat_repo_override_backup = DNF5_REDHAT_REPOS_OVERRIDE_FILE + ".behave-backup"
+        shutil.move(DNF5_REDHAT_REPOS_OVERRIDE_FILE, context.redhat_repo_override_backup)
+
+    yield DNF5_REDHAT_REPOS_OVERRIDE_FILE
+
+    if context.redhat_repo_override_backup and os.path.exists(context.redhat_repo_override_backup):
+        shutil.move(context.redhat_repo_override_backup, DNF5_REDHAT_REPOS_OVERRIDE_FILE)
+    elif os.path.exists(DNF5_REDHAT_REPOS_OVERRIDE_FILE):
+        os.remove(DNF5_REDHAT_REPOS_OVERRIDE_FILE)
+
+
+fixture_registry = {
+    "fixture.no_redhat_dnf5_override_installed": no_redhat_dnf5_override_installed,
+}

--- a/features/json-schemas/com.redhat.rhsm.testing.content.override.Download.json
+++ b/features/json-schemas/com.redhat.rhsm.testing.content.override.Download.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "com.redhat.rhsm.testing.content.override.Download response",
+  "type": "object",
+  "properties": {
+    "content_overrides": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "content_label": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "content_label",
+          "name",
+          "value"
+        ]
+      }
+    }
+  },
+  "required": [
+    "content_overrides"
+  ]
+}

--- a/features/steps/constants.py
+++ b/features/steps/constants.py
@@ -1,1 +1,6 @@
+import os
+
 VARLINK_SOCKET = "/run/rhc/com.redhat.rhc"
+
+OVERRIDE_DIR = "/etc/dnf/repos.override.d"
+OVERRIDE_FILE = os.path.join(OVERRIDE_DIR, "98-redhat.repo")

--- a/features/steps/test_content_override.py
+++ b/features/steps/test_content_override.py
@@ -1,0 +1,49 @@
+from behave import given, then
+import behave.runner
+
+import json
+
+from environment import DNF5_REDHAT_REPOS_OVERRIDE_FILE
+
+
+@given("local DNF5 repo override file exists with content")
+def step_impl(context: behave.runner.Context):
+    """
+    Write the given content to the DNF5 repo override file.
+    Requires @fixture.no_redhat_dnf5_override_installed tag on the scenario.
+    :param context: behave context
+    :return: None
+    """
+    with open(DNF5_REDHAT_REPOS_OVERRIDE_FILE, "w") as f:
+        f.write(context.text.strip() + "\n")
+
+
+@given("local DNF5 repo override file is empty")
+def step_impl(context: behave.runner.Context):
+    """
+    Create an empty DNF5 repo override file.
+    Requires @fixture.no_redhat_dnf5_override_installed tag on the scenario.
+    :param context: behave context
+    :return: None
+    """
+    with open(DNF5_REDHAT_REPOS_OVERRIDE_FILE, "w") as f:
+        f.write("")
+
+
+@then("downloaded content overrides contain label '{label}'")
+def step_impl(context: behave.runner.Context, label: str):
+    """
+    Verify that the Download response contains a content override with the given label.
+    :param context: behave context
+    :param label: content label expected among the downloaded content overrides
+    :return: None
+    """
+    result = json.loads(context.cmd_stdout)
+    assert "content_overrides" in result, (
+        f"Response missing 'content_overrides' key: {result}"
+    )
+    labels = {o["content_label"] for o in result["content_overrides"]}
+    assert label in labels, (
+        f"Expected label '{label}' not found in content overrides. "
+        f"Available labels: {labels}"
+    )

--- a/features/steps/test_content_override.py
+++ b/features/steps/test_content_override.py
@@ -1,0 +1,49 @@
+from behave import given, then
+import behave.runner
+
+import json
+
+from constants import OVERRIDE_FILE
+
+
+@given("local DNF5 repo override file exists with content")
+def step_impl(context: behave.runner.Context):
+    """
+    Write the given content to the DNF5 repo override file.
+    Requires @fixture.dnf5_override tag on the scenario for cleanup.
+    :param context: behave context
+    :return: None
+    """
+    with open(OVERRIDE_FILE, "w") as f:
+        f.write(context.text.strip() + "\n")
+
+
+@given("local DNF5 repo override file is empty")
+def step_impl(context: behave.runner.Context):
+    """
+    Create an empty DNF5 repo override file.
+    Requires @fixture.dnf5_override tag on the scenario for cleanup.
+    :param context: behave context
+    :return: None
+    """
+    with open(OVERRIDE_FILE, "w") as f:
+        f.write("")
+
+
+@then("downloaded content overrides contain label '{label}'")
+def step_impl(context: behave.runner.Context, label: str):
+    """
+    Verify that the Download response contains a content override with the given label.
+    :param context: behave context
+    :param label: content label expected among the downloaded content overrides
+    :return: None
+    """
+    result = json.loads(context.cmd_stdout)
+    assert "content_overrides" in result, (
+        f"Response missing 'content_overrides' key: {result}"
+    )
+    labels = {o["content_label"] for o in result["content_overrides"]}
+    assert label in labels, (
+        f"Expected label '{label}' not found in content overrides. "
+        f"Available labels: {labels}"
+    )

--- a/features/steps/test_varlink_method.py
+++ b/features/steps/test_varlink_method.py
@@ -117,3 +117,72 @@ def step_impl(context: behave.runner.Context):
     :return: None
     """
     assert context.cmd_exitcode == 0, f"Method call failed with exit code {context.cmd_exitcode}"
+
+
+@when("varlink method is called and error is expected")
+def step_impl(context: behave.runner.Context):
+    """
+    Call a varlink method on a specified interface, when it is expected that error is returned.
+    Example of a Gherkin table containing the name of the method, Varlink interface, and argument:
+      | method | interface               | arguments          |
+      | Ping   | com.redhat.rhsm.testing | '{"metadata": {}}' |
+    :param context: behave context
+    :return: None
+    """
+    varlink_interface = None
+    varlink_method = None
+    varlink_args = None
+    counter = 0
+    for row in context.table:
+        varlink_interface = row["interface"]
+        varlink_method = row["method"]
+        varlink_args = row["arguments"]
+        counter += 1
+    assert counter == 1, f"Expected exactly one row in table for 'varlink method called' ({counter} provided)"
+
+    cmd = f"varlinkctl call --no-pager --json=short {VARLINK_SOCKET} {varlink_interface}.{varlink_method} {varlink_args}"
+    run_in_context(context, cmd, can_fail=True)
+
+
+@then("varlink error is raised")
+def step_impl(context: behave.runner.Context):
+    """
+    Verify that given Varlink error was raised
+    :param context: behave context
+    :return: None
+    """
+    assert context.cmd_exitcode != 0, f"Method call did not fail with non-zero exit code"
+    expected_error = context.text
+    std_err = context.cmd_stderr
+    assert expected_error in std_err
+
+
+@step("method result is saved as '{name}'")
+def step_impl(context: behave.runner.Context, name: str):
+    """
+    Save the current method result (stdout) under a named key for later comparison.
+    :param context: behave context
+    :param name: key under which the current method result is saved
+    :return: None
+    """
+    if not hasattr(context, "_saved_results"):
+        context._saved_results = {}
+    context._saved_results[name] = context.cmd_stdout
+
+
+@step("method result matches saved '{name}'")
+def step_impl(context: behave.runner.Context, name: str):
+    """
+    Compare current method result JSON with a previously saved result.
+    :param context: behave context
+    :param name: key of the previously saved method result to compare against
+    :return: None
+    """
+    assert hasattr(context, "_saved_results") and name in context._saved_results, (
+        f"No saved result named '{name}'"
+    )
+    saved = json.loads(context._saved_results[name])
+    current = json.loads(context.cmd_stdout)
+    assert saved == current, (
+        f"Results differ.\nSaved: {saved}\nCurrent: {current}"
+    )

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/jirihnidek/rhsm2 v0.0.0-20260729132541-bd687fccd469
+	github.com/jirihnidek/rhsm2 v0.0.0-20260806125901-cf03098a4d1c
 	github.com/pelletier/go-toml v1.9.5
 	github.com/urfave/cli-altsrc/v3 v3.1.0
 	github.com/urfave/cli-docs/v3 v3.1.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/henvic/httpretty v0.2.0 h1:U4pKgF9SV4uRrE/7PF85TVnCJxXA91zKFpYU0iFwFO
 github.com/henvic/httpretty v0.2.0/go.mod h1:4LSlqxtJoYd+gt1lsqh9omUUziIVwoVsxdW15hZHTcI=
 github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade h1:FmusiCI1wHw+XQbvL9M+1r/C3SPqKrmBaIOYwVfQoDE=
 github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade/go.mod h1:ZDXo8KHryOWSIqnsb/CiDq7hQUYryCgdVnxbj8tDG7o=
-github.com/jirihnidek/rhsm2 v0.0.0-20260729132541-bd687fccd469 h1:3/3RmAOqNXc8V9m/+EGiG0k8m3xpX05WXgZS8GfclJk=
-github.com/jirihnidek/rhsm2 v0.0.0-20260729132541-bd687fccd469/go.mod h1:OhFF2Ju6ZLtmvh1uFiGUIsO9+4vXdXYIp08ZxjpFp3g=
+github.com/jirihnidek/rhsm2 v0.0.0-20260806125901-cf03098a4d1c h1:aUpj2aebLrKSazyOZvo+DP0GKNzfznijypZxDJGO4jg=
+github.com/jirihnidek/rhsm2 v0.0.0-20260806125901-cf03098a4d1c/go.mod h1:OhFF2Ju6ZLtmvh1uFiGUIsO9+4vXdXYIp08ZxjpFp3g=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=


### PR DESCRIPTION
This patch adds Behave integration tests for the
com.redhat.rhsm.testing.content.override interface, covering Download and Upload methods.

- Add feature file with 8 scenarios for content override API
- Add JSON schema for Download response validation
- Add step definitions for DNF5 override file management
- Add reusable generic steps for varlink error and result assertions
- Attempted a fix for the integration tests CI where locally built rhc binary was overriden
- Updated rhsm2 dependency to resolve invalid cached connections
- Updated UploadContentOverrides method to not attempt to send candlepin null overrides

Resolves: CCT-2809