### PR TITLE
feat: implement WriteContentOverrides method in content override varlink API

### DIFF
--- a/cmd/rhc-server/rhc-server.go
+++ b/cmd/rhc-server/rhc-server.go
@@ -172,6 +172,27 @@ func (b *ContentOverrideBackend) Download(in *overrideapi.DownloadIn) (*override
 	return &overrideapi.DownloadOut{ContentOverrides: result}, nil
 }
 
+// WriteContentOverrides writes the given content overrides to the local DNF5 repo override file.
+func (b *ContentOverrideBackend) WriteContentOverrides(in *overrideapi.WriteContentOverridesIn) (*overrideapi.WriteContentOverridesOut, error) {
+	overrides := make([]rhsm2.ContentOverride, 0, len(in.ContentOverrides))
+	for _, co := range in.ContentOverrides {
+		overrides = append(overrides,
+			rhsm2.ContentOverride{
+				ContentLabel: co.ContentLabel,
+				Name:         co.Name,
+				Value:        co.Value,
+			},
+		)
+	}
+
+	if err := WriteLocalContentOverrides(overrides); err != nil {
+		slog.Error("Failed to write content overrides to local DNF5 repo override file", "error", err)
+		return nil, err
+	}
+
+	return &overrideapi.WriteContentOverridesOut{Success: true}, nil
+}
+
 // Upload reads local DNF5 repo overrides and sends them to the candlepin server.
 func (b *ContentOverrideBackend) Upload(in *overrideapi.UploadIn) (*overrideapi.UploadOut, error) {
 	registered, err := IsSystemRegistered()

--- a/cmd/rhc-server/rhsm.go
+++ b/cmd/rhc-server/rhsm.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/jirihnidek/rhsm2"
+	"github.com/redhatinsights/rhc/varlink/overrideapi"
 )
 
 type ClientError struct {
@@ -95,6 +98,18 @@ func UploadContentOverrides(ipcSender *string, locale *string, correlationID *st
 	return nil
 }
 
+// WriteLocalContentOverrides writes content overrides to the local DNF5 repo override file.
+func WriteLocalContentOverrides(overrides []rhsm2.ContentOverride) error {
+	dir := filepath.Dir(rhsm2.Dnf5RedHatReposOverrideFilePath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return &overrideapi.IOFailedError{Message: fmt.Sprintf("failed to create override directory %s: %s", dir, err)}
+	}
+	if err := rhsm2.WriteDnf5RepoOverrides(overrides, rhsm2.Dnf5RedHatReposOverrideFilePath); err != nil {
+		return &overrideapi.IOFailedError{Message: fmt.Sprintf("failed to write content overrides to local file: %s", err)}
+	}
+	return nil
+}
+
 // DownloadRelease downloads the current release information from the server. The release can be set
 // on the candlepin server for the given system. The client has to have chance to get this information
 // from the server.
@@ -135,4 +150,3 @@ func SetRelease(release string, ipcSender *string, locale *string, correlationID
 	clientInfo := rhsm2.RequestMetadata{IPCSender: ipcSender, Locale: locale, CorrelationId: correlationID}
 	return rhsmClient.SetRelease(release, &clientInfo)
 }
-

--- a/features/com.redhat.rhsm.testing.content.override.feature
+++ b/features/com.redhat.rhsm.testing.content.override.feature
@@ -1,7 +1,8 @@
 Feature: The Varlink interface com.redhat.rhsm.testing.content.override
   The Varlink interface com.redhat.rhsm.testing.content.override provides
-  methods for downloading content overrides from the candlepin server and
-  uploading local DNF5 repo overrides to the server.
+  methods for downloading content overrides from the candlepin server,
+  uploading local DNF5 repo overrides to the server, and writing content
+  overrides to the local DNF5 repo override file.
 
 
   Scenario: Download() method raises error on unregistered system
@@ -92,6 +93,69 @@ Feature: The Varlink interface com.redhat.rhsm.testing.content.override
       """
       {"success":true}
       """
+
+
+  @fixture.no_redhat_dnf5_override_installed
+  Scenario: WriteContentOverrides() writes overrides to local file
+    When varlink method is called
+      | method                | interface                                | arguments                                                                                        |
+      | WriteContentOverrides | com.redhat.rhsm.testing.content.override | '{"content_overrides": [{"content_label": "test-write-repo", "name": "enabled", "value": "1"}]}' |
+    Then varlink method returns
+      """
+      {"success":true}
+      """
+    And local DNF5 repo override file contains section 'test-write-repo'
+    And local DNF5 repo override file has 'enabled' set to '1' in section 'test-write-repo'
+
+
+  @fixture.no_redhat_dnf5_override_installed
+  Scenario: WriteContentOverrides() with empty array clears existing content
+    Given local DNF5 repo override file exists with content
+      """
+      [pre-existing-repo]
+      enabled = 1
+      """
+    When varlink method is called
+      | method                | interface                                | arguments                   |
+      | WriteContentOverrides | com.redhat.rhsm.testing.content.override | '{"content_overrides": []}' |
+    Then varlink method returns
+      """
+      {"success":true}
+      """
+    And local DNF5 repo override file is empty
+
+
+  @fixture.no_redhat_dnf5_override_installed
+  Scenario: WriteContentOverrides() called multiple times replaces previous content
+    When varlink method is called
+      | method                | interface                                | arguments                                                                                   |
+      | WriteContentOverrides | com.redhat.rhsm.testing.content.override | '{"content_overrides": [{"content_label": "first-repo", "name": "enabled", "value": "1"}]}' |
+    Then method call was successful
+    And local DNF5 repo override file contains section 'first-repo'
+    And local DNF5 repo override file has 'enabled' set to '1' in section 'first-repo'
+    When varlink method is called
+      | method                | interface                                | arguments                                                                                     |
+      | WriteContentOverrides | com.redhat.rhsm.testing.content.override | '{"content_overrides": [{"content_label": "second-repo", "name": "gpgcheck", "value": "0"}]}' |
+    Then varlink method returns
+      """
+      {"success":true}
+      """
+    And local DNF5 repo override file contains section 'second-repo'
+    And local DNF5 repo override file has 'gpgcheck' set to '0' in section 'second-repo'
+
+
+  @fixture.no_redhat_dnf5_override_installed
+  Scenario: WriteContentOverrides() works on unregistered system
+    Given system is not registered
+    When varlink method is called
+      | method                | interface                                | arguments                                                                                         |
+      | WriteContentOverrides | com.redhat.rhsm.testing.content.override | '{"content_overrides": [{"content_label": "test-unreg-repo", "name": "gpgcheck", "value": "0"}]}' |
+    Then varlink method returns
+      """
+      {"success":true}
+      """
+    And local DNF5 repo override file contains section 'test-unreg-repo'
+    And local DNF5 repo override file has 'gpgcheck' set to '0' in section 'test-unreg-repo'
 
 
   Scenario: Download() returns consistent results across multiple calls

--- a/features/steps/test_content_override.py
+++ b/features/steps/test_content_override.py
@@ -1,5 +1,6 @@
 from behave import given, then
 import behave.runner
+import configparser
 
 import json
 
@@ -46,4 +47,56 @@ def step_impl(context: behave.runner.Context, label: str):
     assert label in labels, (
         f"Expected label '{label}' not found in content overrides. "
         f"Available labels: {labels}"
+    )
+
+
+@then("local DNF5 repo override file contains section '{section}'")
+def step_impl(context: behave.runner.Context, section: str):
+    """
+    Verify the local DNF5 repo override file contains an INI section with the given name.
+    :param context: behave context
+    :param section: INI section name expected in the override file
+    :return: None
+    """
+    config = configparser.ConfigParser()
+    config.read(DNF5_REDHAT_REPOS_OVERRIDE_FILE)
+    assert section in config.sections(), (
+        f"Expected section '{section}' not found in override file. "
+        f"Sections found: {config.sections()}"
+    )
+
+
+@then("local DNF5 repo override file has '{key}' set to '{value}' in section '{section}'")
+def step_impl(context: behave.runner.Context, key: str, value: str, section: str):
+    """
+    Verify a specific key-value pair exists in the given section of the override file.
+    :param context: behave context
+    :param key: INI key to check
+    :param value: expected value for the key
+    :param section: INI section name containing the key
+    :return: None
+    """
+    config = configparser.ConfigParser()
+    config.read(DNF5_REDHAT_REPOS_OVERRIDE_FILE)
+    assert section in config.sections(), (
+        f"Section '{section}' not found in override file. "
+        f"Sections found: {config.sections()}"
+    )
+    actual = config.get(section, key, fallback=None)
+    assert actual == value, (
+        f"Expected [{section}] {key} = {value}, got {actual}"
+    )
+
+
+@then("local DNF5 repo override file is empty")
+def step_impl(context: behave.runner.Context):
+    """
+    Verify the local DNF5 repo override file is empty or contains no INI sections.
+    :param context: behave context
+    :return: None
+    """
+    config = configparser.ConfigParser()
+    config.read(DNF5_REDHAT_REPOS_OVERRIDE_FILE)
+    assert len(config.sections()) == 0, (
+        f"Expected no sections in override file, found: {config.sections()}"
     )

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/jirihnidek/rhsm2 v0.0.0-20260807113404-161e1e76135f
+	github.com/jirihnidek/rhsm2 v0.0.0-20260814154414-71848744336f
 	github.com/pelletier/go-toml v1.9.5
 	github.com/urfave/cli-altsrc/v3 v3.1.0
 	github.com/urfave/cli-docs/v3 v3.1.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/henvic/httpretty v0.2.0 h1:U4pKgF9SV4uRrE/7PF85TVnCJxXA91zKFpYU0iFwFO
 github.com/henvic/httpretty v0.2.0/go.mod h1:4LSlqxtJoYd+gt1lsqh9omUUziIVwoVsxdW15hZHTcI=
 github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade h1:FmusiCI1wHw+XQbvL9M+1r/C3SPqKrmBaIOYwVfQoDE=
 github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade/go.mod h1:ZDXo8KHryOWSIqnsb/CiDq7hQUYryCgdVnxbj8tDG7o=
-github.com/jirihnidek/rhsm2 v0.0.0-20260807113404-161e1e76135f h1:0Qrhb8oVEBGenWjihoHtIe6eTCLrWdHuZefY3Lx3Sek=
-github.com/jirihnidek/rhsm2 v0.0.0-20260807113404-161e1e76135f/go.mod h1:OhFF2Ju6ZLtmvh1uFiGUIsO9+4vXdXYIp08ZxjpFp3g=
+github.com/jirihnidek/rhsm2 v0.0.0-20260814154414-71848744336f h1:VW7JZ1zTljS7MudnU+7Pqb1EgABtov9AOL2ekcXHsK4=
+github.com/jirihnidek/rhsm2 v0.0.0-20260814154414-71848744336f/go.mod h1:OhFF2Ju6ZLtmvh1uFiGUIsO9+4vXdXYIp08ZxjpFp3g=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=

--- a/varlink/overrideapi/com.redhat.rhsm.testing.content.override.go
+++ b/varlink/overrideapi/com.redhat.rhsm.testing.content.override.go
@@ -26,6 +26,14 @@ func (err *ContentNotManagedError) Error() string {
 	return "varlink call failed: com.redhat.rhsm.testing.content.override.ContentNotManaged"
 }
 
+type IOFailedError struct {
+	Message string `json:"message"`
+}
+
+func (err *IOFailedError) Error() string {
+	return "varlink call failed: com.redhat.rhsm.testing.content.override.IOFailed"
+}
+
 type SystemNotRegisteredError struct{}
 
 func (err *SystemNotRegisteredError) Error() string {
@@ -46,6 +54,13 @@ type UploadOut struct {
 	Success bool `json:"success"`
 }
 
+type WriteContentOverridesIn struct {
+	ContentOverrides []ContentOverride `json:"content_overrides"`
+}
+type WriteContentOverridesOut struct {
+	Success bool `json:"success"`
+}
+
 type Client struct {
 	*govarlink.Client
 }
@@ -59,6 +74,8 @@ func unmarshalError(err error) error {
 	switch verr.Name {
 	case "com.redhat.rhsm.testing.content.override.ContentNotManaged":
 		v = new(ContentNotManagedError)
+	case "com.redhat.rhsm.testing.content.override.IOFailed":
+		v = new(IOFailedError)
 	case "com.redhat.rhsm.testing.content.override.SystemNotRegistered":
 		v = new(SystemNotRegisteredError)
 	default:
@@ -85,10 +102,19 @@ func (c Client) Upload(in *UploadIn) (*UploadOut, error) {
 	err := c.Client.Do("com.redhat.rhsm.testing.content.override.Upload", in, out)
 	return out, unmarshalError(err)
 }
+func (c Client) WriteContentOverrides(in *WriteContentOverridesIn) (*WriteContentOverridesOut, error) {
+	if in == nil {
+		in = new(WriteContentOverridesIn)
+	}
+	out := new(WriteContentOverridesOut)
+	err := c.Client.Do("com.redhat.rhsm.testing.content.override.WriteContentOverrides", in, out)
+	return out, unmarshalError(err)
+}
 
 type Backend interface {
 	Download(*DownloadIn) (*DownloadOut, error)
 	Upload(*UploadIn) (*UploadOut, error)
+	WriteContentOverrides(*WriteContentOverridesIn) (*WriteContentOverridesOut, error)
 }
 
 type Handler struct {
@@ -100,6 +126,8 @@ func marshalError(err error) error {
 	switch err.(type) {
 	case *ContentNotManagedError:
 		name = "com.redhat.rhsm.testing.content.override.ContentNotManaged"
+	case *IOFailedError:
+		name = "com.redhat.rhsm.testing.content.override.IOFailed"
 	case *SystemNotRegisteredError:
 		name = "com.redhat.rhsm.testing.content.override.SystemNotRegistered"
 	default:
@@ -128,6 +156,12 @@ func (h Handler) HandleVarlink(call *govarlink.ServerCall, req *govarlink.Server
 			return err
 		}
 		out, err = h.Backend.Upload(in)
+	case "com.redhat.rhsm.testing.content.override.WriteContentOverrides":
+		in := new(WriteContentOverridesIn)
+		if err := json.Unmarshal(req.Parameters, in); err != nil {
+			return err
+		}
+		out, err = h.Backend.WriteContentOverrides(in)
 	default:
 		err = &govarlink.ServerError{
 			Name:       "org.varlink.service.MethodNotFound",
@@ -142,7 +176,7 @@ func (h Handler) HandleVarlink(call *govarlink.ServerCall, req *govarlink.Server
 
 func (h Handler) Register(reg *govarlink.Registry) {
 	reg.Add(&govarlink.RegistryInterface{
-		Definition: "interface com.redhat.rhsm.testing.content.override\n\ntype Metadata (\n    # The user agent string (e.g. \"rhc/5.4.3\")\n    user_agent: ?string,\n    # The correlation id\n    correlation_id: ?string,\n    # The locale string (e.g. en_US.UTF-8)\n    locale: ?string\n)\n\n# Content override representing repo override\ntype ContentOverride (\n    created: ?string,\n    updated: ?string,\n    content_label: string,\n    name: string,\n    value: string\n)\n\n# Many methods in this interface can be used only in the situation, when the system is registered\nerror SystemNotRegistered()\n\n# This error is used, when rhsm is configured to not manage content\nerror ContentNotManaged()\n\n# Get content overrides from the candlepin server\n# When system is not registered, then return error SystemNotRegistered\nmethod Download(\n    metadata: ?Metadata\n) -> (\n    content_overrides: []ContentOverride\n)\n\n# Read current repo-overrides in /etc/dnf/repo.override.d/ and convert it to\n# content overrides and send this document to candlepin server\nmethod Upload(\n    metadata: ?Metadata\n) -> (\n    success: bool\n)\n",
+		Definition: "interface com.redhat.rhsm.testing.content.override\n\ntype Metadata (\n    # The user agent string (e.g. \"rhc/5.4.3\")\n    user_agent: ?string,\n    # The correlation id\n    correlation_id: ?string,\n    # The locale string (e.g. en_US.UTF-8)\n    locale: ?string\n)\n\n# Content override representing repo override\ntype ContentOverride (\n    created: ?string,\n    updated: ?string,\n    content_label: string,\n    name: string,\n    value: string\n)\n\n# Many methods in this interface can be used only in the situation, when the system is registered\nerror SystemNotRegistered()\n\n# This error is used, when rhsm is configured to not manage content\nerror ContentNotManaged()\n\n# This error is returned when a local file system operation fails\nerror IOFailed(message: string)\n\n# Get content overrides from the candlepin server\n# When system is not registered, then return error SystemNotRegistered\nmethod Download(\n    metadata: ?Metadata\n) -> (\n    content_overrides: []ContentOverride\n)\n\n# Read current repo-overrides in /etc/dnf/repo.override.d/ and convert it to\n# content overrides and send this document to candlepin server\nmethod Upload(\n    metadata: ?Metadata\n) -> (\n    success: bool\n)\n\n# Write content overrides to drop-in dnf5 repo override file in /etc/dnf/repo.override.d/\n# Note: created/updated fields on ContentOverride are ignored for this method;\n# they are candlepin-side metadata with no meaning for local repo files.\nmethod WriteContentOverrides(\n    content_overrides: []ContentOverride\n) -> (\n    success: bool\n)\n",
 		Name:       "com.redhat.rhsm.testing.content.override",
 	}, h)
 }

--- a/varlink/overrideapi/com.redhat.rhsm.testing.content.override.varlink
+++ b/varlink/overrideapi/com.redhat.rhsm.testing.content.override.varlink
@@ -24,6 +24,9 @@ error SystemNotRegistered()
 # This error is used, when rhsm is configured to not manage content
 error ContentNotManaged()
 
+# This error is returned when a local file system operation fails
+error IOFailed(message: string)
+
 # Get content overrides from the candlepin server
 # When system is not registered, then return error SystemNotRegistered
 method Download(
@@ -36,6 +39,15 @@ method Download(
 # content overrides and send this document to candlepin server
 method Upload(
     metadata: ?Metadata
+) -> (
+    success: bool
+)
+
+# Write content overrides to drop-in dnf5 repo override file in /etc/dnf/repo.override.d/
+# Note: created/updated fields on ContentOverride are ignored for this method;
+# they are candlepin-side metadata with no meaning for local repo files.
+method WriteContentOverrides(
+    content_overrides: []ContentOverride
 ) -> (
     success: bool
 )


### PR DESCRIPTION
Add WriteContentOverrides to com.redhat.rhsm.testing.content.override,
enabling clients to write downloaded content override data to the local
DNF5 repo override file at /etc/dnf/repos.override.d/98-redhat.repo.

- Add WriteContentOverrides method to varlink interface definition
- Regenerate overrideapi go code with new method types and handler
- Add WriteLocalContentOverrides helper wrapping rhsm2.WriteDnf5RepoOverrides
- No registration check required (it's local-only file operation)
- Bump rhsm2 dependency to 648f6b60538a

This patch also includes Behave integration test scenarios covering the new
WriteContentOverrides method in com.redhat.rhsm.testing.content.override.

Resolves: [CCT-2814](https://redhat.atlassian.net/browse/CCT-2814)

[CCT-2814]: https://redhat.atlassian.net/browse/CCT-2814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ