### PR TITLE
fix: Refresh varlink method should work properly now

### DIFF
--- a/features/com.redhat.rhsm.testing.content.feature
+++ b/features/com.redhat.rhsm.testing.content.feature
@@ -30,8 +30,31 @@ Feature: The Varlink interface com.redhat.rhsm.testing.content
       """
 
 
+  Scenario: Refresh() method succeeds on registered system after regenerating of entitlement certificate
+    Given system is registered against candlepin server
+    Given entitlement certificate is installed
+    Given entitlement certificate is regenerated on candlepin server
+    # We have to wait one second here, because If-Modified-Since HTTP header can be sent only in
+    # time format defined in RFC 822, which has only second precision. If Refresh() method was
+    # called immediately, then it would lead to 304 HTTP code (not modified), because the time
+    # of creating old and new certificate with second precision would be the same.
+    Then wait '1' seconds
+    When varlink method is called
+      | method  | interface                       | arguments          |
+      | Refresh | com.redhat.rhsm.testing.content | '{"force": false}' |
+    Then varlink method returns
+      """
+      {"success":true}
+      """
+    And entitlement certificate has different name and i-node
+    And installed entitlement certificate contains 'BEGIN CERTIFICATE'
+    And installed entitlement certificate contains 'BEGIN ENTITLEMENT DATA'
+    And installed entitlement certificate contains 'BEGIN SIGNATURE'
+
+
   Scenario: Refresh() method succeeds on registered system with metadata
     Given system is registered against candlepin server
+    Given entitlement certificate is installed
     When varlink method is called
       | method  | interface                       | arguments                                             |
       | Refresh | com.redhat.rhsm.testing.content | '{"force": false, "metadata": {"user_agent": "foo"}}' |
@@ -39,10 +62,12 @@ Feature: The Varlink interface com.redhat.rhsm.testing.content
       """
       {"success":true}
       """
+    And entitlement certificate has still the same name and i-node
 
 
   Scenario: Refresh(force=true) method succeeds on registered system
     Given system is registered against candlepin server
+    Given entitlement certificate is installed
     When varlink method is called
       | method  | interface                       | arguments         |
       | Refresh | com.redhat.rhsm.testing.content | '{"force": true}' |
@@ -50,10 +75,37 @@ Feature: The Varlink interface com.redhat.rhsm.testing.content
       """
       {"success":true}
       """
+    And entitlement certificate has still the same name and i-node
+    And installed entitlement certificate contains 'BEGIN CERTIFICATE'
+    And installed entitlement certificate contains 'BEGIN ENTITLEMENT DATA'
+    And installed entitlement certificate contains 'BEGIN SIGNATURE'
+
+
+  Scenario: Refresh(force=true) method succeeds on registered system after regenerating of entitlement certificate
+    Given system is registered against candlepin server
+    Given entitlement certificate is installed
+    Given entitlement certificate is regenerated on candlepin server
+    # We have to wait one second here, because If-Modified-Since HTTP header can be sent only in
+    # time format defined in RFC 822, which has only second precision. If Refresh() method was
+    # called immediately, then it would lead to 304 HTTP code (not modified), because the time
+    # of creating old and new certificate with second precision would be the same.
+    Then wait '1' seconds
+    When varlink method is called
+      | method  | interface                       | arguments          |
+      | Refresh | com.redhat.rhsm.testing.content | '{"force": true}' |
+    Then varlink method returns
+      """
+      {"success":true}
+      """
+    And entitlement certificate has different name and i-node
+    And installed entitlement certificate contains 'BEGIN CERTIFICATE'
+    And installed entitlement certificate contains 'BEGIN ENTITLEMENT DATA'
+    And installed entitlement certificate contains 'BEGIN SIGNATURE'
 
 
   Scenario: Refresh() called twice on a registered system succeeds both times
     Given system is registered against candlepin server
+    Given entitlement certificate is installed
     When varlink method is called
       | method  | interface                       | arguments          |
       | Refresh | com.redhat.rhsm.testing.content | '{"force": false}' |
@@ -61,6 +113,7 @@ Feature: The Varlink interface com.redhat.rhsm.testing.content
       """
       {"success":true}
       """
+    And entitlement certificate has still the same name and i-node
     And varlink method is called
       | method  | interface                       | arguments          |
       | Refresh | com.redhat.rhsm.testing.content | '{"force": false}' |
@@ -68,3 +121,4 @@ Feature: The Varlink interface com.redhat.rhsm.testing.content
       """
       {"success":true}
       """
+    And entitlement certificate has still the same name and i-node

--- a/features/steps/constants.py
+++ b/features/steps/constants.py
@@ -12,3 +12,4 @@ ENTITLEMENT_HOST_CERT_DIR = "/etc/pki/entitlement-host/"
 RHC_SERVER_LOG_FILE = "/var/log/rhc/rhc-server.log"
 DNF5_REPOS_OVERRIDE_DIR = "/etc/dnf/repos.override.d"
 DNF5_REDHAT_REPOS_OVERRIDE_FILE = os.path.join(DNF5_REPOS_OVERRIDE_DIR, "98-redhat.repo")
+RHSM_CONFIG_FILE = "/etc/rhsm/rhsm.conf"

--- a/features/steps/test_content.py
+++ b/features/steps/test_content.py
@@ -1,0 +1,150 @@
+import os
+import configparser
+import subprocess
+import json
+
+import requests
+from behave import step
+import behave.runner
+
+from constants import ENTITLEMENT_CERT_DIR, RHSM_CONFIG_FILE
+
+
+@step("installed entitlement certificate contains '{string}'")
+def step_impl(context: behave.runner.Context, string):
+    """
+    Try to find at least one entitlement certificate and check if it contains '{string}'
+    :param context: behave context
+    :param string: string expected in the entitlement certificate
+    :return: None
+    """
+    files = os.listdir(ENTITLEMENT_CERT_DIR)
+    string_found = False
+    for file_name in files:
+        # Skip key files
+        if file_name.endswith("-key.pem"):
+            continue
+        if file_name.endswith(".pem"):
+            with open(os.path.join(ENTITLEMENT_CERT_DIR, file_name), "r") as f:
+                content = f.read()
+                if string in content:
+                    string_found = True
+                    break
+    assert string_found, f"Entitlement certificate does not contain '{string}'"
+
+
+@step("entitlement certificate is regenerated on candlepin server")
+def step_impl(context: behave.runner.Context):
+    """
+    Try to enforce a regenerating entitlement certificate on the candlepin server. This could
+    be tested only against locally running candlepin server, where we have admin access.
+    :param context: behave context
+    :return: None
+    """
+    config = configparser.ConfigParser()
+    config.read(RHSM_CONFIG_FILE)
+
+    hostname = config.get("server", "hostname")
+    port = config.get("server", "port")
+    prefix = config.get("server", "prefix")
+
+    # Get consumer UUID using D-Bus
+    result = subprocess.run(
+        ["busctl", "call", "--json=short", "com.redhat.RHSM1", "/com/redhat/RHSM1/Consumer",
+         "com.redhat.RHSM1.Consumer", "GetUuid", "s", ""],
+        capture_output=True,
+        text=True,
+        check=True
+    )
+
+    # Parse UUID from JSON output
+    json_output = json.loads(result.stdout)
+    consumer_uuid = json_output["data"][0]
+
+    # Make REST API call to regenerate certificates
+    url = f"https://{hostname}:{port}{prefix}/consumers/{consumer_uuid}/certificates?lazy_regen=false"
+    response = requests.put(url, auth=('admin', 'admin'), verify=False)
+    response.raise_for_status()
+
+
+@step("entitlement certificate is installed")
+def step_impl(context: behave.runner.Context):
+    """
+    Check if at least one entitlement certificate is installed. If yes, then store
+    entitlement certificate path in the context
+    :param context: behave context
+    :return: None
+    """
+    files = os.listdir(ENTITLEMENT_CERT_DIR)
+    ent_cert_found = False
+    for file_name in files:
+        # Skip key files
+        if file_name.endswith("-key.pem"):
+            continue
+        if file_name.endswith(".pem"):
+            with open(os.path.join(ENTITLEMENT_CERT_DIR, file_name), "r") as f:
+                context.entitlement_cert_path = os.path.join(ENTITLEMENT_CERT_DIR, file_name)
+                context.entitlement_cert_inode = os.stat(context.entitlement_cert_path).st_ino
+                ent_cert_found = True
+                break
+
+    if not ent_cert_found:
+        raise Exception("No entitlement certificate found")
+
+
+@step("entitlement certificate has different name and i-node")
+def step_impl(context: behave.runner.Context):
+    """
+    Check if the entitlement certificate has changed name and i-node
+    :param context: behave context
+    :return: None
+    """
+    files = os.listdir(ENTITLEMENT_CERT_DIR)
+    ent_cert_path = None
+    ent_cert_inode = None
+    for file_name in files:
+        # Skip key files
+        if file_name.endswith("-key.pem"):
+            continue
+        if file_name.endswith(".pem"):
+            ent_cert_path = os.path.join(ENTITLEMENT_CERT_DIR, file_name)
+            ent_cert_inode = os.stat(ent_cert_path).st_ino
+            break
+
+    if not ent_cert_path:
+        raise Exception("No entitlement certificate found")
+
+    if context.entitlement_cert_path == ent_cert_path:
+        raise Exception(f"Entitlement certificate has still the same name: {context.entitlement_cert_path}")
+
+    if context.entitlement_cert_inode == ent_cert_inode:
+        raise Exception(f"Entitlement certificate has still the same i-node: {context.entitlement_cert_inode}")
+
+
+@step("entitlement certificate has still the same name and i-node")
+def step_impl(context: behave.runner.Context):
+    """
+    Check if the entitlement certificate has still the same name and i-node
+    :param context: behave context
+    :return: None
+    """
+    files = os.listdir(ENTITLEMENT_CERT_DIR)
+    ent_cert_path = None
+    ent_cert_inode = None
+    for file_name in files:
+        # Skip key files
+        if file_name.endswith("-key.pem"):
+            continue
+        if file_name.endswith(".pem"):
+            ent_cert_path = os.path.join(ENTITLEMENT_CERT_DIR, file_name)
+            ent_cert_inode = os.stat(ent_cert_path).st_ino
+            break
+
+    if not ent_cert_path:
+        raise Exception("No entitlement certificate found")
+
+    if context.entitlement_cert_path != ent_cert_path:
+        raise Exception(f"Entitlement certificate name has changed from {context.entitlement_cert_path} to {ent_cert_path}")
+
+    if context.entitlement_cert_inode != ent_cert_inode:
+        raise Exception(f"Entitlement certificate i-node has changed from {context.entitlement_cert_inode} to {ent_cert_inode}")

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/jirihnidek/rhsm2 v0.0.0-20260824173206-6e9f30cd2db7
+	github.com/jirihnidek/rhsm2 v0.0.0-20260901114510-13670718c1c2
 	github.com/pelletier/go-toml v1.9.5
 	github.com/urfave/cli-altsrc/v3 v3.1.0
 	github.com/urfave/cli-docs/v3 v3.1.0

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade h1:FmusiCI1wH
 github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade/go.mod h1:ZDXo8KHryOWSIqnsb/CiDq7hQUYryCgdVnxbj8tDG7o=
 github.com/jirihnidek/rhsm2 v0.0.0-20260824173206-6e9f30cd2db7 h1:THcVbZyNrkPVIOwSHVZbJ8dGFgiJNkbteYQZ4/UjMPk=
 github.com/jirihnidek/rhsm2 v0.0.0-20260824173206-6e9f30cd2db7/go.mod h1:OhFF2Ju6ZLtmvh1uFiGUIsO9+4vXdXYIp08ZxjpFp3g=
+github.com/jirihnidek/rhsm2 v0.0.0-20260901114510-13670718c1c2 h1:TGOZhthHE0Up0A9tK6tfHWyD3UKsNTUeXl4u850RcsA=
+github.com/jirihnidek/rhsm2 v0.0.0-20260901114510-13670718c1c2/go.mod h1:OhFF2Ju6ZLtmvh1uFiGUIsO9+4vXdXYIp08ZxjpFp3g=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=


### PR DESCRIPTION
* When Refresh() Varlink method was called, then rhsm2
  wrote only first block of entitlement certificate.
  This issue was fixed in upstream of rhsm2:
  https://github.com/jirihnidek/rhsm2/pull/111
* Updated rhsm2 to the latest version
* Added `test_content.py` with more testing steps
* Extended integration tests for the case, when entitlement
  is really updated on the candlepin server
* Added integration test for the issue fixed in:
  https://github.com/jirihnidek/rhsm2/pull/111