### PR TITLE
fix: Check for selinux store before execution of semanage commands

### DIFF
--- a/rhc.spec
+++ b/rhc.spec
@@ -159,7 +159,9 @@ fi
 %if 0%{?with_rhcd_compat}
 # rhcd_t is the SELinux type used by the old rhcd daemon. Add it to the
 # permissive list so existing policies do not block yggdrasil on upgrade.
-/usr/sbin/semanage permissive --add rhcd_t || true
+if [ -d /var/lib/selinux/targeted ]; then
+	/usr/sbin/semanage permissive --add rhcd_t || true
+fi
 
 # Complete the config migration started in %pre: transform the backed-up
 # /etc/rhc/config.toml into a valid /etc/yggdrasil/config.toml.
@@ -183,7 +185,9 @@ fi
 %if 0%{?with_rhcd_compat}
 # Remove rhcd_t from the SELinux permissive list on full package removal.
 if [ $1 -eq 0 ]; then
-    /usr/sbin/semanage permissive --delete rhcd_t || true
+	if [ -d /var/lib/selinux/targeted ]; then
+		/usr/sbin/semanage permissive --delete rhcd_t || true
+	fi
 fi
 %endif
 


### PR DESCRIPTION
* Card Id: RHEL-233053

- Check for the presence of /var/lib/selinux/targeted before executing semange commands. This will remove warnings on package install on environments that do not have SELinux enabled. The fix covers builds where the package is installed using an image mounted inside a container (to be used on bare metal or VM) and SELinux is enabled after package installation.