### PR TITLE
refactor(status): move checks to operations

### DIFF
--- a/cmd/rhc/status_cmd.go
+++ b/cmd/rhc/status_cmd.go
@@ -2,182 +2,14 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"log/slog"
-	"os"
 
 	"github.com/urfave/cli/v3"
 
-	"github.com/redhatinsights/rhc/internal/datacollection"
-	"github.com/redhatinsights/rhc/internal/remotemanagement"
-	"github.com/redhatinsights/rhc/internal/subman"
 	"github.com/redhatinsights/rhc/internal/ui"
 	"github.com/redhatinsights/rhc/pkg/exitcode"
+	"github.com/redhatinsights/rhc/pkg/operations"
 )
-
-// rhsmStatus tries to print status provided by RHSM D-Bus API. If we provide
-// output in machine-readable format, then we only set files in SystemStatus
-// structure and content of this structure will be printed later
-func rhsmStatus(systemStatus *SystemStatus) error {
-	slog.Info("Checking status of Red Hat Subscription Management")
-
-	client, err := subman.NewRHSMClient()
-	if err != nil {
-		systemStatus.returnCode += 1
-		systemStatus.RHSMError = err.Error()
-		return fmt.Errorf("unable to check registration status: %s", err)
-	}
-	registered, err := client.IsRegistered()
-	if err != nil {
-		systemStatus.returnCode += 1
-		systemStatus.RHSMError = err.Error()
-		return fmt.Errorf("unable to check registration status: %s", err)
-	}
-	if !registered {
-		systemStatus.returnCode += 1
-		systemStatus.RHSMConnected = false
-		infoMsg := "Not connected to Red Hat Subscription Management"
-		slog.Info(infoMsg)
-		ui.Printf("%s[ ] %v\n", ui.Indent.Small, infoMsg)
-	} else {
-		systemStatus.RHSMConnected = true
-		infoMsg := "Connected to Red Hat Subscription Management"
-		slog.Info(infoMsg)
-		ui.Printf("%s[%v] %v\n", ui.Indent.Small, ui.Icons.Ok, infoMsg)
-	}
-	return nil
-}
-
-// isContentEnabled reports whether the system has access to RHSM content.
-// It relies on systemStatus.RHSMConnected already being populated by rhsmStatus.
-func isContentEnabled(systemStatus *SystemStatus) error {
-	slog.Info("Checking content status")
-
-	client, err := subman.NewRHSMClient()
-	if err != nil {
-		systemStatus.returnCode += 1
-		systemStatus.ContentError = err.Error()
-		return fmt.Errorf("unable to check content management: %w", err)
-	}
-	contentEnabled, err := client.IsContentManagementEnabled()
-	if err != nil {
-		systemStatus.returnCode += 1
-		systemStatus.ContentError = err.Error()
-		return fmt.Errorf("unable to check content management: %w", err)
-	}
-
-	if contentEnabled && systemStatus.RHSMConnected {
-		systemStatus.ContentEnabled = true
-		infoMsg := "System has access to content"
-		slog.Info(infoMsg)
-		ui.Printf("%s[%v] Content ... %v\n", ui.Indent.Medium, ui.Icons.Ok, infoMsg)
-	} else {
-		systemStatus.ContentEnabled = false
-		infoMsg := "System has no access to content"
-		slog.Info(infoMsg)
-		ui.Printf("%s[ ] Content ... %v\n", ui.Indent.Medium, infoMsg)
-	}
-	return nil
-}
-
-// insightStatus tries to print status of insights client
-func insightStatus(systemStatus *SystemStatus) error {
-	slog.Info("Checking status of Red Hat Lightspeed")
-
-	var isRegistered bool
-	var err error
-	spinErr := ui.Spinner(func() error {
-		isRegistered, err = datacollection.InsightsClientIsRegistered()
-		return nil
-	}, ui.Indent.Medium, "Checking Red Hat Lightspeed (formerly Insights)...")
-	if spinErr != nil {
-		return spinErr
-	}
-
-	if isRegistered {
-		systemStatus.InsightsConnected = true
-		slog.Info("Connected to Red Hat Lightspeed")
-		ui.Printf("%s[%v] Analytics ... Connected to Red Hat Lightspeed (formerly Insights)\n", ui.Indent.Medium, ui.Icons.Ok)
-	} else {
-		systemStatus.returnCode += 1
-		if err == nil {
-			systemStatus.InsightsConnected = false
-			slog.Info("Not connected to Red Hat Lightspeed")
-			ui.Printf("%s[ ] Analytics ... Not connected to Red Hat Lightspeed (formerly Insights)\n", ui.Indent.Medium)
-		} else {
-			systemStatus.InsightsConnected = false
-			systemStatus.InsightsError = err.Error()
-			return err
-		}
-	}
-	return nil
-}
-
-// serviceStatus tries to print status of yggdrasil.service or rhcd.service
-func serviceStatus(systemStatus *SystemStatus) error {
-	slog.Info("Checking status of yggdrasil service")
-
-	state, err := remotemanagement.GetUnitState("yggdrasil.service")
-	if err != nil {
-		systemStatus.YggdrasilRunning = false
-		systemStatus.YggdrasilError = err.Error()
-		return err
-	}
-
-	if state.ActiveState == "active" {
-		systemStatus.YggdrasilRunning = true
-		infoMsg := "The yggdrasil service is active"
-		slog.Info(infoMsg)
-		ui.Printf("%s[%v] Remote Management ... %v\n", ui.Indent.Medium, ui.Icons.Ok, infoMsg)
-	} else if state.LoadState == "loaded" {
-		systemStatus.returnCode += 1
-		systemStatus.YggdrasilRunning = false
-		warnMsg := "The yggdrasil service is not running"
-		slog.Warn(warnMsg)
-		ui.Printf("%s[ ] Remote Management ... %v\n", ui.Indent.Medium, warnMsg)
-	} else {
-		systemStatus.returnCode += 1
-		systemStatus.YggdrasilRunning = false
-		errMsg := "The yggdrasil service is not available"
-		systemStatus.YggdrasilError = errMsg
-		if state.LoadError != "" {
-			slog.Error(errMsg, "reason", state.LoadError)
-		} else {
-			slog.Error(errMsg)
-		}
-		ui.Printf("%s[%s] Remote Management ... %v\n", ui.Indent.Medium, ui.Icons.Error, errMsg)
-	}
-	return nil
-}
-
-// SystemStatus is structure holding information about system status
-// When more file format is supported, then add more tags for fields
-// like xml:"hostname"
-type SystemStatus struct {
-	SystemHostname    string `json:"hostname"`
-	HostnameError     string `json:"hostname_error,omitempty"`
-	RHSMConnected     bool   `json:"rhsm_connected"`
-	RHSMError         string `json:"rhsm_error,omitempty"`
-	ContentEnabled    bool   `json:"content_enabled"`
-	ContentError      string `json:"content_error,omitempty"`
-	InsightsConnected bool   `json:"insights_connected"`
-	InsightsError     string `json:"insights_error,omitempty"`
-	YggdrasilRunning  bool   `json:"yggdrasil_running"`
-	YggdrasilError    string `json:"yggdrasil_error,omitempty"`
-	returnCode        int
-}
-
-// printJSONStatus tries to print the system status as JSON to stdout.
-// When marshaling of systemStatus fails, then error is returned
-func printJSONStatus(systemStatus *SystemStatus) error {
-	data, err := json.MarshalIndent(systemStatus, "", "    ")
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(data))
-	return nil
-}
 
 // beforeStatusAction ensures the user has supplied a correct `--format` flag.
 func beforeStatusAction(ctx context.Context, cmd *cli.Command) (context.Context, error) {
@@ -191,113 +23,110 @@ func beforeStatusAction(ctx context.Context, cmd *cli.Command) (context.Context,
 	return ctx, checkForUnknownArgs(cmd)
 }
 
-// statusAction tries to print status of system. It means that it gives
-// answer on following questions:
-// 1. Is system registered to Red Hat Subscription Management?
-// 2. Is system connected to Red Hat Lightspeed?
-// 3. Is yggdrasil.service (rhcd.service) running?
-// Status can be printed as human-readable text or machine-readable JSON document.
-// Format is influenced by --format json CLI option stored in CLI context
-func statusAction(ctx context.Context, cmd *cli.Command) (err error) {
+// statusAction prints the status of the system: whether it is registered to Red
+// Hat Subscription Management, connected to Red Hat Lightspeed, and whether
+// yggdrasil.service (rhcd.service) is running. The output is human-readable text
+// or a machine-readable JSON document, selected by the --format CLI option.
+func statusAction(_ context.Context, cmd *cli.Command) error {
+	return runStatusAction(cmd, operations.GetStatus)
+}
+
+func runStatusAction(cmd *cli.Command, getStatus func() *operations.StatusReport) error {
 	logCommandStart(cmd)
 
-	var systemStatus SystemStatus
-	var machineReadablePrintFunc func(systemStatus *SystemStatus) error
+	var report *operations.StatusReport
+	_ = ui.Spinner(func() error {
+		report = getStatus()
+		return nil
+	}, ui.Indent.Small, "Querying status...")
 
-	format := cmd.String("format")
-	switch format {
-	case "json":
-		machineReadablePrintFunc = printJSONStatus
-	default:
-		break
-	}
-
-	// When printing of status is requested, then print machine-readable file format
-	// at the end of this function
 	if ui.IsOutputMachineReadable() {
-		defer func(systemStatus *SystemStatus) {
-			err = machineReadablePrintFunc(systemStatus)
-			// When it was not possible to print status to machine-readable format, then
-			// change returned error to CLI exit error to be able to set exit code to
-			// a non-zero value
-			if err != nil {
-				err = cli.Exit(
-					fmt.Errorf("unable to print status as %s document: %s", format, err.Error()),
-					exitcode.IOErr)
-			}
-			// When any of status is not correct, then return exitcode.Err exit code
-			if systemStatus.returnCode != 0 {
-				err = cli.Exit("", exitcode.Err)
-			}
-		}(&systemStatus)
-	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		if ui.IsOutputMachineReadable() {
-			systemStatus.HostnameError = err.Error()
-		} else {
-			return cli.Exit(err, exitcode.Err)
+		printErr := ui.PrintJSON(report)
+		// A failing check takes precedence over a printing error.
+		if report.HasFailures() {
+			return cli.Exit("", exitcode.Err)
 		}
+		if printErr != nil {
+			return cli.Exit(
+				fmt.Errorf("unable to print status as %s document: %s", cmd.String("format"), printErr.Error()),
+				exitcode.IOErr)
+		}
+		return nil
 	}
 
-	systemStatus.SystemHostname = hostname
-	ui.Printf("Connection status for %v:\n\n", hostname)
-	slog.Info("Checking system connection status")
-
-	/* 1. Get Status of RHSM */
-	err = rhsmStatus(&systemStatus)
-	if err != nil {
-		slog.Error(fmt.Sprintf("Cannot detect Red Hat Subscription Management status: %v", err))
-		ui.Printf(
-			"%s[%s] Red Hat Subscription Management ... %s\n",
-			ui.Indent.Small,
-			ui.Icons.Error,
-			err,
-		)
+	if report.HostnameError != "" {
+		return cli.Exit(report.HostnameError, exitcode.Err)
 	}
 
-	/* 2. Is content enabled */
-	err = isContentEnabled(&systemStatus)
-	if err != nil {
-		slog.Error(fmt.Sprintf("Cannot detect content management status: %v", err))
-		ui.Printf(
-			"%s[%s] Content ... %s\n",
-			ui.Indent.Medium,
-			ui.Icons.Error,
-			err,
-		)
-	}
-
-	/* 3. Get status of insights-client */
-	err = insightStatus(&systemStatus)
-	if err != nil {
-		slog.Error(fmt.Sprintf("Cannot detect Red Hat Lightspeed status: %v", err))
-		ui.Printf("%s[%v] Analytics ... Cannot detect Red Hat Lightspeed (formerly Insights) status: %v\n",
-			ui.Indent.Medium,
-			ui.Icons.Error,
-			err,
-		)
-	}
-
-	/* 3. Get status of yggdrasil (rhcd) service */
-	err = serviceStatus(&systemStatus)
-	if err != nil {
-		ui.Printf(
-			"%s[%s] Remote Management ... %s\n",
-			ui.Indent.Medium,
-			ui.Icons.Error,
-			err,
-		)
-	}
+	ui.Printf("Connection status for %v:\n\n", report.Hostname)
+	formatRHSMStatus(*report)
+	formatContentStatus(*report)
+	formatInsightsStatus(*report)
+	formatServiceStatus(*report)
 
 	ui.Printf("\nManage your connected systems: https://red.ht/connector\n")
 
-	// At the end check if all statuses are correct.
-	// If not, return exitcode.Err exit code without any message.
-	if systemStatus.returnCode != 0 {
+	if report.HasFailures() {
 		return cli.Exit("", exitcode.Err)
 	}
 
 	return nil
+}
+
+// formatRHSMStatus prints the human-readable Red Hat Subscription Management line.
+func formatRHSMStatus(report operations.StatusReport) {
+	switch {
+	case report.RHSMError != "":
+		ui.Printf(
+			"%s[%s] Red Hat Subscription Management ... %s\n",
+			ui.Indent.Small,
+			ui.Icons.Error,
+			"unable to check registration status: "+report.RHSMError,
+		)
+	case report.RHSMConnected:
+		ui.Printf("%s[%v] %v\n", ui.Indent.Small, ui.Icons.Ok, "Connected to Red Hat Subscription Management")
+	default:
+		ui.Printf("%s[ ] %v\n", ui.Indent.Small, "Not connected to Red Hat Subscription Management")
+	}
+}
+
+// formatContentStatus prints the human-readable content access line.
+func formatContentStatus(report operations.StatusReport) {
+	switch {
+	case report.ContentError != "":
+		ui.Printf(
+			"%s[%s] Content ... %s\n",
+			ui.Indent.Medium,
+			ui.Icons.Error,
+			"unable to check content management: "+report.ContentError,
+		)
+	case report.ContentEnabled:
+		ui.Printf("%s[%v] Content ... %v\n", ui.Indent.Medium, ui.Icons.Ok, "System has access to content")
+	default:
+		ui.Printf("%s[ ] Content ... %v\n", ui.Indent.Medium, "System has no access to content")
+	}
+}
+
+// formatInsightsStatus prints the human-readable Red Hat Lightspeed line.
+func formatInsightsStatus(report operations.StatusReport) {
+	switch {
+	case report.InsightsConnected:
+		ui.Printf("%s[%v] Analytics ... Connected to Red Hat Lightspeed (formerly Insights)\n", ui.Indent.Medium, ui.Icons.Ok)
+	case report.InsightsError != "":
+		ui.Printf("%s[%v] Analytics ... Cannot detect Red Hat Lightspeed (formerly Insights) status: %v\n", ui.Indent.Medium, ui.Icons.Error, report.InsightsError)
+	default:
+		ui.Printf("%s[ ] Analytics ... Not connected to Red Hat Lightspeed (formerly Insights)\n", ui.Indent.Medium)
+	}
+}
+
+// formatServiceStatus prints the human-readable remote management (yggdrasil) line.
+func formatServiceStatus(report operations.StatusReport) {
+	switch {
+	case report.YggdrasilError != "":
+		ui.Printf("%s[%s] Remote Management ... %s\n", ui.Indent.Medium, ui.Icons.Error, report.YggdrasilError)
+	case report.YggdrasilRunning:
+		ui.Printf("%s[%v] Remote Management ... %v\n", ui.Indent.Medium, ui.Icons.Ok, "The yggdrasil service is active")
+	default:
+		ui.Printf("%s[ ] Remote Management ... %v\n", ui.Indent.Medium, "The yggdrasil service is not running")
+	}
 }

--- a/cmd/rhc/status_cmd_test.go
+++ b/cmd/rhc/status_cmd_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/redhatinsights/rhc/internal/ui"
+	"github.com/redhatinsights/rhc/pkg/operations"
+)
+
+// captureStdout redirects stdout to a pipe, initializes plain UI output, and
+// returns what fn printed. The function may reconfigure the UI while it runs.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	originalStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	os.Stdout = writer
+	ui.ConfigureOutput(false, false, false)
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+		ui.ConfigureOutput(true, true, false)
+	})
+
+	fn()
+	_ = writer.Close()
+	out, _ := io.ReadAll(reader)
+	_ = reader.Close()
+	return string(out)
+}
+
+func TestRunStatusActionJSON(t *testing.T) {
+	statusCalls := 0
+	getStatus := func() *operations.StatusReport {
+		statusCalls++
+		return &operations.StatusReport{
+			Hostname:          "test-host",
+			RHSMConnected:     true,
+			ContentEnabled:    true,
+			InsightsConnected: true,
+			YggdrasilRunning:  true,
+		}
+	}
+
+	var actionErr error
+	got := captureStdout(t, func() {
+		ui.ConfigureOutput(false, false, true)
+		defer ui.ConfigureOutput(false, false, false)
+
+		actionErr = runStatusAction(&cli.Command{Name: "status"}, getStatus)
+	})
+
+	if actionErr != nil {
+		t.Fatalf("status command error = %v", actionErr)
+	}
+	if statusCalls != 1 {
+		t.Errorf("status calls = %d, want 1", statusCalls)
+	}
+	want := `{
+    "hostname": "test-host",
+    "rhsm_connected": true,
+    "content_enabled": true,
+    "insights_connected": true,
+    "yggdrasil_running": true
+}` + "\n"
+	if got != want {
+		t.Errorf("output = %q, want %q", got, want)
+	}
+}
+
+// TestFormatStatusLines pins the exact human-readable line each formatter prints
+// for its success, negative, and error states.
+func TestFormatStatusLines(t *testing.T) {
+	ui.ConfigureOutput(false, false, false)
+	okIcon := ui.Icons.Ok
+	errorIcon := ui.Icons.Error
+	tests := []struct {
+		name   string
+		render func()
+		want   string
+	}{
+		{
+			name:   "rhsm connected",
+			render: func() { formatRHSMStatus(operations.StatusReport{RHSMConnected: true}) },
+			want:   " [" + okIcon + "] Connected to Red Hat Subscription Management\n",
+		},
+		{
+			name:   "rhsm not connected",
+			render: func() { formatRHSMStatus(operations.StatusReport{}) },
+			want:   " [ ] Not connected to Red Hat Subscription Management\n",
+		},
+		{
+			name:   "rhsm error",
+			render: func() { formatRHSMStatus(operations.StatusReport{RHSMError: "boom"}) },
+			want:   " [" + errorIcon + "] Red Hat Subscription Management ... unable to check registration status: boom\n",
+		},
+		{
+			name:   "content enabled",
+			render: func() { formatContentStatus(operations.StatusReport{ContentEnabled: true}) },
+			want:   "  [" + okIcon + "] Content ... System has access to content\n",
+		},
+		{
+			name:   "content disabled",
+			render: func() { formatContentStatus(operations.StatusReport{}) },
+			want:   "  [ ] Content ... System has no access to content\n",
+		},
+		{
+			name:   "content error",
+			render: func() { formatContentStatus(operations.StatusReport{ContentError: "boom"}) },
+			want:   "  [" + errorIcon + "] Content ... unable to check content management: boom\n",
+		},
+		{
+			name:   "insights connected",
+			render: func() { formatInsightsStatus(operations.StatusReport{InsightsConnected: true}) },
+			want:   "  [" + okIcon + "] Analytics ... Connected to Red Hat Lightspeed (formerly Insights)\n",
+		},
+		{
+			name:   "insights not connected",
+			render: func() { formatInsightsStatus(operations.StatusReport{}) },
+			want:   "  [ ] Analytics ... Not connected to Red Hat Lightspeed (formerly Insights)\n",
+		},
+		{
+			name:   "insights error",
+			render: func() { formatInsightsStatus(operations.StatusReport{InsightsError: "boom"}) },
+			want:   "  [" + errorIcon + "] Analytics ... Cannot detect Red Hat Lightspeed (formerly Insights) status: boom\n",
+		},
+		{
+			name:   "yggdrasil active",
+			render: func() { formatServiceStatus(operations.StatusReport{YggdrasilRunning: true}) },
+			want:   "  [" + okIcon + "] Remote Management ... The yggdrasil service is active\n",
+		},
+		{
+			name:   "yggdrasil not running",
+			render: func() { formatServiceStatus(operations.StatusReport{}) },
+			want:   "  [ ] Remote Management ... The yggdrasil service is not running\n",
+		},
+		{
+			name: "yggdrasil error",
+			render: func() {
+				formatServiceStatus(operations.StatusReport{YggdrasilError: "The yggdrasil service is not available"})
+			},
+			want: "  [" + errorIcon + "] Remote Management ... The yggdrasil service is not available\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := captureStdout(t, tt.render)
+			if got != tt.want {
+				t.Errorf("output = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/operations/status.go
+++ b/pkg/operations/status.go
@@ -1,0 +1,189 @@
+package operations
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/redhatinsights/rhc/internal/datacollection"
+	"github.com/redhatinsights/rhc/internal/remotemanagement"
+	"github.com/redhatinsights/rhc/internal/subman"
+)
+
+// statusDependencies holds the infrastructure calls used to gather status.
+// Tests replace these functions with fakes.
+type statusDependencies struct {
+	Hostname                   func() (string, error)
+	RHSMIsRegistered           func() (bool, error)
+	ContentIsEnabled           func() (bool, error)
+	InsightsClientIsRegistered func() (bool, error)
+	GetUnitState               func(string) (*remotemanagement.UnitState, error)
+}
+
+// defaultStatusDependencies returns the dependencies backed by the real
+// infrastructure calls.
+func defaultStatusDependencies() statusDependencies {
+	return statusDependencies{
+		Hostname:                   os.Hostname,
+		RHSMIsRegistered:           IsRegistered,
+		ContentIsEnabled:           contentIsEnabled,
+		InsightsClientIsRegistered: datacollection.InsightsClientIsRegistered,
+		GetUnitState:               remotemanagement.GetUnitState,
+	}
+}
+
+func contentIsEnabled() (bool, error) {
+	service, err := subman.NewRHSMClient()
+	if err != nil {
+		return false, err
+	}
+	return service.IsContentManagementEnabled()
+}
+
+// StatusReport describes the system's connection status. Its fields are the
+// machine-readable form; failedChecks is unexported and so is not serialized.
+type StatusReport struct {
+	Hostname          string `json:"hostname"`
+	HostnameError     string `json:"hostname_error,omitempty"`
+	RHSMConnected     bool   `json:"rhsm_connected"`
+	RHSMError         string `json:"rhsm_error,omitempty"`
+	ContentEnabled    bool   `json:"content_enabled"`
+	ContentError      string `json:"content_error,omitempty"`
+	InsightsConnected bool   `json:"insights_connected"`
+	InsightsError     string `json:"insights_error,omitempty"`
+	YggdrasilRunning  bool   `json:"yggdrasil_running"`
+	YggdrasilError    string `json:"yggdrasil_error,omitempty"`
+	// failedChecks counts checks that failed in a way that should make the
+	// command exit non-zero.
+	failedChecks int
+}
+
+// HasFailures reports whether any check failed in a way that should result in a
+// non-zero exit code.
+func (r *StatusReport) HasFailures() bool {
+	return r.failedChecks != 0
+}
+
+// GetStatus gathers the system's connection status using the real
+// infrastructure dependencies.
+func GetStatus() *StatusReport {
+	return getStatus(defaultStatusDependencies())
+}
+
+// getStatus gathers the system's connection status using the given dependencies.
+// Per-check failures are recorded in the report rather than returned as an error.
+func getStatus(dependencies statusDependencies) *StatusReport {
+	slog.Info("Checking system connection status")
+
+	report := &StatusReport{}
+
+	collectHostname(report, dependencies.Hostname)
+
+	collectRHSMStatus(report, dependencies.RHSMIsRegistered)
+	collectContentStatus(report, dependencies.ContentIsEnabled)
+	collectInsightsStatus(report, dependencies.InsightsClientIsRegistered)
+	collectYggdrasilStatus(report, dependencies.GetUnitState)
+
+	return report
+}
+
+func collectHostname(report *StatusReport, hostname func() (string, error)) {
+	name, err := hostname()
+	report.Hostname = name
+	if err != nil {
+		report.HostnameError = err.Error()
+	}
+}
+
+func collectRHSMStatus(report *StatusReport, isRegistered func() (bool, error)) {
+	slog.Info("Checking status of Red Hat Subscription Management")
+
+	registered, err := isRegistered()
+	if err != nil {
+		report.failedChecks++
+		report.RHSMError = err.Error()
+		slog.Error("Cannot detect Red Hat Subscription Management status", "error", err)
+		return
+	}
+	if !registered {
+		report.failedChecks++
+		report.RHSMConnected = false
+		slog.Info("Not connected to Red Hat Subscription Management")
+	} else {
+		report.RHSMConnected = true
+		slog.Info("Connected to Red Hat Subscription Management")
+	}
+}
+
+func collectContentStatus(report *StatusReport, isEnabled func() (bool, error)) {
+	slog.Info("Checking content status")
+
+	contentEnabled, err := isEnabled()
+	if err != nil {
+		report.failedChecks++
+		report.ContentError = err.Error()
+		slog.Error("Cannot detect content management status", "error", err)
+		return
+	}
+
+	if contentEnabled && report.RHSMConnected {
+		report.ContentEnabled = true
+		slog.Info("System has access to content")
+	} else {
+		report.ContentEnabled = false
+		slog.Info("System has no access to content")
+	}
+}
+
+func collectInsightsStatus(report *StatusReport, insightsClientIsRegistered func() (bool, error)) {
+	slog.Info("Checking status of Red Hat Lightspeed")
+
+	isRegistered, err := insightsClientIsRegistered()
+
+	if isRegistered {
+		report.InsightsConnected = true
+		slog.Info("Connected to Red Hat Lightspeed")
+	} else {
+		report.failedChecks++
+		if err == nil {
+			report.InsightsConnected = false
+			slog.Info("Not connected to Red Hat Lightspeed")
+		} else {
+			report.InsightsConnected = false
+			report.InsightsError = err.Error()
+			slog.Error("Cannot detect Red Hat Lightspeed status", "error", err)
+		}
+	}
+}
+
+func collectYggdrasilStatus(
+	report *StatusReport,
+	getUnitState func(string) (*remotemanagement.UnitState, error),
+) {
+	slog.Info("Checking status of yggdrasil service")
+
+	state, err := getUnitState("yggdrasil.service")
+	if err != nil {
+		report.YggdrasilRunning = false
+		report.YggdrasilError = err.Error()
+		return
+	}
+
+	if state.ActiveState == "active" {
+		report.YggdrasilRunning = true
+		slog.Info("The yggdrasil service is active")
+	} else if state.LoadState == "loaded" {
+		report.failedChecks++
+		report.YggdrasilRunning = false
+		slog.Warn("The yggdrasil service is not running")
+	} else {
+		report.failedChecks++
+		report.YggdrasilRunning = false
+		errMsg := "The yggdrasil service is not available"
+		report.YggdrasilError = errMsg
+		if state.LoadError != "" {
+			slog.Error(errMsg, "reason", state.LoadError)
+		} else {
+			slog.Error(errMsg)
+		}
+	}
+}

--- a/pkg/operations/status_test.go
+++ b/pkg/operations/status_test.go
@@ -1,0 +1,162 @@
+package operations
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/redhatinsights/rhc/internal/remotemanagement"
+)
+
+func checkError(err error) func() (bool, error) {
+	return func() (bool, error) { return false, err }
+}
+
+// passingDeps returns dependencies where every check succeeds. Tests override
+// single fields to exercise a specific failure.
+func passingDeps() statusDependencies {
+	return statusDependencies{
+		Hostname:                   func() (string, error) { return "test-host", nil },
+		RHSMIsRegistered:           func() (bool, error) { return true, nil },
+		ContentIsEnabled:           func() (bool, error) { return true, nil },
+		InsightsClientIsRegistered: func() (bool, error) { return true, nil },
+		GetUnitState: func(string) (*remotemanagement.UnitState, error) {
+			return &remotemanagement.UnitState{ActiveState: "active", LoadState: "loaded"}, nil
+		},
+	}
+}
+
+func TestGetStatusAllConnected(t *testing.T) {
+	report := getStatus(passingDeps())
+
+	if report.Hostname != "test-host" {
+		t.Errorf("Hostname = %q, want %q", report.Hostname, "test-host")
+	}
+	if !report.RHSMConnected {
+		t.Error("RHSMConnected = false, want true")
+	}
+	if !report.ContentEnabled {
+		t.Error("ContentEnabled = false, want true")
+	}
+	if !report.InsightsConnected {
+		t.Error("InsightsConnected = false, want true")
+	}
+	if !report.YggdrasilRunning {
+		t.Error("YggdrasilRunning = false, want true")
+	}
+	if report.HasFailures() {
+		t.Errorf("HasFailures() = true, want false (failedChecks = %d)", report.failedChecks)
+	}
+}
+
+// Independent RHSM and content check errors are both recorded and counted.
+func TestGetStatusRHSMAndContentErrors(t *testing.T) {
+	deps := passingDeps()
+	deps.RHSMIsRegistered = checkError(errors.New("rhsm boom"))
+	deps.ContentIsEnabled = checkError(errors.New("content boom"))
+
+	report := getStatus(deps)
+
+	if report.RHSMError != "rhsm boom" {
+		t.Errorf("RHSMError = %q, want %q", report.RHSMError, "rhsm boom")
+	}
+	if report.ContentError != "content boom" {
+		t.Errorf("ContentError = %q, want %q", report.ContentError, "content boom")
+	}
+	if report.failedChecks != 2 {
+		t.Errorf("failedChecks = %d, want 2", report.failedChecks)
+	}
+	if !report.InsightsConnected {
+		t.Error("InsightsConnected = false, want true")
+	}
+	if !report.YggdrasilRunning {
+		t.Error("YggdrasilRunning = false, want true")
+	}
+}
+
+func TestGetStatusRequiresRHSMConnectionForContent(t *testing.T) {
+	deps := passingDeps()
+	deps.RHSMIsRegistered = func() (bool, error) { return false, nil }
+	deps.ContentIsEnabled = func() (bool, error) { return true, nil }
+
+	report := getStatus(deps)
+
+	if report.RHSMConnected {
+		t.Error("RHSMConnected = true, want false")
+	}
+	if report.ContentEnabled {
+		t.Error("ContentEnabled = true, want false")
+	}
+	if report.failedChecks != 1 {
+		t.Errorf("failedChecks = %d, want 1", report.failedChecks)
+	}
+}
+
+func TestGetStatusYggdrasilUnavailable(t *testing.T) {
+	deps := passingDeps()
+	deps.GetUnitState = func(string) (*remotemanagement.UnitState, error) {
+		return &remotemanagement.UnitState{ActiveState: "inactive", LoadState: "not-found"}, nil
+	}
+
+	report := getStatus(deps)
+
+	if report.YggdrasilRunning {
+		t.Error("YggdrasilRunning = true, want false")
+	}
+	wantError := "The yggdrasil service is not available"
+	if report.YggdrasilError != wantError {
+		t.Errorf("YggdrasilError = %q, want %q", report.YggdrasilError, wantError)
+	}
+	if report.failedChecks != 1 {
+		t.Errorf("failedChecks = %d, want 1", report.failedChecks)
+	}
+}
+
+func TestGetStatusCountsEachFailure(t *testing.T) {
+	deps := passingDeps()
+	deps.RHSMIsRegistered = func() (bool, error) { return false, nil }
+	deps.ContentIsEnabled = func() (bool, error) { return false, nil }
+	deps.InsightsClientIsRegistered = func() (bool, error) { return false, nil }
+	deps.GetUnitState = func(string) (*remotemanagement.UnitState, error) {
+		return &remotemanagement.UnitState{ActiveState: "inactive", LoadState: "loaded"}, nil
+	}
+
+	report := getStatus(deps)
+
+	// RHSM not registered, insights not registered, yggdrasil loaded-but-inactive.
+	if report.failedChecks != 3 {
+		t.Errorf("failedChecks = %d, want 3", report.failedChecks)
+	}
+	if !report.HasFailures() {
+		t.Error("HasFailures() = false, want true")
+	}
+}
+
+func TestHasFailures(t *testing.T) {
+	if (&StatusReport{}).HasFailures() {
+		t.Error("empty report should report no failures")
+	}
+	if !(&StatusReport{failedChecks: 1}).HasFailures() {
+		t.Error("failedChecks = 1 should report a failure")
+	}
+}
+
+func TestStatusReportJSONContract(t *testing.T) {
+	report := &StatusReport{Hostname: "host", failedChecks: 5}
+
+	data, err := json.MarshalIndent(report, "", "    ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	want := `{
+    "hostname": "host",
+    "rhsm_connected": false,
+    "content_enabled": false,
+    "insights_connected": false,
+    "yggdrasil_running": false
+}`
+	if got := string(data); got != want {
+		t.Errorf("JSON document =\n%s\nwant:\n%s", got, want)
+	}
+}


### PR DESCRIPTION
* CardID: CCT-2407

Move status collection behind a clean GetStatus API while keeping
dependency injection private for tests. Keep formatting, spinner, and
exit-code handling in the CLI, rendering output after collection completes.