### PR TITLE
feat(ui): support FORCE_COLOR

### DIFF
--- a/cmd/rhc/connect_cmd.go
+++ b/cmd/rhc/connect_cmd.go
@@ -139,7 +139,7 @@ func (connectResult *ConnectResult) TryRegisterRHSM(cmd *cli.Command, enableCont
 	}
 
 	var s *spinner.Spinner
-	if ui.IsOutputRich() {
+	if ui.AreAnimationsEnabled() {
 		s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 		s.Prefix = ui.Indent.Small + "["
 		s.Suffix = "] Connecting to Red Hat Subscription Management..."
@@ -164,7 +164,7 @@ func (connectResult *ConnectResult) TryRegisterRHSM(cmd *cli.Command, enableCont
 				return
 			}
 			// Stop spinner to display the organization list and prompt the user
-			if ui.IsOutputRich() {
+			if ui.AreAnimationsEnabled() {
 				s.Stop()
 			}
 
@@ -189,7 +189,7 @@ func (connectResult *ConnectResult) TryRegisterRHSM(cmd *cli.Command, enableCont
 			organization = strings.TrimSpace(scanner.Text())
 			fmt.Printf("\n")
 
-			if ui.IsOutputRich() {
+			if ui.AreAnimationsEnabled() {
 				s.Start()
 			}
 

--- a/cmd/rhc/main.go
+++ b/cmd/rhc/main.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -23,10 +24,11 @@ import (
 )
 
 const (
-	cliLogLevel  = "log-level"
-	cliCertFile  = "cert-file"
-	cliKeyFile   = "key-file"
-	cliAPIServer = "base-url"
+	cliLogLevel   = "log-level"
+	cliCertFile   = "cert-file"
+	cliKeyFile    = "key-file"
+	envForceColor = "FORCE_COLOR"
+	envNoColor    = "NO_COLOR"
 )
 
 // mainAction is triggered in the case, when no sub-command is specified
@@ -51,23 +53,47 @@ func mainAction(ctx context.Context, cmd *cli.Command) error {
 // configureUI sets up the global UI state by calling ui.ConfigureOutput
 // with appropriate parameters.
 func configureUI(cmd *cli.Command) {
+	// Machine-readable output is enabled when a format is requested.
+	machineReadable := cmd.String("format") != ""
+	forceColor := isForceColorEnabled()
+	noColor := isNoColorEnabled(cmd)
+	// Animations require human-readable output to an interactive terminal.
+	animationsEnabled := ui.IsInteractive() && !machineReadable
+	// Colors are enabled for human terminal output or with FORCE_COLOR,
+	// unless NO_COLOR or --no-color disables them.
+	colorsEnabled := !noColor && (forceColor || animationsEnabled)
+
 	ui.ConfigureOutput(
-		// Rich output (animations) is only enabled when all are true:
-		// - we're printing in human-friendly format,
-		// - stdout is an interactive console.
-		!cmd.IsSet("format") && ui.IsInteractive(),
-		// Colors are only enabled when all are true:
-		// output is rich,
-		// --no-color/$NO_COLOR are not set.
-		!cmd.IsSet("no-color"),
-		// Machine-readable output is enabled when all are true:
-		// - we're printing in JSON or other parseable format.
-		cmd.IsSet("format"),
+		animationsEnabled,
+		colorsEnabled,
+		machineReadable,
 	)
+}
+
+func isNoColorEnabled(cmd *cli.Command) bool {
+	return cmd.Bool("no-color") || isEnvironmentVariableEnabled(envNoColor)
+}
+
+// isForceColorEnabled returns true for Boolean true values or positive integers.
+func isForceColorEnabled() bool {
+	if isEnvironmentVariableEnabled(envForceColor) {
+		return true
+	}
+
+	colorLevel, err := strconv.Atoi(os.Getenv(envForceColor))
+	return err == nil && colorLevel >= 1
 }
 
 // beforeAction is triggered before other actions are triggered
 func beforeAction(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+	forceColor := isForceColorEnabled()
+	if forceColor && isNoColorEnabled(cmd) {
+		return ctx, cli.Exit(
+			"FORCE_COLOR cannot be used together with NO_COLOR or --no-color",
+			exitcode.Usage,
+		)
+	}
+
 	// check if --log-level was set via command line
 	var logLevelSrc string
 	if cmd.IsSet(cliLogLevel) {
@@ -101,18 +127,6 @@ func beforeAction(ctx context.Context, cmd *cli.Command) (context.Context, error
 	if !cmd.Bool("generate-man-page") && !cmd.Bool("generate-markdown") {
 		configureFileLogging(conf.Config.LogLevel)
 		slog.Info(cmd.Root().Name+" started", "version", version.Version, "pid", os.Getpid())
-	}
-
-	// When environment variable NO_COLOR or --no-color CLI option is set, then do not display colors
-	// and animations too. The NO_COLOR environment variable have to have value "1" or "true",
-	// "True", "TRUE" to take effect
-	// When no-color is not set, then try to detect if the output goes to some file. In this case
-	// colors nor animations will not be printed to file.
-	if !isTerminal(os.Stdout.Fd()) {
-		err := cmd.Set("no-color", "true")
-		if err != nil {
-			slog.Debug("Unable to set no-color flag to \"true\"")
-		}
 	}
 
 	// Set up standard output preference: colors, icons, etc.
@@ -175,7 +189,7 @@ func main() {
 			Name:    "no-color",
 			Hidden:  false,
 			Value:   false,
-			Sources: cli.EnvVars("NO_COLOR"),
+			Sources: cli.EnvVars(envNoColor),
 		},
 		&cli.StringFlag{
 			Name:        "config",

--- a/cmd/rhc/main_test.go
+++ b/cmd/rhc/main_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/redhatinsights/rhc/internal/ui"
+	"github.com/redhatinsights/rhc/pkg/exitcode"
+)
+
+func TestIsEnvironmentVariableEnabled(t *testing.T) {
+	const environmentVariable = "RHC_TEST_BOOLEAN"
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "empty", value: "", want: false},
+		{name: "one", value: "1", want: true},
+		{name: "lowercase t", value: "t", want: true},
+		{name: "uppercase T", value: "T", want: true},
+		{name: "lowercase true", value: "true", want: true},
+		{name: "title case true", value: "True", want: true},
+		{name: "uppercase true", value: "TRUE", want: true},
+		{name: "zero", value: "0", want: false},
+		{name: "false", value: "false", want: false},
+		{name: "two", value: "2", want: false},
+		{name: "three", value: "3", want: false},
+		{name: "invalid", value: "invalid", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(environmentVariable, tt.value)
+
+			if got := isEnvironmentVariableEnabled(environmentVariable); got != tt.want {
+				t.Errorf("isEnvironmentVariableEnabled() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsForceColorEnabled(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "empty", value: "", want: false},
+		{name: "true", value: "true", want: true},
+		{name: "one", value: "1", want: true},
+		{name: "two", value: "2", want: true},
+		{name: "three", value: "3", want: true},
+		{name: "larger positive integer", value: "42", want: true},
+		{name: "zero", value: "0", want: false},
+		{name: "negative integer", value: "-1", want: false},
+		{name: "false", value: "false", want: false},
+		{name: "non-integer", value: "1.5", want: false},
+		{name: "invalid", value: "invalid", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envForceColor, tt.value)
+
+			if got := isForceColorEnabled(); got != tt.want {
+				t.Errorf("isForceColorEnabled() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigureUIForNonInteractiveOutput(t *testing.T) {
+	originalStdout := os.Stdout
+	pipeReader, pipeWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	os.Stdout = pipeWriter
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+		_ = pipeReader.Close()
+		_ = pipeWriter.Close()
+		ui.ConfigureOutput(true, true, false)
+	})
+
+	if ui.IsInteractive() {
+		t.Fatal("ui.IsInteractive() = true for pipe output, want false")
+	}
+
+	tests := []struct {
+		name       string
+		forceColor string
+		wantIcon   string
+	}{
+		{
+			name:     "colors disabled by default",
+			wantIcon: "✓",
+		},
+		{
+			name:       "colors forced with positive integer",
+			forceColor: "2",
+			wantIcon:   "\u001B[32m✓\u001B[0m",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envForceColor, tt.forceColor)
+			t.Setenv(envNoColor, "false")
+
+			cmd := &cli.Command{
+				Flags: []cli.Flag{
+					&cli.BoolFlag{Name: "no-color", Sources: cli.EnvVars(envNoColor)},
+					&cli.StringFlag{Name: "format"},
+				},
+				Action: func(_ context.Context, cmd *cli.Command) error {
+					configureUI(cmd)
+					return nil
+				},
+			}
+			if err := cmd.Run(context.Background(), []string{"rhc"}); err != nil {
+				t.Fatalf("Command.Run() error = %v", err)
+			}
+
+			if ui.AreAnimationsEnabled() {
+				t.Error("AreAnimationsEnabled() = true, want false")
+			}
+			if got := ui.Icons.Ok; got != tt.wantIcon {
+				t.Errorf("Icons.Ok = %q, want %q", got, tt.wantIcon)
+			}
+			if ui.IsOutputMachineReadable() {
+				t.Error("IsOutputMachineReadable() = true, want false")
+			}
+		})
+	}
+}
+
+func TestBeforeActionRejectsColorConflicts(t *testing.T) {
+	tests := []struct {
+		name               string
+		arguments          []string
+		noColorEnvironment string
+	}{
+		{
+			name:               "NO_COLOR",
+			noColorEnvironment: "1",
+		},
+		{
+			name:               "--no-color",
+			arguments:          []string{"--no-color"},
+			noColorEnvironment: "false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envForceColor, "2")
+			t.Setenv(envNoColor, tt.noColorEnvironment)
+
+			cmd := &cli.Command{
+				ExitErrHandler: func(context.Context, *cli.Command, error) {},
+				Flags: []cli.Flag{
+					&cli.BoolFlag{Name: "no-color", Sources: cli.EnvVars(envNoColor)},
+				},
+				Before: beforeAction,
+				Action: func(context.Context, *cli.Command) error {
+					t.Fatal("Action() called after conflicting color options")
+					return nil
+				},
+			}
+			err := cmd.Run(
+				context.Background(),
+				append([]string{"rhc"}, tt.arguments...),
+			)
+			if err == nil {
+				t.Fatal("Command.Run() error = nil, want color conflict")
+			}
+			const wantError = "FORCE_COLOR cannot be used together with NO_COLOR or --no-color"
+			if err.Error() != wantError {
+				t.Errorf("Command.Run() error = %q, want %q", err, wantError)
+			}
+			exitErr, ok := err.(cli.ExitCoder)
+			if !ok {
+				t.Fatalf("Command.Run() error type = %T, want cli.ExitCoder", err)
+			}
+			if got := exitErr.ExitCode(); got != exitcode.Usage {
+				t.Errorf("Command.Run() exit code = %d, want %d", got, exitcode.Usage)
+			}
+		})
+	}
+}

--- a/cmd/rhc/util.go
+++ b/cmd/rhc/util.go
@@ -7,13 +7,19 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/urfave/cli/v3"
-	"golang.org/x/sys/unix"
 
 	"github.com/redhatinsights/rhc/pkg/exitcode"
 )
+
+// isEnvironmentVariableEnabled returns true for Boolean true values.
+func isEnvironmentVariableEnabled(name string) bool {
+	enabled, err := strconv.ParseBool(os.Getenv(name))
+	return err == nil && enabled
+}
 
 // isShellCompletion returns true when the process was invoked for shell completion.
 func isShellCompletion() bool {
@@ -23,12 +29,6 @@ func isShellCompletion() bool {
 		}
 	}
 	return false
-}
-
-// isTerminal returns true if the file descriptor is terminal.
-func isTerminal(fd uintptr) bool {
-	_, err := unix.IoctlGetTermios(int(fd), unix.TCGETS)
-	return err == nil
 }
 
 // BashCompleteCommand prints all visible flag options for the given command,

--- a/go.sum
+++ b/go.sum
@@ -25,14 +25,6 @@ github.com/henvic/httpretty v0.2.0 h1:U4pKgF9SV4uRrE/7PF85TVnCJxXA91zKFpYU0iFwFO
 github.com/henvic/httpretty v0.2.0/go.mod h1:4LSlqxtJoYd+gt1lsqh9omUUziIVwoVsxdW15hZHTcI=
 github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade h1:FmusiCI1wHw+XQbvL9M+1r/C3SPqKrmBaIOYwVfQoDE=
 github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade/go.mod h1:ZDXo8KHryOWSIqnsb/CiDq7hQUYryCgdVnxbj8tDG7o=
-github.com/jirihnidek/rhsm2 v0.0.0-20260729132541-bd687fccd469 h1:3/3RmAOqNXc8V9m/+EGiG0k8m3xpX05WXgZS8GfclJk=
-github.com/jirihnidek/rhsm2 v0.0.0-20260729132541-bd687fccd469/go.mod h1:OhFF2Ju6ZLtmvh1uFiGUIsO9+4vXdXYIp08ZxjpFp3g=
-github.com/jirihnidek/rhsm2 v0.0.0-20260806054428-629538e7441d h1:1jpnEBDJ0ZXQjP8UlBJZZLU/sjD3tCaP7BGXNRdfyQ4=
-github.com/jirihnidek/rhsm2 v0.0.0-20260806054428-629538e7441d/go.mod h1:OhFF2Ju6ZLtmvh1uFiGUIsO9+4vXdXYIp08ZxjpFp3g=
-github.com/jirihnidek/rhsm2 v0.0.0-20260806125901-cf03098a4d1c h1:aUpj2aebLrKSazyOZvo+DP0GKNzfznijypZxDJGO4jg=
-github.com/jirihnidek/rhsm2 v0.0.0-20260806125901-cf03098a4d1c/go.mod h1:OhFF2Ju6ZLtmvh1uFiGUIsO9+4vXdXYIp08ZxjpFp3g=
-github.com/jirihnidek/rhsm2 v0.0.0-20260807102124-ac46e4945e02 h1:zVvIeouzIILYfkFs6vqKnnd6ENTK5nniisv/fbEp/04=
-github.com/jirihnidek/rhsm2 v0.0.0-20260807102124-ac46e4945e02/go.mod h1:OhFF2Ju6ZLtmvh1uFiGUIsO9+4vXdXYIp08ZxjpFp3g=
 github.com/jirihnidek/rhsm2 v0.0.0-20260807113404-161e1e76135f h1:0Qrhb8oVEBGenWjihoHtIe6eTCLrWdHuZefY3Lx3Sek=
 github.com/jirihnidek/rhsm2 v0.0.0-20260807113404-161e1e76135f/go.mod h1:OhFF2Ju6ZLtmvh1uFiGUIsO9+4vXdXYIp08ZxjpFp3g=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -37,7 +37,7 @@ type icons struct {
 }
 
 var Icons icons
-var isOutputRich bool
+var areAnimationsEnabled bool
 var isOutputMachineReadable bool
 
 func init() {
@@ -57,17 +57,12 @@ func isTerminal(fd uintptr) bool {
 }
 
 // ConfigureOutput sets up a global state for communicating information to the user.
-// 'rich' represents the output's ability to display animations or colors,
-// 'colored' represents the user's preference to display colors, and requires 'rich' to be true,
-// 'machine' is true when the output is formatted as JSON or similar machine-readable format.
-func ConfigureOutput(rich bool, colored bool, machine bool) {
-	if machine {
-		isOutputMachineReadable = true
-		isOutputRich = false
-	}
-	if rich {
-		isOutputRich = true
-	}
+// 'animated' enables transient animations such as spinners,
+// 'colored' enables ANSI colors,
+// 'machineReadable' is true for JSON or similar machine-readable formats.
+func ConfigureOutput(animated bool, colored bool, machineReadable bool) {
+	areAnimationsEnabled = animated
+	isOutputMachineReadable = machineReadable
 
 	Icons = icons{
 		Ok:      "✓",
@@ -75,7 +70,7 @@ func ConfigureOutput(rich bool, colored bool, machine bool) {
 		Warning: "!",
 		Error:   "𐄂",
 	}
-	if rich && colored {
+	if colored {
 		Icons.Ok = colorGreen + Icons.Ok + colorReset
 		Icons.Info = colorYellow + Icons.Info + colorReset
 		Icons.Error = colorRed + Icons.Error + colorReset
@@ -89,10 +84,9 @@ func IsOutputMachineReadable() bool {
 	return isOutputMachineReadable
 }
 
-// IsOutputRich returns true when the output should be displayed in a terminal
-// supporting animations and colors.
-func IsOutputRich() bool {
-	return isOutputRich
+// AreAnimationsEnabled returns true when transient output animations are enabled.
+func AreAnimationsEnabled() bool {
+	return areAnimationsEnabled
 }
 
 // Printf acts as a no-op if the output is machine-readable.
@@ -108,14 +102,14 @@ func Printf(
 }
 
 // Spinner calls a function and displays a spinner with an explanatory message.
-// The spinner is not displayed if the output isn't a rich terminal.
+// The spinner is not displayed when animations are disabled.
 func Spinner(
 	function func() error,
 	prefix string,
 	message string,
 ) error {
 	var s *spinner.Spinner
-	if IsOutputRich() {
+	if AreAnimationsEnabled() {
 		s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 		s.Prefix = prefix + "["
 		s.Suffix = "]" + " " + message

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1,0 +1,93 @@
+package ui
+
+import "testing"
+
+func TestConfigureOutput(t *testing.T) {
+	plainIcons := icons{
+		Ok:      "✓",
+		Info:    "●",
+		Error:   "𐄂",
+		Warning: "!",
+	}
+	coloredIcons := icons{
+		Ok:      colorGreen + "✓" + colorReset,
+		Info:    colorYellow + "●" + colorReset,
+		Error:   colorRed + "𐄂" + colorReset,
+		Warning: colorRed + "!" + colorReset,
+	}
+	tests := []struct {
+		name                  string
+		animated              bool
+		colored               bool
+		machineReadable       bool
+		wantAnimationsEnabled bool
+		wantMachineReadable   bool
+		wantIcons             icons
+	}{
+		{
+			name:                  "animated and colored",
+			animated:              true,
+			colored:               true,
+			machineReadable:       false,
+			wantAnimationsEnabled: true,
+			wantMachineReadable:   false,
+			wantIcons:             coloredIcons,
+		},
+		{
+			name:                  "colored without animations",
+			animated:              false,
+			colored:               true,
+			machineReadable:       false,
+			wantAnimationsEnabled: false,
+			wantMachineReadable:   false,
+			wantIcons:             coloredIcons,
+		},
+		{
+			name:                  "animated without color",
+			animated:              true,
+			colored:               false,
+			machineReadable:       false,
+			wantAnimationsEnabled: true,
+			wantMachineReadable:   false,
+			wantIcons:             plainIcons,
+		},
+		{
+			name:                  "machine-readable output",
+			animated:              false,
+			colored:               true,
+			machineReadable:       true,
+			wantAnimationsEnabled: false,
+			wantMachineReadable:   true,
+			wantIcons:             coloredIcons,
+		},
+		{
+			name:                  "plain without animations",
+			animated:              false,
+			colored:               false,
+			machineReadable:       false,
+			wantAnimationsEnabled: false,
+			wantMachineReadable:   false,
+			wantIcons:             plainIcons,
+		},
+	}
+
+	t.Cleanup(func() {
+		ConfigureOutput(true, true, false)
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ConfigureOutput(tt.animated, tt.colored, tt.machineReadable)
+
+			if got := AreAnimationsEnabled(); got != tt.wantAnimationsEnabled {
+				t.Errorf("AreAnimationsEnabled() = %v, want %v", got, tt.wantAnimationsEnabled)
+			}
+			if got := IsOutputMachineReadable(); got != tt.wantMachineReadable {
+				t.Errorf("IsOutputMachineReadable() = %v, want %v", got, tt.wantMachineReadable)
+			}
+			if Icons != tt.wantIcons {
+				t.Errorf("Icons = %#v, want %#v", Icons, tt.wantIcons)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- CardID: CCT-2653

Honor FORCE_COLOR when stdout is redirected so commands such as `watch -c FORCE_COLOR=1 rhc status` retain ANSI colors.

Handle colors independently from terminal animations, keeping spinners disabled for non-interactive output. Reject FORCE_COLOR when combined with NO_COLOR or --no-color.