### PR TITLE
build: support RPM builds without running tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,8 @@ $ # Prepare source RPM
 $ make srpm
 $ # Build binary RPMs
 $ make rpm
+$ # Build binary RPMs without running unit tests
+$ make rpm NOCHECK=1
 ```
 
 You can create an RPM package using [packit](https://packit.dev/docs/cli) CLI too:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 VERSION := $(shell rpmspec rhc.spec --query --srpm --queryformat '%{version}')
 LDFLAGS := -ldflags "-X github.com/redhatinsights/rhc/pkg/version.Version=$(VERSION)"
 GO_BUILD := go build $(LDFLAGS)
+RPMBUILD_CHECK_OPTION := $(if $(filter 1,$(NOCHECK)),--without check)
 
 # The 'build' target is not used during downstream packaging; it is present for upstream development purposes.
 .PHONY: build
@@ -36,7 +37,7 @@ srpm: archive archive-deps
 
 .PHONY: rpm
 rpm: srpm
-	rpmbuild --define "_sourcedir $$(pwd)" -bb rhc.spec
+	rpmbuild $(RPMBUILD_CHECK_OPTION) --define "_sourcedir $$(pwd)" -bb rhc.spec
 
 # The 'clean' target removes build artifacts.
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 VERSION := $(shell rpmspec rhc.spec --query --srpm --queryformat '%{version}')
 LDFLAGS := -ldflags "-X github.com/redhatinsights/rhc/pkg/version.Version=$(VERSION)"
 GO_BUILD := go build $(LDFLAGS)
+RPMBUILD_CHECK_OPTION := $(if $(NOCHECK),--without check)
 
 # The 'build' target is not used during downstream packaging; it is present for upstream development purposes.
 .PHONY: build
@@ -36,7 +37,7 @@ srpm: archive archive-deps
 
 .PHONY: rpm
 rpm: srpm
-	rpmbuild --define "_sourcedir $$(pwd)" -bb rhc.spec
+	rpmbuild $(RPMBUILD_CHECK_OPTION) --define "_sourcedir $$(pwd)" -bb rhc.spec
 
 # The 'clean' target removes build artifacts.
 .PHONY: clean


### PR DESCRIPTION
Allow `make rpm NOCHECK=1` to skip unit tests, giving developers a
faster way to build RPM packages when test execution isn’t required.