### PR TITLE
feat(selinux): add in-tree module skeleton for collector domains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ settings.toml
 /vendor/
 /artifacts/
 __pycache__/
+/selinux/*.pp
+/selinux/*.mod
+/selinux/tmp/

--- a/selinux/rhc.fc
+++ b/selinux/rhc.fc
@@ -1,0 +1,14 @@
+# rhc-collector systemd oneshot binary
+/usr/libexec/rhc/rhc-collector			--	gen_context(system_u:object_r:rhc_collector_exec_t,s0)
+
+# com.redhat.minimal collector binary
+/usr/libexec/rhc/collectors/com\.redhat\.minimal	--	gen_context(system_u:object_r:rhc_collector_minimal_exec_t,s0)
+
+# Collector configuration (TOML) shipped under /usr/lib/rhc/collectors
+/usr/lib/rhc/collectors(/.*)?				gen_context(system_u:object_r:rhc_collector_conf_t,s0)
+
+# Collector timer cache
+/var/cache/rhc/collectors(/.*)?				gen_context(system_u:object_r:rhc_cache_t,s0)
+
+# Collector working directory
+/var/tmp/rhc(/.*)?					gen_context(system_u:object_r:rhc_tmp_t,s0)

--- a/selinux/rhc.if
+++ b/selinux/rhc.if
@@ -1,0 +1,54 @@
+## <summary>SELinux policy for rhc-collector domains</summary>
+
+########################################
+## <summary>
+##	Execute rhc-collector in the rhc_collector_t domain.
+## </summary>
+## <desc>
+##	<p>
+##	Public API for transitioning into rhc_collector_t when executing
+##	rhc_collector_exec_t. Not invoked from rhc.te: init_daemon_domain()
+##	already wires init_t (systemd) for the oneshot runner. Exported for
+##	CCT-2894 and for other policy modules that need this transition.
+##	</p>
+## </desc>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`rhc_collector_domtrans',`
+	gen_require(`
+		type rhc_collector_t, rhc_collector_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, rhc_collector_exec_t, rhc_collector_t)
+')
+
+########################################
+## <summary>
+##	Execute com.redhat.minimal in the rhc_collector_minimal_t domain.
+## </summary>
+## <desc>
+##	<p>
+##	Automatic domain transition to rhc_collector_minimal_t when executing
+##	rhc_collector_minimal_exec_t. Sufficient for rhc_collector_t to start
+##	the child collector confined.
+##	</p>
+## </desc>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`rhc_collector_minimal_domtrans',`
+	gen_require(`
+		type rhc_collector_minimal_t, rhc_collector_minimal_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, rhc_collector_minimal_exec_t, rhc_collector_minimal_t)
+')

--- a/selinux/rhc.te
+++ b/selinux/rhc.te
@@ -1,0 +1,47 @@
+policy_module(rhc, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+# Skeleton only: process domains and file types. Do not encode the full
+# allow set here; that is later work.
+#
+
+#
+# rhc_collector_t — systemd oneshot runner (/usr/libexec/rhc/rhc-collector)
+#
+type rhc_collector_t;
+type rhc_collector_exec_t;
+init_daemon_domain(rhc_collector_t, rhc_collector_exec_t)
+
+#
+# rhc_collector_minimal_t — com.redhat.minimal child collector
+#
+type rhc_collector_minimal_t;
+type rhc_collector_minimal_exec_t;
+application_domain(rhc_collector_minimal_t, rhc_collector_minimal_exec_t)
+role system_r types rhc_collector_minimal_t;
+
+#
+# File types
+#
+type rhc_collector_conf_t;
+files_config_file(rhc_collector_conf_t)
+
+type rhc_cache_t;
+files_type(rhc_cache_t)
+
+type rhc_tmp_t;
+files_tmp_file(rhc_tmp_t)
+
+########################################
+#
+# Domain transitions
+#
+# init_t -> rhc_collector_t is established by init_daemon_domain() above.
+# rhc_collector_domtrans() in rhc.if is the exported public API (not called here).
+# rhc_collector_t -> rhc_collector_minimal_t uses the exported interface below.
+#
+
+rhc_collector_minimal_domtrans(rhc_collector_t)


### PR DESCRIPTION
Declare rhc_collector_t and rhc_collector_minimal_t plus the collector file types in selinux/rhc.{te,fc,if}. Export domain-transition interfaces for init_t -> rhc_collector_t and rhc_collector_t -> rhc_collector_minimal_t. Leave the full allow set for later work.

Resolves: CCT-2894