### PR TITLE
Fix empty JSON output to return "[]" instead of "{}"

### DIFF
--- a/cmd/rhc/collector_cmd.go
+++ b/cmd/rhc/collector_cmd.go
@@ -106,7 +106,7 @@ func collectorListAction(ctx context.Context, cmd *cli.Command) error {
 
 	if ui.IsOutputMachineReadable() {
 		if len(response.Collectors) == 0 {
-			fmt.Println("{}")
+			fmt.Println("[]")
 			return nil
 		}
 		jsonData, err := json.Marshal(response.Collectors)

--- a/internal/ui/collector.go
+++ b/internal/ui/collector.go
@@ -43,7 +43,7 @@ func formatRelativeTime(d time.Duration) string {
 // printMachineReadable marshals data to JSON and prints it to stdout.
 func printMachineReadable(data interface{}) {
 	if slice, ok := data.([]*collectorapi.CollectorInfo); ok && len(slice) == 0 {
-		fmt.Println("{}")
+		fmt.Println("[]")
 		return
 	}
 	jsonData, err := json.Marshal(data)


### PR DESCRIPTION
  When no data collectors are configured, 'rhc collector list --format json'
  and 'rhc collector timers --format json' output {} (empty JSON object).
  Since collectors are a list, the correct empty value is [] (empty array).

## Fix:
Changed two locations that explicitly print `{}` to print `[]` instead:
  - `cmd/rhc/collector_cmd.go` — `collectorListAction`
  - `internal/ui/collector.go` — `printMachineReadable`

 ## How I tested
  1. Built rhc and rhc-server from source on RHEL 10 (x86_64)
  2. Started rhc-server with an empty /usr/lib/rhc/collectors/ directory
  3. Before fix: rhc collector list --format json → {}
  4. Before fix: rhc collector timers --format json → {}
  5. After fix: rhc collector list --format json → []
  6. After fix: rhc collector timers --format json → []

  Resolves: RHEL-216725