### PR TITLE
chore(test): re-enable e2e test for resolved bugs

### DIFF
--- a/integration-tests/test_e2e.py
+++ b/integration-tests/test_e2e.py
@@ -13,11 +13,11 @@ from utils import (
     yggdrasil_service_is_active,
     prepare_args_for_connect,
 )
+from pytest_client_tools.util import loop_until
 
 
-@pytest.mark.skip("Test cannot be run due to unresolved issues CCT-862 and CCT-696")
 @pytest.mark.parametrize("auth", ["activation-key", "basic"])
-def test_rhc_client_connect_e2e(rhc, test_config, auth, external_inventory, subman):
+def test_rhc_client_connect_e2e(external_candlepin, rhc, test_config, auth, external_inventory, subman, insights_client):
     """
     :id: bbac96bd-a551-423c-b00b-1e62a743d4ed
     :title: Test RHC client connect end-to-end with basic auth and activation key
@@ -51,6 +51,7 @@ def test_rhc_client_connect_e2e(rhc, test_config, auth, external_inventory, subm
     command = ["connect"] + command_args
     rhc.run(*command)
     assert rhc.is_registered
+    assert loop_until(lambda: insights_client.is_registered)
     assert yggdrasil_service_is_active()
     timeout = 60.0
     start = time.time()
@@ -62,4 +63,3 @@ def test_rhc_client_connect_e2e(rhc, test_config, auth, external_inventory, subm
         current = time.time()
         if current - start > timeout:
             raise ValueError("timeout")
-        time.sleep(10)


### PR DESCRIPTION
Since the bugs in e2e tests were resolved (CCT-862, CCT-696), the pytest skip marker can be dropped and the test re-enabled. The `external_candlepin` fixture was added to properly set up the Candlepin server dependency for the test. The extra sleep() call was also removed as this is already handled in pytest_client_tools testing framework.